### PR TITLE
fix(console): align deployment state and service UX

### DIFF
--- a/apps/temps-cli/openapi.json
+++ b/apps/temps-cli/openapi.json
@@ -4487,7 +4487,7 @@
         "properties": {
           "docker_image": {
             "description": "Docker image being used",
-            "example": "ghcr.io/rustfs/rustfs:0.5.0",
+            "example": "rustfs/rustfs:1.0.0-rc.5",
             "type": [
               "string",
               "null"
@@ -4505,7 +4505,7 @@
           },
           "version": {
             "description": "Current version (if running)",
-            "example": "0.5.0",
+            "example": "1.0.0-rc.5",
             "type": [
               "string",
               "null"
@@ -14219,7 +14219,7 @@
         "properties": {
           "docker_image": {
             "description": "Docker image to use (optional, defaults to RustFS)",
-            "example": "ghcr.io/rustfs/rustfs:0.5.0",
+            "example": "rustfs/rustfs:1.0.0-rc.5",
             "type": [
               "string",
               "null"
@@ -21622,6 +21622,9 @@
       },
       "LatestDeploymentMediaResponseItem": {
         "properties": {
+          "latest_attempt_status": {
+            "type": "string"
+          },
           "project_id": {
             "format": "int32",
             "type": "integer"
@@ -21640,7 +21643,8 @@
           }
         },
         "required": [
-          "project_id"
+          "project_id",
+          "latest_attempt_status"
         ],
         "type": "object"
       },
@@ -42742,8 +42746,8 @@
         "description": "Request to update Blob service configuration",
         "properties": {
           "docker_image": {
-            "description": "Docker image to use (e.g., \"rustfs/rustfs:1.0.0-alpha.98\")",
-            "example": "rustfs/rustfs:1.0.0-alpha.98",
+            "description": "Docker image to use (e.g., \"rustfs/rustfs:1.0.0-rc.5\")",
+            "example": "rustfs/rustfs:1.0.0-rc.5",
             "type": [
               "string",
               "null"
@@ -61609,7 +61613,7 @@
         "operationId": "get_provider_metadata",
         "parameters": [
           {
-            "description": "Service type (mongodb, postgres, redis, s3)",
+            "description": "Service type (mariadb, mongodb, postgres, redis, s3, kv, blob, rustfs, or legacy minio)",
             "in": "path",
             "name": "service_type",
             "required": true,

--- a/apps/temps-cli/src/api/types.gen.ts
+++ b/apps/temps-cli/src/api/types.gen.ts
@@ -10156,6 +10156,7 @@ export type LatestDeploymentMediaResponse = {
 };
 
 export type LatestDeploymentMediaResponseItem = {
+    latest_attempt_status: string;
     project_id: number;
     screenshot_location?: string | null;
     url?: string | null;
@@ -19672,7 +19673,7 @@ export type UpdateBackupScheduleRequest = {
  */
 export type UpdateBlobRequest = {
     /**
-     * Docker image to use (e.g., "rustfs/rustfs:1.0.0-alpha.98")
+     * Docker image to use (e.g., "rustfs/rustfs:1.0.0-rc.5")
      */
     docker_image?: string | null;
 };
@@ -30438,7 +30439,7 @@ export type GetProviderMetadataData = {
     body?: never;
     path: {
         /**
-         * Service type (mongodb, postgres, redis, s3)
+         * Service type (mariadb, mongodb, postgres, redis, s3, kv, blob, rustfs, or legacy minio)
          */
         service_type: string;
     };

--- a/crates/temps-blob/src/handlers/types.rs
+++ b/crates/temps-blob/src/handlers/types.rs
@@ -182,10 +182,10 @@ pub struct BlobStatusResponse {
     #[schema(example = true)]
     pub healthy: bool,
     /// Current version (if running)
-    #[schema(example = "0.5.0")]
+    #[schema(example = "1.0.0-rc.5")]
     pub version: Option<String>,
     /// Docker image being used
-    #[schema(example = "ghcr.io/rustfs/rustfs:0.5.0")]
+    #[schema(example = "rustfs/rustfs:1.0.0-rc.5")]
     pub docker_image: Option<String>,
 }
 
@@ -193,7 +193,7 @@ pub struct BlobStatusResponse {
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct EnableBlobRequest {
     /// Docker image to use (optional, defaults to RustFS)
-    #[schema(example = "ghcr.io/rustfs/rustfs:0.5.0")]
+    #[schema(example = "rustfs/rustfs:1.0.0-rc.5")]
     pub docker_image: Option<String>,
     /// Root user for S3 access
     pub root_user: Option<String>,
@@ -228,8 +228,8 @@ pub struct DisableBlobResponse {
 /// Request to update Blob service configuration
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct UpdateBlobRequest {
-    /// Docker image to use (e.g., "rustfs/rustfs:1.0.0-alpha.98")
-    #[schema(example = "rustfs/rustfs:1.0.0-alpha.98")]
+    /// Docker image to use (e.g., "rustfs/rustfs:1.0.0-rc.5")
+    #[schema(example = "rustfs/rustfs:1.0.0-rc.5")]
     pub docker_image: Option<String>,
 }
 

--- a/crates/temps-blob/src/services/config.rs
+++ b/crates/temps-blob/src/services/config.rs
@@ -6,8 +6,9 @@
 use rand::RngExt;
 use serde::{Deserialize, Serialize};
 
-/// Default RustFS Docker image
-pub const DEFAULT_RUSTFS_IMAGE: &str = "rustfs/rustfs:1.0.0-alpha.98";
+/// Default RustFS Docker image. Re-export the provider default so managed S3
+/// and the blob subsystem cannot silently provision different releases.
+pub use temps_providers::externalsvc::rustfs::DEFAULT_RUSTFS_IMAGE;
 /// Default container name
 pub const DEFAULT_CONTAINER_NAME: &str = "temps-blob-rustfs";
 /// Default volume name
@@ -18,7 +19,7 @@ pub const DEFAULT_BUCKET_NAME: &str = "temps-blobs";
 /// User-provided configuration for Blob service (with defaults)
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct BlobInputConfig {
-    /// Docker image to use (e.g., "rustfs/rustfs:1.0.0-alpha.98")
+    /// Docker image to use (e.g., "rustfs/rustfs:1.0.0-rc.5")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub docker_image: Option<String>,
 

--- a/crates/temps-deployments/src/handlers/types.rs
+++ b/crates/temps-deployments/src/handlers/types.rs
@@ -219,6 +219,7 @@ pub struct DeploymentListResponse {
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct LatestDeploymentMediaResponseItem {
     pub project_id: i32,
+    pub latest_attempt_status: String,
     pub url: Option<String>,
     pub screenshot_location: Option<String>,
 }
@@ -227,6 +228,7 @@ impl From<crate::services::types::LatestDeploymentMedia> for LatestDeploymentMed
     fn from(media: crate::services::types::LatestDeploymentMedia) -> Self {
         Self {
             project_id: media.project_id,
+            latest_attempt_status: media.latest_attempt_status,
             url: media.url,
             screenshot_location: media.screenshot_location,
         }

--- a/crates/temps-deployments/src/services/services.rs
+++ b/crates/temps-deployments/src/services/services.rs
@@ -331,11 +331,13 @@ fn deployment_url_from_settings(
 impl DeploymentService {
     /// Return the currently served deployment media for each requested project.
     ///
-    /// Deployment rows are selected in one ranked `DISTINCT ON` query. A
+    /// Media rows are selected in one ranked `DISTINCT ON` query. A
     /// non-preview production current deployment wins, followed by another
     /// current deployment, then the newest historical deployment with a
     /// screenshot. Historical fallbacks omit their URL because they are not
-    /// guaranteed to be routable.
+    /// guaranteed to be routable. The newest attempt status is selected
+    /// independently because a failed attempt does not replace the older
+    /// deployment that remains live.
     pub async fn get_latest_deployment_media(
         &self,
         project_ids: &[i32],
@@ -359,7 +361,13 @@ impl DeploymentService {
         let statement = sea_orm::Statement::from_sql_and_values(
             sea_orm::DatabaseBackend::Postgres,
             format!(
-                "WITH candidates AS ( \
+                "WITH latest_attempts AS ( \
+                    SELECT DISTINCT ON (d.project_id) \
+                        d.project_id, d.state AS latest_attempt_status \
+                    FROM deployments d \
+                    WHERE d.project_id IN ({placeholders}) \
+                    ORDER BY d.project_id, d.created_at DESC, d.id DESC \
+                 ), candidates AS ( \
                     SELECT d.project_id, d.slug, d.screenshot_location, TRUE AS is_current, \
                         CASE WHEN e.slug = 'production' AND NOT e.is_preview THEN 0 ELSE 1 END AS priority, \
                         e.updated_at AS candidate_updated_at, d.created_at, d.id \
@@ -375,11 +383,17 @@ impl DeploymentService {
                     FROM deployments d \
                     WHERE d.project_id IN ({placeholders}) \
                       AND d.screenshot_location IS NOT NULL \
+                 ), selected_media AS ( \
+                    SELECT DISTINCT ON (project_id) \
+                        project_id, slug, screenshot_location, is_current \
+                    FROM candidates \
+                    ORDER BY project_id, priority, candidate_updated_at DESC, created_at DESC, id DESC \
                  ) \
-                 SELECT DISTINCT ON (project_id) \
-                    project_id, slug, screenshot_location, is_current \
-                 FROM candidates \
-                 ORDER BY project_id, priority, candidate_updated_at DESC, created_at DESC, id DESC"
+                 SELECT latest_attempts.project_id, latest_attempts.latest_attempt_status, \
+                    selected_media.slug, selected_media.screenshot_location, \
+                    COALESCE(selected_media.is_current, FALSE) AS is_current \
+                 FROM latest_attempts \
+                 LEFT JOIN selected_media USING (project_id)"
             ),
             project_ids.iter().copied().map(Into::into),
         );
@@ -406,11 +420,18 @@ impl DeploymentService {
                     ),
                 }
             })?;
-            let slug: String =
+            let slug: Option<String> =
                 row.try_get("", "slug")
                     .map_err(|error| DeploymentError::DatabaseError {
                         reason: format!(
                             "Failed to decode deployment slug for project {project_id}: {error}"
+                        ),
+                    })?;
+            let latest_attempt_status: String =
+                row.try_get("", "latest_attempt_status")
+                    .map_err(|error| DeploymentError::DatabaseError {
+                        reason: format!(
+                            "Failed to decode latest deployment attempt status for project {project_id}: {error}"
                         ),
                     })?;
             let screenshot_location = row.try_get("", "screenshot_location").map_err(|error| {
@@ -427,12 +448,22 @@ impl DeploymentService {
                     ),
                 }
             })?;
+            let url = if is_current {
+                let slug = slug.ok_or_else(|| DeploymentError::DatabaseError {
+                    reason: format!(
+                        "Current deployment media for project {project_id} is missing its deployment slug"
+                    ),
+                })?;
+                Some(deployment_url_from_settings(&settings, proxy_port, &slug))
+            } else {
+                None
+            };
             media_by_project.insert(
                 project_id,
                 LatestDeploymentMedia {
                     project_id,
-                    url: is_current
-                        .then(|| deployment_url_from_settings(&settings, proxy_port, &slug)),
+                    latest_attempt_status,
+                    url,
                     screenshot_location,
                 },
             );
@@ -5303,7 +5334,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn latest_deployment_media_returns_current_deployment_per_project() {
+    async fn latest_deployment_media_keeps_current_media_and_reports_latest_attempt() {
         let test_db = match TestDatabase::with_migrations().await {
             Ok(db) => db,
             Err(error) => {
@@ -5315,6 +5346,16 @@ mod tests {
         let (project, environment, old_deployment) = setup_test_data(&db)
             .await
             .expect("create deployment fixtures");
+        let service = create_deployment_service_for_test(db.clone());
+        let status_without_media = service
+            .get_latest_deployment_media(&[project.id])
+            .await
+            .expect("query a latest attempt without current or historical media");
+        assert_eq!(status_without_media.len(), 1);
+        assert_eq!(status_without_media[0].latest_attempt_status, "deployed");
+        assert_eq!(status_without_media[0].url, None);
+        assert_eq!(status_without_media[0].screenshot_location, None);
+
         let old_screenshot = "screenshots/old.webp".to_string();
         let mut old: deployments::ActiveModel = old_deployment.into();
         old.screenshot_location = Set(Some(old_screenshot));
@@ -5348,7 +5389,6 @@ mod tests {
             .await
             .expect("set current deployment");
 
-        let service = create_deployment_service_for_test(db.clone());
         let media = service
             .get_latest_deployment_media(&[project.id, i32::MAX])
             .await
@@ -5356,6 +5396,7 @@ mod tests {
 
         assert_eq!(media.len(), 1);
         assert_eq!(media[0].project_id, project.id);
+        assert_eq!(media[0].latest_attempt_status, "completed");
         assert_eq!(
             media[0].screenshot_location.as_deref(),
             Some(newest_screenshot.as_str())
@@ -5364,6 +5405,37 @@ mod tests {
             .url
             .as_deref()
             .is_some_and(|url| url.contains(&newest_slug)));
+
+        let failed_attempt = deployments::ActiveModel {
+            project_id: Set(project.id),
+            environment_id: Set(environment.id),
+            slug: Set("failed-attempt".to_string()),
+            state: Set("failed".to_string()),
+            screenshot_location: Set(None),
+            metadata: Set(Some(
+                temps_entities::deployments::DeploymentMetadata::default(),
+            )),
+            created_at: Set(Utc::now() + chrono::Duration::seconds(1)),
+            updated_at: Set(Utc::now() + chrono::Duration::seconds(1)),
+            ..Default::default()
+        }
+        .insert(db.as_ref())
+        .await
+        .expect("insert failed latest attempt");
+        let media_after_failure = service
+            .get_latest_deployment_media(&[project.id])
+            .await
+            .expect("query current media after a failed attempt");
+        assert_eq!(media_after_failure[0].latest_attempt_status, "failed");
+        assert_eq!(
+            media_after_failure[0].screenshot_location.as_deref(),
+            Some(newest_screenshot.as_str())
+        );
+        assert!(media_after_failure[0]
+            .url
+            .as_deref()
+            .is_some_and(|url| url.contains(&newest_slug)));
+        assert_ne!(failed_attempt.id, newest.id);
 
         let mut environment: environments::ActiveModel = environment.into();
         environment.current_deployment_id = Set(None);
@@ -5376,6 +5448,7 @@ mod tests {
             .await
             .expect("query historical screenshot fallback");
         assert_eq!(historical_media.len(), 1);
+        assert_eq!(historical_media[0].latest_attempt_status, "failed");
         assert_eq!(historical_media[0].url, None);
         assert_eq!(
             historical_media[0].screenshot_location.as_deref(),

--- a/crates/temps-deployments/src/services/types.rs
+++ b/crates/temps-deployments/src/services/types.rs
@@ -44,6 +44,9 @@ pub struct DeploymentListResponse {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct LatestDeploymentMedia {
     pub project_id: i32,
+    /// State of the newest deployment attempt, which may differ from the
+    /// older deployment that is still serving traffic and supplying media.
+    pub latest_attempt_status: String,
     /// Public deployment URL when this is a currently served deployment.
     /// Historical screenshot fallbacks deliberately omit the URL.
     pub url: Option<String>,

--- a/crates/temps-providers/src/externalsvc/rustfs.rs
+++ b/crates/temps-providers/src/externalsvc/rustfs.rs
@@ -36,11 +36,13 @@ use super::{
 
 /// Default RustFS Docker image (from Docker Hub).
 ///
-/// `1.0.0-beta.6` is the first stable line with reliable OTLP custom-header
-/// support (`RUSTFS_OBS_ENDPOINT_METRICS_HEADERS`), fixed in alpha.99. This
-/// lets us authenticate metrics push with an `Authorization` header instead of
-/// embedding the ingest token in the URL path (which leaks into logs).
-pub const DEFAULT_RUSTFS_IMAGE: &str = "rustfs/rustfs:1.0.0-beta.6";
+/// `1.0.0-rc.5` is the current named RustFS release and includes reliable
+/// OTLP custom-header support (`RUSTFS_OBS_ENDPOINT_METRICS_HEADERS`). Pinning
+/// the version avoids the moving `latest` channel. Container registries can
+/// still replace a tag, so callers that require immutable artifacts should
+/// additionally verify the image digest.
+pub const DEFAULT_RUSTFS_IMAGE: &str = "rustfs/rustfs:1.0.0-rc.5";
+const DEFAULT_RUSTFS_VERSION: &str = "1.0.0-rc.5";
 /// Default RustFS API port
 pub const DEFAULT_RUSTFS_API_PORT: u16 = 9000;
 /// Default RustFS console port
@@ -1532,7 +1534,10 @@ impl ExternalService for RustfsService {
     }
 
     fn get_default_docker_image(&self) -> (String, String) {
-        ("rustfs/rustfs".to_string(), "latest".to_string())
+        (
+            "rustfs/rustfs".to_string(),
+            DEFAULT_RUSTFS_VERSION.to_string(),
+        )
     }
 
     async fn get_current_docker_image(&self) -> Result<(String, String)> {
@@ -1555,7 +1560,7 @@ impl ExternalService for RustfsService {
     }
 
     fn get_default_version(&self) -> String {
-        "latest".to_string()
+        DEFAULT_RUSTFS_VERSION.to_string()
     }
 
     async fn get_current_version(&self) -> Result<String> {
@@ -2606,6 +2611,16 @@ mod tests {
         assert_eq!(config.docker_image, DEFAULT_RUSTFS_IMAGE);
         assert!(!config.access_key.is_empty());
         assert!(!config.secret_key.is_empty());
+    }
+
+    #[test]
+    fn rustfs_lifecycle_defaults_match_the_provisioning_image() {
+        let (repository, version) = DEFAULT_RUSTFS_IMAGE
+            .rsplit_once(':')
+            .expect("the tested RustFS image must include an explicit version");
+
+        assert_eq!(repository, "rustfs/rustfs");
+        assert_eq!(version, DEFAULT_RUSTFS_VERSION);
     }
 
     #[test]

--- a/crates/temps-providers/src/handlers/handlers.rs
+++ b/crates/temps-providers/src/handlers/handlers.rs
@@ -96,7 +96,7 @@ async fn get_providers_metadata(
         (status = 500, description = "Internal server error")
     ),
     params(
-        ("service_type" = String, Path, description = "Service type (mongodb, postgres, redis, s3)")
+        ("service_type" = String, Path, description = "Service type (mariadb, mongodb, postgres, redis, s3, kv, blob, rustfs, or legacy minio)")
     )
 )]
 async fn get_provider_metadata(

--- a/crates/temps-providers/src/handlers/types.rs
+++ b/crates/temps-providers/src/handlers/types.rs
@@ -411,9 +411,37 @@ impl ProviderMetadata {
     }
 
     pub fn get_by_type(service_type: &ServiceTypeRoute) -> Option<Self> {
-        Self::get_all()
+        let metadata = Self::get_all()
             .into_iter()
-            .find(|p| &p.service_type == service_type)
+            .find(|p| &p.service_type == service_type);
+        if metadata.is_some() {
+            return metadata;
+        }
+
+        match service_type {
+            ServiceTypeRoute::Rustfs => Some(Self {
+                service_type: ServiceTypeRoute::Rustfs,
+                display_name: "RustFS".to_string(),
+                description: "High-performance S3-compatible object storage".to_string(),
+                icon_url: "/providers/s3.svg".to_string(),
+                color: "#C72E49".to_string(),
+            }),
+            ServiceTypeRoute::Kv => Some(Self {
+                service_type: ServiceTypeRoute::Kv,
+                display_name: "KV Store".to_string(),
+                description: "Managed key-value storage backed by Redis".to_string(),
+                icon_url: "/providers/redis.svg".to_string(),
+                color: "#DC382D".to_string(),
+            }),
+            ServiceTypeRoute::Blob => Some(Self {
+                service_type: ServiceTypeRoute::Blob,
+                display_name: "Blob Storage".to_string(),
+                description: "Managed S3-compatible object storage backed by RustFS".to_string(),
+                icon_url: "/providers/s3.svg".to_string(),
+                color: "#C72E49".to_string(),
+            }),
+            _ => None,
+        }
     }
 }
 
@@ -436,6 +464,24 @@ mod tests {
             ServiceTypeRoute::Minio
         );
         assert!(ProviderMetadata::get_by_type(&ServiceTypeRoute::Minio).is_some());
+    }
+
+    #[test]
+    fn managed_service_aliases_have_detail_metadata_without_duplicate_cards() {
+        let creatable = ProviderMetadata::get_creatable();
+
+        for service_type in [
+            ServiceTypeRoute::Kv,
+            ServiceTypeRoute::Blob,
+            ServiceTypeRoute::Rustfs,
+        ] {
+            let metadata = ProviderMetadata::get_by_type(&service_type)
+                .expect("managed service alias should have detail metadata");
+            assert_eq!(metadata.service_type, service_type);
+            assert!(creatable
+                .iter()
+                .all(|provider| provider.service_type != service_type));
+        }
     }
 
     #[test]

--- a/crates/temps-providers/src/parameter_strategies.rs
+++ b/crates/temps-providers/src/parameter_strategies.rs
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: 2024-2026 Temps Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::externalsvc::{mariadb::MariaDbSizeProfile, ServiceResourceLimits};
+use crate::externalsvc::{
+    mariadb::MariaDbSizeProfile, rustfs::DEFAULT_RUSTFS_IMAGE, ServiceResourceLimits,
+};
 use serde_json::{json, Value as JsonValue};
 use std::collections::HashMap;
 
@@ -759,7 +761,7 @@ impl ParameterStrategy for S3ParameterStrategy {
         if is_empty_value(params.get("docker_image")) {
             params.insert(
                 "docker_image".to_string(),
-                JsonValue::String("rustfs/rustfs:1.0.0-alpha.98".to_string()),
+                JsonValue::String(DEFAULT_RUSTFS_IMAGE.to_string()),
             );
         }
 
@@ -877,7 +879,7 @@ impl ParameterStrategy for S3ParameterStrategy {
                 "docker_image": {
                     "type": "string",
                     "description": "Docker image (updateable)",
-                    "default": "rustfs/rustfs:1.0.0-alpha.98"
+                    "default": DEFAULT_RUSTFS_IMAGE
                 }
             },
             "readonly": ["backend", "access_key", "secret_key", "host", "region"]
@@ -1050,7 +1052,7 @@ impl ParameterStrategy for RustfsParameterStrategy {
         if is_empty_value(params.get("docker_image")) {
             params.insert(
                 "docker_image".to_string(),
-                JsonValue::String("rustfs/rustfs:1.0.0-alpha.98".to_string()),
+                JsonValue::String(DEFAULT_RUSTFS_IMAGE.to_string()),
             );
         }
 
@@ -1162,7 +1164,7 @@ impl ParameterStrategy for RustfsParameterStrategy {
                 "docker_image": {
                     "type": "string",
                     "description": "Docker image (updateable)",
-                    "default": "rustfs/rustfs:1.0.0-alpha.98"
+                    "default": DEFAULT_RUSTFS_IMAGE
                 }
             },
             "readonly": ["access_key", "secret_key", "host", "region"]
@@ -1798,6 +1800,31 @@ mod tests {
             err.contains("container_name"),
             "error should mention 'container_name', got: {err}"
         );
+    }
+
+    #[test]
+    fn managed_s3_and_rustfs_defaults_use_the_provider_image() {
+        for strategy in [
+            &S3ParameterStrategy as &dyn ParameterStrategy,
+            &RustfsParameterStrategy as &dyn ParameterStrategy,
+        ] {
+            let mut params = HashMap::new();
+            strategy
+                .auto_generate_missing(&mut params)
+                .expect("managed defaults must be generated");
+            assert_eq!(
+                params.get("docker_image").and_then(JsonValue::as_str),
+                Some(DEFAULT_RUSTFS_IMAGE)
+            );
+            assert_eq!(
+                strategy.get_schema().and_then(|schema| {
+                    schema["properties"]["docker_image"]["default"]
+                        .as_str()
+                        .map(str::to_owned)
+                }),
+                Some(DEFAULT_RUSTFS_IMAGE.to_string())
+            );
+        }
     }
 
     #[test]

--- a/crates/temps-providers/src/services.rs
+++ b/crates/temps-providers/src/services.rs
@@ -8,7 +8,7 @@ use crate::externalsvc::{
     postgres::PostgresService,
     postgres_cluster::PostgresClusterService,
     redis::RedisService,
-    rustfs::RustfsService,
+    rustfs::{RustfsService, DEFAULT_RUSTFS_IMAGE},
     s3::S3Service,
     AvailableContainer, ClusterMemberResult, ClusterMemberSpec, ExternalService, HealthProbeStatus,
     ManagedS3BackendKind, ManagedS3BackendSelection, PgAutoFailoverState, ServiceConfig,
@@ -1569,7 +1569,7 @@ impl ExternalServiceManager {
                 let image = parameters
                     .get("docker_image")
                     .cloned()
-                    .unwrap_or_else(|| "ghcr.io/rustfs/rustfs:latest".to_string());
+                    .unwrap_or_else(|| DEFAULT_RUSTFS_IMAGE.to_string());
                 let access_key = parameters
                     .get("access_key")
                     .cloned()
@@ -11563,17 +11563,30 @@ mod tests {
     fn remote_create_uses_provider_canonical_container_names() {
         let manager = mock_service_manager(vec![]);
 
-        for (service_type, expected) in [
-            (ServiceType::Postgres, "postgres-orders"),
-            (ServiceType::Mariadb, "mariadb-orders"),
-            (ServiceType::Mongodb, "temps-mongodb-orders"),
-            (ServiceType::Redis, "redis-orders"),
-            (ServiceType::Rustfs, "rustfs-orders"),
+        for (service_type, expected_name, expected_image) in [
+            (ServiceType::Postgres, "postgres-orders", None),
+            (ServiceType::Mariadb, "mariadb-orders", None),
+            (ServiceType::Mongodb, "temps-mongodb-orders", None),
+            (ServiceType::Redis, "redis-orders", None),
+            (
+                ServiceType::Rustfs,
+                "rustfs-orders",
+                Some(DEFAULT_RUSTFS_IMAGE),
+            ),
+            (ServiceType::S3, "rustfs-orders", Some(DEFAULT_RUSTFS_IMAGE)),
+            (
+                ServiceType::Blob,
+                "rustfs-orders",
+                Some(DEFAULT_RUSTFS_IMAGE),
+            ),
         ] {
             let params = manager
                 .build_remote_create_params("orders", &service_type, &HashMap::new())
                 .expect("default remote service parameters should be valid");
-            assert_eq!(params.name, expected, "wrong name for {service_type}");
+            assert_eq!(params.name, expected_name, "wrong name for {service_type}");
+            if let Some(expected_image) = expected_image {
+                assert_eq!(params.image, expected_image);
+            }
         }
     }
 

--- a/web/src/api/client/types.gen.ts
+++ b/web/src/api/client/types.gen.ts
@@ -10156,6 +10156,7 @@ export type LatestDeploymentMediaResponse = {
 };
 
 export type LatestDeploymentMediaResponseItem = {
+    latest_attempt_status: string;
     project_id: number;
     screenshot_location?: string | null;
     url?: string | null;
@@ -19672,7 +19673,7 @@ export type UpdateBackupScheduleRequest = {
  */
 export type UpdateBlobRequest = {
     /**
-     * Docker image to use (e.g., "rustfs/rustfs:1.0.0-alpha.98")
+     * Docker image to use (e.g., "rustfs/rustfs:1.0.0-rc.5")
      */
     docker_image?: string | null;
 };
@@ -30438,7 +30439,7 @@ export type GetProviderMetadataData = {
     body?: never;
     path: {
         /**
-         * Service type (mongodb, postgres, redis, s3)
+         * Service type (mariadb, mongodb, postgres, redis, s3, kv, blob, rustfs, or legacy minio)
          */
         service_type: string;
     };

--- a/web/src/components/ai/AiAssistantDock.tsx
+++ b/web/src/components/ai/AiAssistantDock.tsx
@@ -20,7 +20,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { ProjectAvatar } from '@/components/project/ProjectAvatar'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -91,18 +91,16 @@ function metaFor(contextType: string) {
 }
 
 /**
- * Project favicon with a small context-type badge (deployment/alert/project)
+ * Project identity with a small context-type badge (deployment/alert/project)
  * overlaid in the corner. Shared by the conversation list and the open-chat
  * header so a chat looks the same in both places.
  */
 function ContextAvatar({
-  projectId,
   projectName,
   contextType,
   className,
   badgeClassName,
 }: {
-  projectId: number
   projectName?: string
   contextType: string
   className?: string
@@ -111,15 +109,11 @@ function ContextAvatar({
   const { label, Icon } = metaFor(contextType)
   return (
     <div className="relative shrink-0">
-      <Avatar className={cn('size-8 rounded-md', className)}>
-        <AvatarImage
-          src={`/api/projects/${projectId}/favicon`}
-          alt={projectName ?? 'Project'}
-        />
-        <AvatarFallback className="rounded-md bg-primary/10 text-xs font-medium text-primary">
-          {(projectName ?? label).slice(0, 1).toUpperCase()}
-        </AvatarFallback>
-      </Avatar>
+      <ProjectAvatar
+        name={projectName ?? label}
+        className={cn('size-8 rounded-md', className)}
+        fallbackClassName="rounded-md bg-primary/10 text-xs text-primary"
+      />
       <span
         className={cn(
           'absolute -bottom-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full border border-background bg-muted text-muted-foreground',
@@ -644,7 +638,6 @@ export function DockBody({
               )}
               {inConversation && active && (
                 <ContextAvatar
-                  projectId={active.projectId}
                   projectName={active.projectName}
                   contextType={active.contextType}
                   className="size-7"
@@ -973,7 +966,6 @@ function ConversationList({
               className="flex min-w-0 flex-1 items-center gap-3 px-2 py-2.5 text-left"
             >
               <ContextAvatar
-                projectId={c.project_id}
                 projectName={c.project_name ?? undefined}
                 contextType={c.context_type}
               />
@@ -1166,15 +1158,11 @@ function ProjectPicker({
               }
               className="group flex w-full items-center gap-3 rounded-md border border-transparent px-2 py-2.5 text-left transition-colors hover:border-border hover:bg-accent disabled:opacity-60"
             >
-              <Avatar className="size-8 rounded-md">
-                <AvatarImage
-                  src={`/api/projects/${p.id}/favicon`}
-                  alt={p.name}
-                />
-                <AvatarFallback className="rounded-md bg-primary/10 text-xs font-medium text-primary">
-                  {p.name.slice(0, 1).toUpperCase()}
-                </AvatarFallback>
-              </Avatar>
+              <ProjectAvatar
+                name={p.name}
+                className="size-8 rounded-md"
+                fallbackClassName="rounded-md bg-primary/10 text-xs text-primary"
+              />
               <div className="min-w-0 flex-1">
                 <div className="truncate text-sm font-medium">{p.name}</div>
                 {p.slug && (

--- a/web/src/components/command/CommandPalette.tsx
+++ b/web/src/components/command/CommandPalette.tsx
@@ -7,7 +7,7 @@ import {
   listGlobalSkillsOptions,
   listServicesInfiniteOptions,
 } from '@/api/client/@tanstack/react-query.gen'
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { ProjectAvatar } from '@/components/project/ProjectAvatar'
 import {
   Command,
   CommandDialog,
@@ -1517,12 +1517,7 @@ export function CommandPalette() {
         key: `project:${project.id}`,
         title: project.slug,
         category: 'Project',
-        icon: (
-          <Avatar className="size-5">
-            <AvatarImage src={`/api/projects/${project.id}/favicon`} />
-            <AvatarFallback>{project.name.charAt(0)}</AvatarFallback>
-          </Avatar>
-        ),
+        icon: <ProjectAvatar name={project.name} className="size-5" />,
         score: rank(`project:${project.id}`, project.name, result.score),
         run: () => navigate(`/projects/${project.slug}`),
       })
@@ -1729,12 +1724,7 @@ export function CommandPalette() {
         out.push({
           key,
           title: project.slug,
-          icon: (
-            <Avatar className="size-5">
-              <AvatarImage src={`/api/projects/${project.id}/favicon`} />
-              <AvatarFallback>{project.name.charAt(0)}</AvatarFallback>
-            </Avatar>
-          ),
+          icon: <ProjectAvatar name={project.name} className="size-5" />,
           run: () => navigate(`/projects/${project.slug}`),
         })
       } else if (key.startsWith('skill:')) {
@@ -1809,10 +1799,7 @@ export function CommandPalette() {
             }
             className="flex items-center gap-2"
           >
-            <Avatar className="size-6">
-              <AvatarImage src={`/api/projects/${project.id}/favicon`} />
-              <AvatarFallback>{project.name.charAt(0)}</AvatarFallback>
-            </Avatar>
+            <ProjectAvatar name={project.name} className="size-6" />
             <span>{project.slug}</span>
           </CommandItem>
         ))}

--- a/web/src/components/dashboard/Header.tsx
+++ b/web/src/components/dashboard/Header.tsx
@@ -9,6 +9,7 @@ import { AiAssistantButton } from '@/components/ai/AiAssistantButton'
 import { BackupAlertsButton } from '@/components/dashboard/BackupAlertsButton'
 import { DropButton } from '@/components/dashboard/DropButton'
 import { FeatureMaturityBadge } from '@/components/feature-maturity/FeatureMaturityBadge'
+import { ProjectAvatar } from '@/components/project/ProjectAvatar'
 import { useBreadcrumbs } from '@/contexts/BreadcrumbContext'
 import { featureKeyForPath } from '@/lib/feature-maturity'
 import { useConsoleExtensions } from '@temps-sdk/console-kit'
@@ -24,7 +25,6 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from '../ui/breadcrumb'
-import { Avatar, AvatarFallback, AvatarImage } from '../ui/avatar'
 import {
   Command,
   CommandEmpty,
@@ -65,12 +65,11 @@ function ProjectRowIcon({
     )
   }
   return (
-    <Avatar className="size-5 rounded-sm">
-      <AvatarImage src={`/api/projects/${projectId}/favicon`} />
-      <AvatarFallback className="rounded-sm bg-muted text-[10px] font-medium text-muted-foreground">
-        {name.slice(0, 1).toUpperCase()}
-      </AvatarFallback>
-    </Avatar>
+    <ProjectAvatar
+      name={name}
+      className="size-5 rounded-sm"
+      fallbackClassName="rounded-sm bg-muted text-[10px] text-muted-foreground"
+    />
   )
 }
 

--- a/web/src/components/dashboard/OnboardingNextStepCard.tsx
+++ b/web/src/components/dashboard/OnboardingNextStepCard.tsx
@@ -21,7 +21,10 @@ import {
 } from 'lucide-react'
 import { useState } from 'react'
 import { Link } from 'react-router'
-import { firstIncompleteGettingStartedIndex } from './onboarding-next-step'
+import {
+  firstIncompleteGettingStartedIndex,
+  onboardingStepPosition,
+} from './onboarding-next-step'
 
 const STEP_ICONS: Record<string, LucideIcon> = {
   ai: Bot,
@@ -107,8 +110,8 @@ export function OnboardingNextStepCard() {
             >
               <ChevronLeft className="size-4" />
             </Button>
-            <span className="min-w-10 text-center text-xs tabular-nums text-muted-foreground">
-              {safeSelectedIndex + 1} / {totalCount}
+            <span className="min-w-16 text-center text-xs tabular-nums text-muted-foreground">
+              {onboardingStepPosition(safeSelectedIndex, totalCount)}
             </span>
             <Button
               variant="ghost"

--- a/web/src/components/dashboard/ProjectCard.render.test.tsx
+++ b/web/src/components/dashboard/ProjectCard.render.test.tsx
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+import type { ProjectResponse } from '@/api/client'
+import { describe, expect, test } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router'
+import { ProjectCard } from './ProjectCard'
+
+const project = {
+  id: 1,
+  name: 'Example',
+  slug: 'example',
+  preset: null,
+  last_deployment: '2026-09-02T12:00:00Z',
+} as unknown as ProjectResponse
+
+describe('ProjectCard deployment state', () => {
+  for (const layout of ['compact', 'dense', 'wide'] as const) {
+    test(`${layout} layout uses the latest deployment status`, () => {
+      const markup = renderToStaticMarkup(
+        <MemoryRouter>
+          <ProjectCard
+            project={project}
+            layout={layout}
+            latestDeploymentMedia={{ latest_attempt_status: 'failed' }}
+          />
+        </MemoryRouter>
+      )
+
+      expect(markup).toContain('Last attempt')
+      expect(markup).not.toContain('>Deployed<')
+    })
+  }
+
+  test('shows explicit loading and unavailable states for deployment metadata', () => {
+    const loading = renderToStaticMarkup(
+      <MemoryRouter>
+        <ProjectCard project={project} latestDeploymentMediaLoading />
+      </MemoryRouter>
+    )
+    const unavailable = renderToStaticMarkup(
+      <MemoryRouter>
+        <ProjectCard project={project} latestDeploymentMediaError />
+      </MemoryRouter>
+    )
+
+    expect(loading).not.toContain('Last attempt')
+    expect(unavailable).toContain('Unavailable')
+    expect(unavailable).not.toContain('Last attempt')
+  })
+})

--- a/web/src/components/dashboard/ProjectCard.test.ts
+++ b/web/src/components/dashboard/ProjectCard.test.ts
@@ -13,6 +13,7 @@ import {
 describe('deploymentLabel', () => {
   test('calls only completed runs deployed', () => {
     expect(deploymentLabel('completed')).toBe('Deployed')
+    expect(deploymentLabel('deployed')).toBe('Deployed')
     expect(deploymentLabel('failed')).toBe('Last attempt')
     expect(deploymentLabel('cancelled')).toBe('Last attempt')
     expect(deploymentLabel(undefined)).toBe('Last attempt')

--- a/web/src/components/dashboard/ProjectCard.tsx
+++ b/web/src/components/dashboard/ProjectCard.tsx
@@ -50,9 +50,12 @@ interface ProjectCardProps {
   /** Latest production uptime-monitor status; outranks traffic health. */
   monitorHealth?: ProjectMonitorHealth
   latestDeploymentMedia?: {
+    latest_attempt_status: string
     url?: string | null
     screenshot_location?: string | null
   }
+  latestDeploymentMediaLoading?: boolean
+  latestDeploymentMediaError?: boolean
 }
 
 const HEALTH_TONE_STYLES: Record<
@@ -135,6 +138,8 @@ export function ProjectCard({
   health,
   monitorHealth,
   latestDeploymentMedia,
+  latestDeploymentMediaLoading = false,
+  latestDeploymentMediaError = false,
 }: ProjectCardProps) {
   const repository = projectRepository(project)
   const buildSource = projectBuildSource(project)
@@ -155,6 +160,18 @@ export function ProjectCard({
     traffic.kind === 'visitors'
       ? 'Visitor traffic over the last 24 hours'
       : 'API request traffic over the last 24 hours'
+
+  const deploymentBadge = latestDeploymentMediaLoading ? (
+    <Skeleton className="h-5 w-20" />
+  ) : latestDeploymentMediaError ? (
+    <Badge variant="outline" className="h-5 shrink-0 px-1.5">
+      Unavailable
+    </Badge>
+  ) : (
+    <Badge variant="secondary" className="h-5 shrink-0 px-1.5">
+      {deploymentLabel(latestDeploymentMedia?.latest_attempt_status)}
+    </Badge>
+  )
 
   const activityContent =
     analyticsLoading && healthLoading ? (
@@ -265,11 +282,7 @@ export function ProjectCard({
               <p className="mt-1 text-xs text-muted-foreground">Not deployed</p>
             )}
           </div>
-          {project.last_deployment && (
-            <Badge variant="secondary" className="h-5 shrink-0 px-1.5">
-              {deploymentLabel()}
-            </Badge>
-          )}
+          {project.last_deployment && deploymentBadge}
         </div>
       </Link>
     )
@@ -314,9 +327,7 @@ export function ProjectCard({
         <div className="min-w-0 text-sm">
           {project.last_deployment ? (
             <div className="flex min-w-0 items-center gap-2">
-              <Badge variant="secondary" className="h-5 shrink-0 px-1.5">
-                Deployed
-              </Badge>
+              {deploymentBadge}
               <span className="truncate text-xs text-muted-foreground">
                 <TimeAgo date={project.last_deployment} />
               </span>
@@ -406,9 +417,7 @@ export function ProjectCard({
       <MetadataCell label="Latest deployment">
         {project.last_deployment ? (
           <div className="min-w-0">
-            <Badge variant="secondary" className="h-5 px-1.5">
-              Deployed
-            </Badge>
+            {deploymentBadge}
             <p className="mt-1 truncate text-xs text-muted-foreground">
               <TimeAgo date={project.last_deployment} />
             </p>

--- a/web/src/components/dashboard/Sidebar.tsx
+++ b/web/src/components/dashboard/Sidebar.tsx
@@ -623,7 +623,7 @@ function GettingStartedNavItem() {
           <SidebarMenuItem>
             <SidebarMenuButton
               asChild
-              tooltip={`Finish setup — ${completedCount}/${totalCount}`}
+              tooltip={`Platform setup — ${completedCount}/${totalCount}`}
               className="justify-center"
             >
               <Link to="/setup">
@@ -644,7 +644,7 @@ function GettingStartedNavItem() {
       >
         <div className="flex items-center gap-2">
           <BadgeCheck className="size-4 shrink-0 text-primary" />
-          <span className="flex-1 text-sm font-medium">Finish setup</span>
+          <span className="flex-1 text-sm font-medium">Platform setup</span>
           <span className="text-xs tabular-nums text-muted-foreground">
             {completedCount}/{totalCount}
           </span>
@@ -1111,7 +1111,7 @@ function ProjectSetupNavItem({ project }: { project: ProjectResponse }) {
       >
         <div className="flex items-center gap-2">
           <BadgeCheck className="size-4 shrink-0 text-primary" />
-          <span className="flex-1 text-sm font-medium">Finish setup</span>
+          <span className="flex-1 text-sm font-medium">Project setup</span>
           <span className="text-xs tabular-nums text-muted-foreground">
             {setup.completedCount}/{setup.totalCount}
           </span>

--- a/web/src/components/dashboard/onboarding-next-step.test.ts
+++ b/web/src/components/dashboard/onboarding-next-step.test.ts
@@ -6,6 +6,7 @@ import type { GettingStartedItem } from '@/hooks/useGettingStarted'
 import {
   firstIncompleteGettingStartedIndex,
   nextIncompleteGettingStartedItem,
+  onboardingStepPosition,
 } from './onboarding-next-step'
 
 function step(key: string, done: boolean): GettingStartedItem {
@@ -50,5 +51,9 @@ describe('dashboard onboarding next step', () => {
     expect(
       firstIncompleteGettingStartedIndex([step('ai', true), step('git', true)])
     ).toBe(-1)
+  })
+
+  test('labels carousel position as a step rather than completion progress', () => {
+    expect(onboardingStepPosition(0, 8)).toBe('Step 1 of 8')
   })
 })

--- a/web/src/components/dashboard/onboarding-next-step.ts
+++ b/web/src/components/dashboard/onboarding-next-step.ts
@@ -14,3 +14,7 @@ export function firstIncompleteGettingStartedIndex(
 ): number {
   return items.findIndex((item) => !item.done)
 }
+
+export function onboardingStepPosition(index: number, total: number): string {
+  return `Step ${index + 1} of ${total}`
+}

--- a/web/src/components/dashboard/project-card-data.ts
+++ b/web/src/components/dashboard/project-card-data.ts
@@ -136,6 +136,7 @@ export function projectBuildSource(
 export function deploymentLabel(status?: string | null): string {
   switch (status) {
     case 'completed':
+    case 'deployed':
       return 'Deployed'
     case 'running':
     case 'pending':

--- a/web/src/components/forms/ServiceTypePresets.tsx
+++ b/web/src/components/forms/ServiceTypePresets.tsx
@@ -3,6 +3,7 @@
 
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { DEFAULT_RUSTFS_IMAGE } from '@/lib/service-images'
 import { AlertTriangle } from 'lucide-react'
 import type { ReactNode } from 'react'
 import { useState } from 'react'
@@ -115,16 +116,14 @@ function PresetGroup({
         <div className="flex items-start gap-2 rounded-md border border-amber-500/20 bg-amber-500/10 p-3 text-sm text-amber-800 dark:text-amber-200">
           <AlertTriangle className="h-4 w-4 flex-shrink-0 mt-0.5" />
           <div className="space-y-1">
-            <p className="font-medium">
-              Point-in-time recovery not available
-            </p>
+            <p className="font-medium">Point-in-time recovery not available</p>
             <p className="text-xs">
-              This image does not include WAL-G. Backups will be basic
-              snapshots — you won't be able to restore to a specific
-              timestamp.
+              This image does not include WAL-G. Backups will be basic snapshots
+              — you won’t be able to restore to a specific timestamp.
               {pitrManagedImage && (
                 <>
-                  {' '}For full PITR support, use{' '}
+                  {' '}
+                  For full PITR support, use{' '}
                   <code className="font-mono bg-amber-500/10 px-1 rounded">
                     {pitrManagedImage}
                   </code>
@@ -158,9 +157,7 @@ export interface PresetState {
  *
  * Returns null ui + empty overrides for service types that don't have a preset.
  */
-export function useServiceTypePreset(
-  serviceType: string | null
-): PresetState {
+export function useServiceTypePreset(serviceType: string | null): PresetState {
   // One hook call per possible preset keeps hook order stable.
   const postgres = usePostgresPreset()
   const mariadb = useMariDbPreset()
@@ -395,7 +392,7 @@ const S3_OPTIONS: PresetOption[] = [
     id: 'rustfs',
     title: 'RustFS',
     subtitle: 'Rust-native',
-    value: 'rustfs/rustfs:1.0.0-alpha.98',
+    value: DEFAULT_RUSTFS_IMAGE,
     hint: 'Default',
   },
   {

--- a/web/src/components/project/ProjectAvatar.test.tsx
+++ b/web/src/components/project/ProjectAvatar.test.tsx
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+import { describe, expect, test } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { ProjectAvatar } from './ProjectAvatar'
+
+describe('ProjectAvatar', () => {
+  test('renders a deterministic fallback without requesting a missing favicon', () => {
+    const markup = renderToStaticMarkup(<ProjectAvatar name="Example" />)
+
+    expect(markup).toContain('E')
+    expect(markup).not.toContain('<img')
+    expect(markup).not.toContain('/favicon')
+  })
+})

--- a/web/src/components/project/ProjectAvatar.tsx
+++ b/web/src/components/project/ProjectAvatar.tsx
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+import { Avatar, AvatarFallback } from '@/components/ui/avatar'
+import { cn } from '@/lib/utils'
+
+interface ProjectAvatarProps {
+  name: string
+  className?: string
+  fallbackClassName?: string
+}
+
+/**
+ * Deterministic project identity for surfaces that do not have deployment
+ * media. The console has no project-favicon endpoint, so this deliberately
+ * avoids issuing a guaranteed 404 request.
+ */
+export function ProjectAvatar({
+  name,
+  className,
+  fallbackClassName,
+}: ProjectAvatarProps) {
+  return (
+    <Avatar className={className}>
+      <AvatarFallback className={cn('font-medium', fallbackClassName)}>
+        {name.slice(0, 1).toUpperCase()}
+      </AvatarFallback>
+    </Avatar>
+  )
+}

--- a/web/src/components/project/ProjectDetailHeader.tsx
+++ b/web/src/components/project/ProjectDetailHeader.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 import type { DeploymentResponse, ProjectResponse } from '@/api/client'
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { ProjectAvatar } from '@/components/project/ProjectAvatar'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { ReloadableImage } from '@/components/utils/ReloadableImage'
@@ -95,7 +95,8 @@ export function ProjectDetailHeader({
   // own build succeeded once.
   const hasCompletedDeployment =
     !!lastDeployment?.is_current &&
-    (lastDeployment?.status === 'completed' || lastDeployment?.status === 'deployed')
+    (lastDeployment?.status === 'completed' ||
+      lastDeployment?.status === 'deployed')
   const repositoryUrl = repositoryCloneUrl
     ? repositoryWebUrl(repositoryCloneUrl)
     : null
@@ -126,10 +127,7 @@ export function ProjectDetailHeader({
               />
             </div>
           ) : (
-            <Avatar className="size-8">
-              <AvatarImage src={`/api/projects/${project.id}/favicon`} />
-              <AvatarFallback>{project.name.charAt(0)}</AvatarFallback>
-            </Avatar>
+            <ProjectAvatar name={project.name} className="size-8" />
           )}
           <div className="flex items-center gap-2 min-w-0">
             <h1 className="text-base sm:text-lg font-semibold truncate">

--- a/web/src/components/storage/PlatformServices.tsx
+++ b/web/src/components/storage/PlatformServices.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024-2026 Temps Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import {
   kvStatusOptions,
   kvEnableMutation,
@@ -46,6 +46,7 @@ import {
 } from 'lucide-react'
 import { Skeleton } from '@/components/ui/skeleton'
 import { toast } from 'sonner'
+import { DEFAULT_RUSTFS_IMAGE } from '@/lib/service-images'
 
 type ServiceType = 'kv' | 'blob'
 
@@ -53,7 +54,8 @@ interface EditDockerImageDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   serviceName: string
-  currentImage: string
+  dockerImage: string
+  onDockerImageChange: (image: string) => void
   onSave: (newImage: string) => void
   isPending: boolean
 }
@@ -62,19 +64,11 @@ function EditDockerImageDialog({
   open,
   onOpenChange,
   serviceName,
-  currentImage,
+  dockerImage,
+  onDockerImageChange,
   onSave,
   isPending,
 }: EditDockerImageDialogProps) {
-  const [dockerImage, setDockerImage] = useState(currentImage)
-
-  // Sync state when dialog opens with new currentImage
-  useEffect(() => {
-    if (open) {
-      setDockerImage(currentImage)
-    }
-  }, [open, currentImage])
-
   const handleSave = () => {
     if (dockerImage.trim()) {
       onSave(dockerImage.trim())
@@ -97,21 +91,32 @@ function EditDockerImageDialog({
             <Input
               id="docker-image"
               value={dockerImage}
-              onChange={(e) => setDockerImage(e.target.value)}
-              placeholder={serviceName === 'KV Store' ? 'redis:8-alpine' : 'rustfs/rustfs:1.0.0-alpha.98'}
+              onChange={(e) => onDockerImageChange(e.target.value)}
+              placeholder={
+                serviceName === 'KV Store'
+                  ? 'redis:8-alpine'
+                  : DEFAULT_RUSTFS_IMAGE
+              }
             />
             <p className="text-xs text-muted-foreground">
               {serviceName === 'KV Store'
-                ? 'Examples: redis:8-alpine, redis:8-alpine, valkey/valkey:8-alpine'
-                : 'Examples: rustfs/rustfs:1.0.0-alpha.98, rustfs/rustfs:latest'}
+                ? 'Examples: redis:8-alpine, valkey/valkey:8-alpine'
+                : `Examples: ${DEFAULT_RUSTFS_IMAGE}, rustfs/rustfs:latest`}
             </p>
           </div>
         </div>
         <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isPending}
+          >
             Cancel
           </Button>
-          <Button onClick={handleSave} disabled={isPending || !dockerImage.trim()}>
+          <Button
+            onClick={handleSave}
+            disabled={isPending || !dockerImage.trim()}
+          >
             {isPending ? (
               <>
                 <Loader2 className="h-4 w-4 animate-spin mr-2" />
@@ -131,6 +136,7 @@ export function PlatformServices() {
   const queryClient = useQueryClient()
   const [editDialogOpen, setEditDialogOpen] = useState(false)
   const [editingService, setEditingService] = useState<ServiceType | null>(null)
+  const [editDockerImage, setEditDockerImage] = useState('')
 
   // Fetch KV status
   const { data: kvStatus, isLoading: kvLoading } = useQuery({
@@ -219,11 +225,13 @@ export function PlatformServices() {
   const isLoading = kvLoading || blobLoading
 
   const handleEditKv = () => {
+    setEditDockerImage(kvStatus?.docker_image || 'redis:8-alpine')
     setEditingService('kv')
     setEditDialogOpen(true)
   }
 
   const handleEditBlob = () => {
+    setEditDockerImage(blobStatus?.docker_image || DEFAULT_RUSTFS_IMAGE)
     setEditingService('blob')
     setEditDialogOpen(true)
   }
@@ -247,11 +255,8 @@ export function PlatformServices() {
     )
   }
 
-  const currentServiceName = editingService === 'kv' ? 'KV Store' : 'Blob Storage'
-  const currentImage =
-    editingService === 'kv'
-      ? kvStatus?.docker_image || 'redis:8-alpine'
-      : blobStatus?.docker_image || 'rustfs/rustfs:1.0.0-alpha.98'
+  const currentServiceName =
+    editingService === 'kv' ? 'KV Store' : 'Blob Storage'
 
   return (
     <div className="space-y-6">
@@ -259,7 +264,7 @@ export function PlatformServices() {
         <Info className="h-4 w-4" />
         <AlertTitle>Platform Services</AlertTitle>
         <AlertDescription>
-          These services are shared across all projects. Each project's data is
+          These services are shared across all projects. Each project’s data is
           isolated by namespace. Enable a service to make it available for all
           projects.
         </AlertDescription>
@@ -319,7 +324,8 @@ export function PlatformServices() {
           if (!open) setEditingService(null)
         }}
         serviceName={currentServiceName}
-        currentImage={currentImage}
+        dockerImage={editDockerImage}
+        onDockerImageChange={setEditDockerImage}
         onSave={handleSaveDockerImage}
         isPending={kvUpdateMut.isPending || blobUpdateMut.isPending}
       />
@@ -371,7 +377,9 @@ function ServiceCard({
             <div>
               <CardTitle className="text-lg">{name}</CardTitle>
               <Badge
-                variant={enabled ? (healthy ? 'default' : 'destructive') : 'secondary'}
+                variant={
+                  enabled ? (healthy ? 'default' : 'destructive') : 'secondary'
+                }
                 className="mt-1"
               >
                 {enabled ? (

--- a/web/src/lib/project-detail-routes.test.ts
+++ b/web/src/lib/project-detail-routes.test.ts
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+import { describe, expect, test } from 'bun:test'
+import { legacyDatabasesRedirectPath } from './project-detail-routes'
+
+describe('legacy project routes', () => {
+  test('redirects Databases to the canonical project storage page', () => {
+    expect(legacyDatabasesRedirectPath('example')).toBe(
+      '/projects/example/storage'
+    )
+  })
+})

--- a/web/src/lib/project-detail-routes.ts
+++ b/web/src/lib/project-detail-routes.ts
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+/** Canonical destination for the retired project-level Databases route. */
+export function legacyDatabasesRedirectPath(projectSlug: string): string {
+  return `/projects/${projectSlug}/storage`
+}

--- a/web/src/lib/service-images.test.ts
+++ b/web/src/lib/service-images.test.ts
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+import { describe, expect, test } from 'bun:test'
+import { DEFAULT_RUSTFS_IMAGE } from './service-images'
+
+describe('managed service image defaults', () => {
+  test('uses the OTLP-capable RustFS release', () => {
+    expect(DEFAULT_RUSTFS_IMAGE).toBe('rustfs/rustfs:1.0.0-rc.5')
+  })
+})

--- a/web/src/lib/service-images.ts
+++ b/web/src/lib/service-images.ts
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+/** Keep console-side fallbacks aligned with the managed RustFS provider. */
+export const DEFAULT_RUSTFS_IMAGE = 'rustfs/rustfs:1.0.0-rc.5'

--- a/web/src/pages/CreateServiceNew.tsx
+++ b/web/src/pages/CreateServiceNew.tsx
@@ -535,7 +535,7 @@ export function CreateService() {
           <Link to="/storage">
             <Button variant="ghost" size="sm" className="gap-2">
               <ArrowLeft className="h-4 w-4" />
-              Back to Storage
+              Back to Databases
             </Button>
           </Link>
 

--- a/web/src/pages/ProjectDetail.tsx
+++ b/web/src/pages/ProjectDetail.tsx
@@ -51,6 +51,7 @@ import { ErrorAlert } from '@/components/utils/ErrorAlert'
 import { useBreadcrumbs } from '@/contexts/BreadcrumbContext'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { resolveStableUrl } from '@/lib/deployment-url'
+import { legacyDatabasesRedirectPath } from '@/lib/project-detail-routes'
 import {
   deploymentsAfterStartPath,
   projectDeployLaunchMode,
@@ -509,6 +510,15 @@ export function ProjectDetail() {
             <Route
               path="storage"
               element={<ProjectStorage project={project} />}
+            />
+            <Route
+              path="databases"
+              element={
+                <Navigate
+                  to={legacyDatabasesRedirectPath(project.slug)}
+                  replace
+                />
+              }
             />
             <Route
               path="services/*"

--- a/web/src/pages/Projects.tsx
+++ b/web/src/pages/Projects.tsx
@@ -162,6 +162,10 @@ export function Projects() {
         latestDeploymentMedia={
           latestDeploymentMedia.data?.projects?.[String(project.id)]
         }
+        latestDeploymentMediaLoading={latestDeploymentMedia.isLoading}
+        latestDeploymentMediaError={
+          latestDeploymentMedia.isError && !latestDeploymentMedia.data
+        }
       />
     ))
 


### PR DESCRIPTION
## Summary

- report the newest deployment attempt independently from the older deployment that may still provide the live URL and screenshot, with explicit loading/error UI in every project-card layout
- centralize the managed RustFS default on `rustfs/rustfs:1.0.0-rc.5` across provider, blob, local/remote provisioning, schemas, generated clients, and console presets
- repair the legacy project Databases route, setup terminology/counters, Databases return copy, missing managed-service alias metadata, and guaranteed project-favicon 404 requests
- leave the domain lifecycle behavior unchanged as directed; do not patch the separately reported auth lifecycle because it did not reproduce

## Evidence

**Backend**: newest-attempt status remains independent from currently served media, including a completed live deployment followed by a failed attempt.

```bash
cargo test --lib -p temps-deployments latest_deployment_media_keeps_current_media_and_reports_latest_attempt
```

```text
cargo test: 1 passed, 691 filtered out (1 suite, 6.49s)
```

The final isolated server returned the corrected contract:

```bash
curl -sS \
  -H "Cookie: $(awk -F '\t' 'NF >= 7 {print $6 "=" $7}' /tmp/temps-slot1-cookie.txt)" \
  'http://127.0.0.1:8091/api/deployments/latest-media?project_ids=1'
```

```json
{"projects":{"1":{"project_id":1,"latest_attempt_status":"completed","url":"http://ui-fix-proof-completed.localho.st:8090","screenshot_location":null}}}
```

**Frontend / UI**: the real authenticated browser flow verifies the deployment label, legacy redirect, RustFS default, Databases copy, missing-favicon request removal, and auth-navigation reproduction.

```bash
python3 -u /private/tmp/temps-round2-proof.py
```

```text
FUNCTIONAL_FAILURES []
AUTH_401_500 []
```

The run generated fresh recordings and screenshots for both the functional-fix flow and the Projects → Databases → Domains → Settings → Proxy → Projects → Proxy auth-lifecycle sequence.

**Focused web regressions**:

```bash
bun test \
  src/components/dashboard/ProjectCard.render.test.tsx \
  src/components/dashboard/ProjectCard.test.ts \
  src/components/project/ProjectAvatar.test.tsx \
  src/lib/service-images.test.ts \
  src/lib/project-detail-routes.test.ts \
  src/components/dashboard/onboarding-next-step.test.ts
```

```text
25 pass
0 fail
48 expect() calls
```

**Affected Rust suites**:

```text
cargo test --lib -p temps-deployments -- --test-threads=1
689 passed, 3 ignored

cargo test --lib -p temps-providers
592 passed

cargo test --lib -p temps-blob
24 passed
```

**Build and generated-client contracts**:

```text
cargo check --lib                                      # 0 errors
bunx tsc --noEmit                                      # passed
bun run build                                          # passed
bun run spec:check && bun run typecheck                # 733 paths canonical; passed
cargo fmt --all -- --check && git diff --check         # passed
```

The web build retains two pre-existing CSS `@import` ordering warnings. No new build warning was introduced.

## Review

- architecture/API-contract review: approved with no blocking findings
- security review: approved; authorization and parameterized project scoping remain intact
- residual defense-in-depth note: the official `rc.5` registry tag is named but not immutable; the code documents digest verification for callers that require immutable artifacts

## Scope decisions

- no domain cleanup or certificate-state behavior changed
- no speculative auth/session rewrite was made because the reported failure did not reproduce across seven authenticated route transitions
- generated OpenAPI/client diffs were curated to this branch's contract changes only
