### PR TITLE
fix(console): streamline service actions and log onboarding

### DIFF
--- a/web/src/components/sandboxes/CreateSandboxDocs.test.ts
+++ b/web/src/components/sandboxes/CreateSandboxDocs.test.ts
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+import { describe, expect, test } from 'bun:test'
+import {
+  SANDBOX_CLI_EXAMPLE,
+  SANDBOX_WORKSPACE_EXAMPLE,
+} from './CreateSandboxDocs'
+
+describe('sandbox CLI onboarding', () => {
+  test('uses the real context store and targets the chosen instance explicitly', () => {
+    expect(SANDBOX_CLI_EXAMPLE).toContain('~/.temps/.contexts.json')
+    expect(SANDBOX_CLI_EXAMPLE).toContain(
+      'login https://your-temps-instance.com --context my-instance'
+    )
+    expect(SANDBOX_CLI_EXAMPLE).toContain('--target-context my-instance')
+    expect(SANDBOX_CLI_EXAMPLE).not.toContain('~/.config/temps/auth.json')
+
+    for (const command of SANDBOX_WORKSPACE_EXAMPLE.split('\n').filter((line) =>
+      line.startsWith('bunx ')
+    )) {
+      expect(command).toContain('--target-context my-instance')
+    }
+  })
+})

--- a/web/src/components/sandboxes/CreateSandboxDocs.tsx
+++ b/web/src/components/sandboxes/CreateSandboxDocs.tsx
@@ -19,47 +19,46 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 // REST, or the SDK. Keep the three examples behaviorally identical so a
 // reader can pick whichever fits their workflow and expect the same result.
 
-const CLI_EXAMPLE = `# Authenticate once (cached in ~/.config/temps/auth.json)
-export TEMPS_API_URL="https://your-temps-instance.com"
-export TEMPS_API_TOKEN="temps_pat_..."
+export const SANDBOX_CLI_EXAMPLE = `# Authenticate once (cached in ~/.temps/.contexts.json)
+bunx @temps-sdk/cli login https://your-temps-instance.com --context my-instance
 
 # Create a sandbox with a 2h idle timeout
-bunx @temps-sdk/cli sandbox create --timeout-secs 7200 --name my-sandbox
+bunx @temps-sdk/cli --target-context my-instance sandbox create --timeout-secs 7200 --name my-sandbox
 
 # List, show details, or exec a command inside it
-bunx @temps-sdk/cli sandbox list
-bunx @temps-sdk/cli sandbox show sbx_abc123
-bunx @temps-sdk/cli sandbox exec sbx_abc123 -- node --version
+bunx @temps-sdk/cli --target-context my-instance sandbox list
+bunx @temps-sdk/cli --target-context my-instance sandbox show sbx_abc123
+bunx @temps-sdk/cli --target-context my-instance sandbox exec sbx_abc123 -- node --version
 
 # Remove the sandbox when done (aliases: \`stop\`, \`destroy\`)
-bunx @temps-sdk/cli sandbox rm sbx_abc123`
+bunx @temps-sdk/cli --target-context my-instance sandbox rm sbx_abc123`
 
-const WORKSPACE_EXAMPLE = `# From a linked checkout, nothing else is needed: the project comes
-# from .temps/config.json, the repo and branch from your git remote.
+export const SANDBOX_WORKSPACE_EXAMPLE = `# Use the named context created in the CLI tab. From a linked checkout,
+# the project comes from .temps/config.json, the repo and branch from your git remote.
 cd ~/code/my-repo
-bunx @temps-sdk/cli sandbox create --workspace
+bunx @temps-sdk/cli --target-context my-instance sandbox create --workspace
 
 # Name the project explicitly, and start a fresh branch
-bunx @temps-sdk/cli sandbox create --workspace \\
+bunx @temps-sdk/cli --target-context my-instance sandbox create --workspace \\
   --project my-api --branch main --new-branch feat/checkout
 
 # A repo that has no temps project — resolved off your git connection,
 # so private repos clone without you handling a token
-bunx @temps-sdk/cli sandbox create --workspace --repo acme/internal-tools
+bunx @temps-sdk/cli --target-context my-instance sandbox create --workspace --repo acme/internal-tools
 
 # Any other URL
-bunx @temps-sdk/cli sandbox create --workspace \\
+bunx @temps-sdk/cli --target-context my-instance sandbox create --workspace \\
   --git-url https://github.com/org/repo.git --branch develop
 
 # Come back days later — this wakes the workspace automatically
-bunx @temps-sdk/cli sandbox exec sbx_abc123 -- git status
+bunx @temps-sdk/cli --target-context my-instance sandbox exec sbx_abc123 -- git status
 
 # The image ships claude, codex, opencode, gh and glab. Supply your own
 # key at create time until credential injection lands (ADR-036). Pass it by
 # reference so the secret stays out of your shell history.
-bunx @temps-sdk/cli sandbox create --workspace -e ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY"
+bunx @temps-sdk/cli --target-context my-instance sandbox create --workspace -e ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY"
 
-bunx @temps-sdk/cli sandbox list --workspace`
+bunx @temps-sdk/cli --target-context my-instance sandbox list --workspace`
 
 const REST_EXAMPLE = `# Create
 curl -X POST https://your-temps-instance.com/v1/sandbox \\
@@ -117,7 +116,9 @@ interface CreateSandboxDocsProps {
   variant?: Variant
 }
 
-export function CreateSandboxDocs({ variant = 'full' }: CreateSandboxDocsProps) {
+export function CreateSandboxDocs({
+  variant = 'full',
+}: CreateSandboxDocsProps) {
   const [open, setOpen] = useState(variant === 'full')
 
   const body = (
@@ -131,23 +132,22 @@ export function CreateSandboxDocs({ variant = 'full' }: CreateSandboxDocsProps) 
       <TabsContent value="cli" className="space-y-2">
         <p className="text-xs text-muted-foreground">
           Run via{' '}
-          <code className="bg-muted px-1 rounded">bunx @temps-sdk/cli</code>{' '}
-          — no install step needed. All subcommands read{' '}
-          <code className="bg-muted px-1 rounded">TEMPS_API_URL</code> and{' '}
-          <code className="bg-muted px-1 rounded">TEMPS_API_TOKEN</code>{' '}
-          from the environment.
+          <code className="bg-muted px-1 rounded">bunx @temps-sdk/cli</code> —
+          no install step needed. Log in once to store a named context, then
+          pass <code className="bg-muted px-1 rounded">--target-context</code>{' '}
+          so every command reaches the intended server.
         </p>
-        <CodeBlock code={CLI_EXAMPLE} language="bash" />
+        <CodeBlock code={SANDBOX_CLI_EXAMPLE} language="bash" />
       </TabsContent>
       <TabsContent value="workspace" className="space-y-2">
         <p className="text-xs text-muted-foreground">
-          A <strong>workspace</strong> is a sandbox you keep. It still
-          suspends after its idle timeout so it doesn't hold memory on the
-          host, but the next command wakes it automatically and your files
-          are exactly as you left them. Nothing deletes it until you run{' '}
+          A <strong>workspace</strong> is a sandbox you keep. It still suspends
+          after its idle timeout so it doesn&apos;t hold memory on the host, but
+          the next command wakes it automatically and your files are exactly as
+          you left them. Nothing deletes it until you run{' '}
           <code className="bg-muted px-1 rounded">sandbox rm</code>.
         </p>
-        <CodeBlock code={WORKSPACE_EXAMPLE} language="bash" />
+        <CodeBlock code={SANDBOX_WORKSPACE_EXAMPLE} language="bash" />
       </TabsContent>
       <TabsContent value="rest" className="space-y-2">
         <p className="text-xs text-muted-foreground">
@@ -164,10 +164,12 @@ export function CreateSandboxDocs({ variant = 'full' }: CreateSandboxDocsProps) 
         <p className="text-xs text-muted-foreground">
           The Node SDK wraps the REST API and exposes ergonomic helpers for{' '}
           <code className="bg-muted px-1 rounded">exec</code>,{' '}
-          <code className="bg-muted px-1 rounded">domain(port)</code>,
-          file I/O, and detached jobs. Install with{' '}
-          <code className="bg-muted px-1 rounded">bun add @temps-sdk/sandbox</code>.
-          Shape is drop-in compatible with{' '}
+          <code className="bg-muted px-1 rounded">domain(port)</code>, file I/O,
+          and detached jobs. Install with{' '}
+          <code className="bg-muted px-1 rounded">
+            bun add @temps-sdk/sandbox
+          </code>
+          . Shape is drop-in compatible with{' '}
           <code className="bg-muted px-1 rounded">@vercel/sandbox</code>.
         </p>
         <CodeBlock code={SDK_EXAMPLE} language="typescript" />

--- a/web/src/hooks/useLogHistory.ts
+++ b/web/src/hooks/useLogHistory.ts
@@ -96,7 +96,9 @@ export interface LogSearchParams {
 
 // ── API call ───────────────────────────────────────────────────────────
 
-async function searchLogs(params: LogSearchParams): Promise<SearchLogsResponse> {
+async function searchLogs(
+  params: LogSearchParams
+): Promise<SearchLogsResponse> {
   const body: Record<string, unknown> = {
     project_id: params.projectId,
   }
@@ -128,7 +130,13 @@ async function searchLogs(params: LogSearchParams): Promise<SearchLogsResponse> 
   // React Query sets `error` and the UI shows the failure state instead of
   // crashing in getNextPageParam when it receives an undefined page.
   if (response.data == null) {
-    throw new Error('Log search returned no data — the server may have returned an error')
+    const problem = response.error as
+      { detail?: string; title?: string } | undefined
+    throw new Error(
+      problem?.detail ??
+        problem?.title ??
+        'Log search returned no data — the server may have returned an error'
+    )
   }
 
   return response.data as SearchLogsResponse
@@ -156,7 +164,8 @@ export function useLogHistory(params: LogSearchParams, enabled = true) {
       params.nodeIds,
     ],
     queryFn: () => searchLogs(params),
-    enabled: enabled && (!!params.projectId || params.externalServiceId != null),
+    enabled:
+      enabled && (!!params.projectId || params.externalServiceId != null),
     staleTime: 1000 * 30, // 30 seconds
     placeholderData: keepPreviousData,
   })
@@ -202,7 +211,8 @@ export function useLogHistoryInfinite(
     // lastPage is the most recently fetched (oldest) page; its next_cursor
     // points at the next-older page. Undefined stops the "load older" walk.
     getNextPageParam: (lastPage) => lastPage?.next_cursor ?? undefined,
-    enabled: enabled && (!!params.projectId || params.externalServiceId != null),
+    enabled:
+      enabled && (!!params.projectId || params.externalServiceId != null),
     staleTime: 1000 * 30,
   })
 }

--- a/web/src/lib/service-log-availability.ts
+++ b/web/src/lib/service-log-availability.ts
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+export type ServiceLogAvailability = 'checking' | 'available' | 'needs-project'
+
+export function serviceLogAvailability({
+  linksLoading,
+  linksFailed,
+  linkedProjectCount,
+}: {
+  linksLoading: boolean
+  linksFailed: boolean
+  linkedProjectCount: number | undefined
+}): ServiceLogAvailability {
+  if (linksLoading) return 'checking'
+  // If the prerequisite check itself fails, let the log endpoint return its
+  // canonical error instead of incorrectly claiming that the service is
+  // unlinked.
+  if (linksFailed || linkedProjectCount === undefined) return 'available'
+  return linkedProjectCount === 0 ? 'needs-project' : 'available'
+}

--- a/web/src/pages/ServiceDetail.tsx
+++ b/web/src/pages/ServiceDetail.tsx
@@ -92,6 +92,7 @@ import {
   ArrowLeft,
   ArrowUpCircle,
   CheckCircle2,
+  ChevronDown,
   ChevronLeft,
   ChevronRight,
   Clock,
@@ -99,8 +100,8 @@ import {
   Eye,
   EyeOff,
   HardDrive,
+  Link2,
   Loader2,
-  MoreVertical,
   Pencil,
   Plus,
   Radio,
@@ -190,7 +191,7 @@ export function ServiceDetail() {
     container_name: string
   } | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const [prevStatus, setPrevStatus] = useState<string | undefined>(undefined)
+  const prevStatusRef = useRef<string | undefined>(undefined)
   const [visibleParameters, setVisibleParameters] = useState<Set<string>>(
     new Set()
   )
@@ -307,6 +308,9 @@ export function ServiceDetail() {
 
   useEffect(() => {
     if (backupsPage > backupsTotalPages) {
+      // The server total can shrink after a backup is removed while this page
+      // is open; synchronize the requested page back into the valid range.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setBackupsPage(backupsTotalPages)
     }
   }, [backupsPage, backupsTotalPages])
@@ -325,7 +329,14 @@ export function ServiceDetail() {
     return Array.from({ length: windowSize }, (_, idx) => start + idx)
   }, [backupsPage, backupsTotalPages])
 
-  const [isLinkPopoverOpen, setIsLinkPopoverOpen] = useState(false)
+  const [isLinkPopoverOpen, setIsLinkPopoverOpen] = useState(
+    () =>
+      (
+        location.state as {
+          openLinkedProjects?: boolean
+        } | null
+      )?.openLinkedProjects === true
+  )
 
   const linkService = useMutation({
     ...linkServiceToProjectMutation(),
@@ -359,15 +370,14 @@ export function ServiceDetail() {
   // Notify when cluster creation completes or fails
   useEffect(() => {
     const currentStatus = service?.service?.status
+    const prevStatus = prevStatusRef.current
     if (prevStatus === 'creating' && currentStatus === 'running') {
       toast.success('Cluster created successfully')
     } else if (prevStatus === 'creating' && currentStatus === 'failed') {
       toast.error('Cluster creation failed')
     }
-    if (currentStatus) {
-      setPrevStatus(currentStatus)
-    }
-  }, [service?.service?.status, prevStatus])
+    prevStatusRef.current = currentStatus
+  }, [service?.service?.status])
 
   const startService = useMutation({
     ...startServiceMutation(),
@@ -663,19 +673,16 @@ export function ServiceDetail() {
               onOpenChange={setIsLinkPopoverOpen}
             >
               <PopoverTrigger asChild>
-                <Button variant="outline" size="sm" className="gap-2">
-                  <Plus className="h-4 w-4" />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="min-h-12 gap-2 sm:min-h-8"
+                >
+                  <Link2 className="h-4 w-4" />
                   {linkedProjectsLoading ? (
                     <Loader2 className="h-3 w-3 animate-spin" />
                   ) : (
-                    <>
-                      <span className="hidden sm:inline">
-                        {linkedProjectsResponse?.length || 0} linked
-                      </span>
-                      <span className="sm:hidden">
-                        {linkedProjectsResponse?.length || 0}
-                      </span>
-                    </>
+                    <span>{linkedProjectsResponse?.length || 0} linked</span>
                   )}
                 </Button>
               </PopoverTrigger>
@@ -752,61 +759,92 @@ export function ServiceDetail() {
               </PopoverContent>
             </Popover>
 
-            {service.service.status === 'running' && (
-              <Link to={`/storage/${id}/monitoring`}>
-                <Button variant="outline" size="sm" className="gap-2">
-                  <Activity className="h-4 w-4" />
-                  <span className="hidden sm:inline">Monitoring</span>
-                </Button>
-              </Link>
-            )}
-            <Link to={`/storage/${id}/browse`}>
-              <Button variant="outline" size="sm" className="gap-2">
-                <Database className="h-4 w-4" />
-                <span className="hidden sm:inline">Browse Data</span>
-              </Button>
-            </Link>
-            <Link to={`/storage/${id}/logs`}>
-              <Button variant="outline" size="sm" className="gap-2">
-                <ScrollText className="h-4 w-4" />
-                <span className="hidden sm:inline">Logs</span>
-              </Button>
-            </Link>
-            {service.service.service_type === 'postgres' && (
-              <Link to={`/storage/${id}/query-performance`}>
-                <Button variant="outline" size="sm" className="gap-2">
-                  <BarChart2 className="h-4 w-4" />
-                  <span className="hidden sm:inline">Query Performance</span>
-                </Button>
-              </Link>
-            )}
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon" className="h-8 w-8">
-                  <MoreVertical className="h-4 w-4" />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="min-h-12 gap-2 sm:min-h-8"
+                >
+                  <Eye className="h-4 w-4" />
+                  Explore
+                  <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="min-w-48">
+                {service.service.status === 'running' && (
+                  <DropdownMenuItem asChild className="min-h-12 sm:min-h-8">
+                    <Link to={`/storage/${id}/monitoring`}>
+                      <Activity className="mr-2 h-4 w-4" />
+                      Monitoring
+                    </Link>
+                  </DropdownMenuItem>
+                )}
+                <DropdownMenuItem asChild className="min-h-12 sm:min-h-8">
+                  <Link to={`/storage/${id}/browse`}>
+                    <Database className="mr-2 h-4 w-4" />
+                    Browse data
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem asChild className="min-h-12 sm:min-h-8">
+                  <Link to={`/storage/${id}/logs`}>
+                    <ScrollText className="mr-2 h-4 w-4" />
+                    Logs
+                  </Link>
+                </DropdownMenuItem>
+                {service.service.service_type === 'postgres' && (
+                  <DropdownMenuItem asChild className="min-h-12 sm:min-h-8">
+                    <Link to={`/storage/${id}/query-performance`}>
+                      <BarChart2 className="mr-2 h-4 w-4" />
+                      Query performance
+                    </Link>
+                  </DropdownMenuItem>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="min-h-12 gap-2 sm:min-h-8"
+                >
+                  Actions
+                  <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={() => setIsBackupDialogOpen(true)}>
+                <DropdownMenuItem
+                  className="min-h-12 sm:min-h-8"
+                  onClick={() => setIsBackupDialogOpen(true)}
+                >
                   <HardDrive className="h-4 w-4 mr-2" />
                   Backup
                 </DropdownMenuItem>
                 <DropdownMenuItem
+                  className="min-h-12 sm:min-h-8"
                   onClick={() => navigate(`/storage/${parseInt(id!)}/restore`)}
                 >
                   <RotateCcw className="h-4 w-4 mr-2" />
                   Restore…
                 </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => setIsEditDialogOpen(true)}>
+                <DropdownMenuItem
+                  className="min-h-12 sm:min-h-8"
+                  onClick={() => setIsEditDialogOpen(true)}
+                >
                   <Pencil className="h-4 w-4 mr-2" />
                   Edit
                 </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => setIsUpgradeDialogOpen(true)}>
+                <DropdownMenuItem
+                  className="min-h-12 sm:min-h-8"
+                  onClick={() => setIsUpgradeDialogOpen(true)}
+                >
                   <ArrowUpCircle className="h-4 w-4 mr-2" />
                   Upgrade
                 </DropdownMenuItem>
                 {service.service.service_type === 'postgres' ? (
                   <DropdownMenuItem
+                    className="min-h-12 sm:min-h-8"
                     onClick={() => setIsMajorUpgradeDialogOpen(true)}
                   >
                     <ArrowUpCircle className="h-4 w-4 mr-2" />
@@ -821,11 +859,11 @@ export function ServiceDetail() {
                     startService.isPending ||
                     stopService.isPending
                   }
-                  className={
-                    service.service.status === 'running'
-                      ? 'text-destructive focus:text-destructive'
-                      : ''
-                  }
+                  className={cn(
+                    'min-h-12 sm:min-h-8',
+                    service.service.status === 'running' &&
+                      'text-destructive focus:text-destructive'
+                  )}
                 >
                   {startService.isPending || stopService.isPending ? (
                     <Loader2 className="h-4 w-4 mr-2 animate-spin" />
@@ -843,7 +881,7 @@ export function ServiceDetail() {
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
                   onClick={() => setIsDeleteDialogOpen(true)}
-                  className="text-destructive focus:text-destructive"
+                  className="min-h-12 text-destructive focus:text-destructive sm:min-h-8"
                 >
                   <Trash2 className="h-4 w-4 mr-2" />
                   Delete
@@ -1835,8 +1873,8 @@ export function ServiceDetail() {
                 {memberToRemove?.container_name}
               </span>{' '}
               from this cluster. The container, its data volume, and the
-              member's DNS record will be deleted. The pg_auto_failover monitor
-              will mark the node as unreachable; run{' '}
+              member&apos;s DNS record will be deleted. The pg_auto_failover
+              monitor will mark the node as unreachable; run{' '}
               <span className="font-mono">pg_autoctl drop node</span> manually
               if you want a fully-clean monitor view.
             </DialogDescription>

--- a/web/src/pages/ServiceLogs.test.ts
+++ b/web/src/pages/ServiceLogs.test.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+import { describe, expect, test } from 'bun:test'
+import { serviceLogAvailability } from '@/lib/service-log-availability'
+
+describe('service log availability', () => {
+  test('waits for project links before querying logs', () => {
+    expect(
+      serviceLogAvailability({
+        linksLoading: true,
+        linksFailed: false,
+        linkedProjectCount: undefined,
+      })
+    ).toBe('checking')
+  })
+
+  test('onboards an unlinked service instead of querying a denied scope', () => {
+    expect(
+      serviceLogAvailability({
+        linksLoading: false,
+        linksFailed: false,
+        linkedProjectCount: 0,
+      })
+    ).toBe('needs-project')
+  })
+
+  test('loads logs for linked services and defers failed checks to the log API', () => {
+    expect(
+      serviceLogAvailability({
+        linksLoading: false,
+        linksFailed: false,
+        linkedProjectCount: 1,
+      })
+    ).toBe('available')
+    expect(
+      serviceLogAvailability({
+        linksLoading: false,
+        linksFailed: true,
+        linkedProjectCount: undefined,
+      })
+    ).toBe('available')
+  })
+})

--- a/web/src/pages/ServiceLogs.tsx
+++ b/web/src/pages/ServiceLogs.tsx
@@ -1,7 +1,10 @@
 // SPDX-FileCopyrightText: 2024-2026 Temps Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-import { getServiceOptions } from '@/api/client/@tanstack/react-query.gen'
+import {
+  getServiceOptions,
+  listServiceProjectsOptions,
+} from '@/api/client/@tanstack/react-query.gen'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -22,23 +25,19 @@ import {
   type LogSearchLine,
   useLogHistoryInfinite,
 } from '@/hooks/useLogHistory'
+import { serviceLogAvailability } from '@/lib/service-log-availability'
 import { useQuery } from '@tanstack/react-query'
 import {
   ArrowLeft,
   Database,
+  Link2,
   Loader2,
   RefreshCw,
   ScrollText,
   Server,
 } from 'lucide-react'
 import type { DateRange } from 'react-day-picker'
-import {
-  useCallback,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react'
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { Link, useParams } from 'react-router'
 
 /** Tailwind classes per normalized level — mirrors the deployment log viewer. */
@@ -108,10 +107,26 @@ export function ServiceLogs() {
     enabled: !Number.isNaN(serviceId),
   })
 
+  const {
+    data: linkedProjects,
+    isLoading: linkedProjectsLoading,
+    isError: linkedProjectsFailed,
+  } = useQuery({
+    ...listServiceProjectsOptions({ path: { id: serviceId } }),
+    enabled: !Number.isNaN(serviceId),
+  })
+
+  const logAvailability = serviceLogAvailability({
+    linksLoading: linkedProjectsLoading,
+    linksFailed: linkedProjectsFailed,
+    linkedProjectCount: linkedProjects?.length,
+  })
+
   const [text, setText] = useState('')
   const [activeLevels, setActiveLevels] = useState<LogLevel[]>([])
   // Bumped by Refresh to collapse back to a single newest page and re-tail.
   const [refreshKey, setRefreshKey] = useState(0)
+  const [rangeAnchor, setRangeAnchor] = useState(Date.now)
 
   // ── Date/time range filter ───────────────────────────────────────────
   const [preset, setPreset] = useState<TimePreset>('24h')
@@ -126,7 +141,7 @@ export function ServiceLogs() {
     if (preset !== 'custom') {
       const ms = PRESET_MS[preset]
       return {
-        startTime: new Date(Date.now() - ms).toISOString(),
+        startTime: new Date(rangeAnchor - ms).toISOString(),
         endTime: undefined,
       }
     }
@@ -134,13 +149,14 @@ export function ServiceLogs() {
       startTime: customRange?.from?.toISOString(),
       endTime: customRange?.to?.toISOString(),
     }
-  }, [preset, customRange])
+  }, [preset, customRange, rangeAnchor])
 
   // When switching away from custom, reset the custom range so the DateRangePicker
   // comes up clean if the user switches back.
   function handlePresetChange(next: TimePreset) {
     if (next !== 'custom') setCustomRange(undefined)
     setPreset(next)
+    setRangeAnchor(Date.now())
     // A time-range change should re-tail to the newest lines.
     setRefreshKey((k) => k + 1)
   }
@@ -168,7 +184,9 @@ export function ServiceLogs() {
       pageSize: PAGE_SIZE,
       refreshKey,
     },
-    !Number.isNaN(serviceId) && startTime !== undefined
+    !Number.isNaN(serviceId) &&
+      startTime !== undefined &&
+      logAvailability === 'available'
   )
 
   // Pages come newest-first (page 0 = newest). Reverse so the oldest loaded
@@ -338,7 +356,10 @@ export function ServiceLogs() {
               variant="outline"
               size="sm"
               className="gap-2"
-              onClick={() => setRefreshKey((k) => k + 1)}
+              onClick={() => {
+                setRangeAnchor(Date.now())
+                setRefreshKey((k) => k + 1)
+              }}
               disabled={refreshing}
             >
               <RefreshCw
@@ -411,7 +432,30 @@ export function ServiceLogs() {
 
         {/* Log panel — bounded height + its own scrollbar. Tails to the newest
             line on load; scrolling to the top lazily pages in older lines. */}
-        {preset === 'custom' && !customRange?.from ? (
+        {logAvailability === 'needs-project' ? (
+          <div className="rounded-md border border-dashed p-8 text-center">
+            <Link2 className="mx-auto h-6 w-6 text-muted-foreground" />
+            <p className="mt-3 text-sm font-medium">
+              Link this service to a project to view logs
+            </p>
+            <p className="mx-auto mt-1 max-w-md text-sm text-muted-foreground">
+              Service logs inherit project access controls. Link at least one
+              project before searching or retaining this service&apos;s logs.
+            </p>
+            <Button asChild variant="outline" size="sm" className="mt-4">
+              <Link to={`/storage/${id}`} state={{ openLinkedProjects: true }}>
+                <Link2 className="mr-2 h-4 w-4" />
+                Link a project
+              </Link>
+            </Button>
+          </div>
+        ) : logAvailability === 'checking' ? (
+          <div className="space-y-2">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Skeleton key={i} className="h-5 w-full" />
+            ))}
+          </div>
+        ) : preset === 'custom' && !customRange?.from ? (
           <div className="rounded-md border border-dashed p-8 text-center text-sm text-muted-foreground">
             Select a start date above to load logs for a custom time range.
           </div>


### PR DESCRIPTION
## Summary

- reduce the service-detail header to three clear controls: linked projects, **Explore**, and **Actions**
- guide unlinked services through project linking before requesting unavailable logs, while preserving API problem details for real failures
- keep relative log ranges current on refresh and correct sandbox CLI context documentation

## Functional evidence

### Service navigation and actions

The redesigned header was exercised at desktop (1440 px) and mobile (390 px) widths against the `temps-test-1` test environment. It has no horizontal overflow and keeps 48 px mobile interaction targets.

- **Explore:** Monitoring, Browse data, Logs, and PostgreSQL Query performance
- **Actions:** Backup, Restore, Edit, Upgrade, Major Version Upgrade, Start/Stop, and Delete

### Unlinked service logs

Before this change, opening logs for an unlinked S3 service issued two failing `POST /api/logs/search` requests (404) and then misleadingly displayed `0 lines`. After this change, it issues zero log-search requests, explains that a project link is required, and opens the linked-project picker directly from **Link a project**.

### Interactive report

The reproducible HTML report includes screenshots and three playable videos and is available inside the project Tailscale network:

http://100.76.250.19:8765/

The report media remains outside the repository in `/private/tmp`; no screenshots, videos, generated reports, credentials, or runtime data are included in this PR.

## Verification

- changed-file ESLint: passed
- TypeScript (`bunx tsc --noEmit`): passed
- frontend tests: **475 passed, 0 failed, 822 assertions across 93 files**
- production build: passed
- staged diff whitespace check: passed
- staged path and secret/artifact review: passed

The workspace-wide lint command still reports pre-existing errors in files untouched by this change; every changed source and test file is lint-clean.

## Scope

The previously discussed active-domain lifecycle behavior is intentionally excluded, per product decision: `active` describes certificate validity and is not itself evidence that the deleted project remains active.
