### PR TITLE
feat(vulnerability-scanner): make Trivy scanning opt-in per project, disabled by default

### DIFF
--- a/apps/temps-cli/openapi.json
+++ b/apps/temps-cli/openapi.json
@@ -29920,6 +29920,10 @@
           "updated_at": {
             "format": "int64",
             "type": "integer"
+          },
+          "vulnerability_scanning_enabled": {
+            "description": "Opt-in Trivy vulnerability scanning of this project's deployed Docker\nimages. Off by default — project owners explicitly enable it.",
+            "type": "boolean"
           }
         },
         "required": [
@@ -29935,6 +29939,7 @@
           "attack_mode",
           "ai_write_actions_enabled",
           "error_source_context_enabled",
+          "vulnerability_scanning_enabled",
           "enable_preview_environments",
           "preview_envs_on_demand",
           "preview_envs_idle_timeout_seconds",
@@ -44844,6 +44849,13 @@
           "slug": {
             "type": [
               "string",
+              "null"
+            ]
+          },
+          "vulnerability_scanning_enabled": {
+            "description": "Opt in to Trivy vulnerability scanning of this project's deployed Docker\nimages (post-deployment scan + daily rescans). Off by default.",
+            "type": [
+              "boolean",
               "null"
             ]
           }

--- a/apps/temps-cli/src/api/types.gen.ts
+++ b/apps/temps-cli/src/api/types.gen.ts
@@ -13921,6 +13921,11 @@ export type ProjectResponse = {
      */
     source_type: SourceType;
     updated_at: number;
+    /**
+     * Opt-in Trivy vulnerability scanning of this project's deployed Docker
+     * images. Off by default — project owners explicitly enable it.
+     */
+    vulnerability_scanning_enabled: boolean;
 };
 
 export type ProjectSecretEnvironmentInfo = {
@@ -20729,6 +20734,11 @@ export type UpdateProjectSettingsRequest = {
     repo_name?: string | null;
     repo_owner?: string | null;
     slug?: string | null;
+    /**
+     * Opt in to Trivy vulnerability scanning of this project's deployed Docker
+     * images (post-deployment scan + daily rescans). Off by default.
+     */
+    vulnerability_scanning_enabled?: boolean | null;
 };
 
 /**

--- a/apps/temps-cli/src/commands/projects/index.ts
+++ b/apps/temps-cli/src/commands/projects/index.ts
@@ -70,7 +70,7 @@ export function registerProjectsCommands(program: Command): void {
 
   projects
     .command('settings')
-    .description('Update project settings (name, slug, attack mode, preview environments, image retention)')
+    .description('Update project settings (name, slug, attack mode, preview environments, vulnerability scanning, image retention)')
     .option('-p, --project <project>', 'Project slug or ID')
     .option('--name <name>', 'Project display name (does not change the URL)')
     .option('--slug <slug>', 'Project URL slug')
@@ -78,6 +78,14 @@ export function registerProjectsCommands(program: Command): void {
     .option('--no-attack-mode', 'Disable attack mode')
     .option('--preview-envs', 'Enable preview environments')
     .option('--no-preview-envs', 'Disable preview environments')
+    .option(
+      '--vulnerability-scanning',
+      'Enable Trivy vulnerability scanning of deployed Docker images (post-deploy + daily)'
+    )
+    .option(
+      '--no-vulnerability-scanning',
+      'Disable vulnerability scanning'
+    )
     .option(
       '--image-retention-hours <hours>',
       'Hours to keep built images before nightly cleanup removes them (1-8760). ' +

--- a/apps/temps-cli/src/commands/projects/show.ts
+++ b/apps/temps-cli/src/commands/projects/show.ts
@@ -87,6 +87,7 @@ export async function show(options: ShowOptions): Promise<void> {
     'Git Provider': gitProviderLabel(project.git_provider_type),
     'Attack Mode': project.attack_mode ? 'Enabled' : 'Disabled',
     'Preview Envs': project.enable_preview_environments ? 'Enabled' : 'Disabled',
+    'Vulnerability Scanning': project.vulnerability_scanning_enabled ? 'Enabled' : 'Disabled',
     Created: formatDate(new Date(project.created_at * 1000).toISOString()),
     Updated: formatDate(new Date(project.updated_at * 1000).toISOString()),
   })

--- a/apps/temps-cli/src/commands/projects/update.ts
+++ b/apps/temps-cli/src/commands/projects/update.ts
@@ -104,6 +104,7 @@ export async function updateSettingsAction(
     slug?: string
     attackMode?: boolean
     previewEnvs?: boolean
+    vulnerabilityScanning?: boolean
     imageRetentionHours?: string
     resetImageRetention?: boolean
     json?: boolean
@@ -176,6 +177,7 @@ export async function updateSettingsAction(
   let slug = options.slug
   let attackMode = options.attackMode
   let previewEnvs = options.previewEnvs
+  let vulnerabilityScanning = options.vulnerabilityScanning
 
   // Only prompt if no flags provided AND not in automation mode
   if (
@@ -183,6 +185,7 @@ export async function updateSettingsAction(
     slug === undefined &&
     attackMode === undefined &&
     previewEnvs === undefined &&
+    vulnerabilityScanning === undefined &&
     imageRetentionHours === undefined &&
     !options.yes
   ) {
@@ -210,6 +213,12 @@ export async function updateSettingsAction(
       message: 'Enable preview environments for branches?',
       default: project.enable_preview_environments ?? false,
     })
+
+    vulnerabilityScanning = await promptConfirm({
+      message:
+        'Enable vulnerability scanning (Trivy scans of deployed Docker images, post-deploy + daily)?',
+      default: project.vulnerability_scanning_enabled ?? false,
+    })
   }
 
   const updated = await withSpinner('Updating project settings...', async () => {
@@ -221,6 +230,7 @@ export async function updateSettingsAction(
         slug: slug ?? undefined,
         attack_mode: attackMode ?? undefined,
         enable_preview_environments: previewEnvs ?? undefined,
+        vulnerability_scanning_enabled: vulnerabilityScanning ?? undefined,
         // Only include the key when the user actually asked to change it —
         // sending `null` unconditionally would silently reset every project
         // to the system default.
@@ -248,6 +258,7 @@ export async function updateSettingsAction(
   keyValue('Slug', updated?.slug ?? slug ?? project.slug)
   keyValue('Attack Mode', attackMode ? colors.success('Enabled') : colors.muted('Disabled'))
   keyValue('Preview Environments', previewEnvs ? colors.success('Enabled') : colors.muted('Disabled'))
+  keyValue('Vulnerability Scanning', vulnerabilityScanning ? colors.success('Enabled') : colors.muted('Disabled'))
 
   const effectiveRetention =
     imageRetentionHours !== undefined

--- a/apps/temps-cli/src/commands/projects/update.ts
+++ b/apps/temps-cli/src/commands/projects/update.ts
@@ -258,7 +258,14 @@ export async function updateSettingsAction(
   keyValue('Slug', updated?.slug ?? slug ?? project.slug)
   keyValue('Attack Mode', attackMode ? colors.success('Enabled') : colors.muted('Disabled'))
   keyValue('Preview Environments', previewEnvs ? colors.success('Enabled') : colors.muted('Disabled'))
-  keyValue('Vulnerability Scanning', vulnerabilityScanning ? colors.success('Enabled') : colors.muted('Disabled'))
+  keyValue(
+    'Vulnerability Scanning',
+    (updated?.vulnerability_scanning_enabled ??
+      vulnerabilityScanning ??
+      project.vulnerability_scanning_enabled)
+      ? colors.success('Enabled')
+      : colors.muted('Disabled')
+  )
 
   const effectiveRetention =
     imageRetentionHours !== undefined

--- a/crates/temps-agents/src/services/config_service.rs
+++ b/crates/temps-agents/src/services/config_service.rs
@@ -1264,6 +1264,7 @@ mod tests {
             allow_alternate_sources: None,
             ai_write_actions_enabled: false,
             error_source_context_enabled: false,
+            vulnerability_scanning_enabled: false,
             error_source_root: None,
             enable_preview_environments: false,
             preview_envs_on_demand: false,

--- a/crates/temps-agents/src/services/executor.rs
+++ b/crates/temps-agents/src/services/executor.rs
@@ -4165,6 +4165,7 @@ mod tests {
             allow_alternate_sources: None,
             ai_write_actions_enabled: false,
             error_source_context_enabled: true,
+            vulnerability_scanning_enabled: false,
             error_source_root: None,
             enable_preview_environments: true,
             preview_envs_on_demand: false,

--- a/crates/temps-ai-chat/src/handlers.rs
+++ b/crates/temps-ai-chat/src/handlers.rs
@@ -2248,6 +2248,7 @@ mod tests {
             ai_debug_chat_enabled: toggle,
             ai_write_actions_enabled: false,
             error_source_context_enabled: false,
+            vulnerability_scanning_enabled: false,
             error_source_root: None,
             enable_preview_environments: false,
             preview_envs_on_demand: false,

--- a/crates/temps-ai-chat/src/pending_actions.rs
+++ b/crates/temps-ai-chat/src/pending_actions.rs
@@ -620,6 +620,7 @@ mod tests {
             ai_debug_chat_enabled: Some(true),
             ai_write_actions_enabled: write_enabled,
             error_source_context_enabled: false,
+            vulnerability_scanning_enabled: false,
             error_source_root: None,
             enable_preview_environments: false,
             preview_envs_on_demand: false,

--- a/crates/temps-ai-chat/src/providers/project.rs
+++ b/crates/temps-ai-chat/src/providers/project.rs
@@ -108,6 +108,7 @@ mod tests {
             ai_debug_chat_enabled: Some(true),
             ai_write_actions_enabled: false,
             error_source_context_enabled: false,
+            vulnerability_scanning_enabled: false,
             error_source_root: None,
             enable_preview_environments: false,
             preview_envs_on_demand: false,

--- a/crates/temps-ai-chat/src/providers/repo_tools.rs
+++ b/crates/temps-ai-chat/src/providers/repo_tools.rs
@@ -775,6 +775,7 @@ mod tests {
             ai_debug_chat_enabled: None,
             ai_write_actions_enabled: false,
             error_source_context_enabled: false,
+            vulnerability_scanning_enabled: false,
             error_source_root: None,
             enable_preview_environments: false,
             preview_envs_on_demand: false,

--- a/crates/temps-ai-chat/src/service.rs
+++ b/crates/temps-ai-chat/src/service.rs
@@ -3964,6 +3964,7 @@ mod tests {
             ai_debug_chat_enabled: toggle,
             ai_write_actions_enabled: false,
             error_source_context_enabled: false,
+            vulnerability_scanning_enabled: false,
             error_source_root: None,
             enable_preview_environments: false,
             preview_envs_on_demand: false,

--- a/crates/temps-analytics-performance/src/handlers/handler.rs
+++ b/crates/temps-analytics-performance/src/handlers/handler.rs
@@ -961,6 +961,7 @@ mod tests {
             ai_debug_chat_enabled: None,
             ai_write_actions_enabled: false,
             error_source_context_enabled: false,
+            vulnerability_scanning_enabled: false,
             error_source_root: None,
             enable_preview_environments: false,
             preview_envs_on_demand: false,

--- a/crates/temps-analytics/src/ingest_keys/test_fixtures.rs
+++ b/crates/temps-analytics/src/ingest_keys/test_fixtures.rs
@@ -59,6 +59,7 @@ pub fn project_model(id: i32) -> projects::Model {
         ai_debug_chat_enabled: None,
         ai_write_actions_enabled: false,
         error_source_context_enabled: false,
+        vulnerability_scanning_enabled: false,
         error_source_root: None,
         enable_preview_environments: false,
         preview_envs_on_demand: false,

--- a/crates/temps-deployments/src/services/job_processor.rs
+++ b/crates/temps-deployments/src/services/job_processor.rs
@@ -1931,6 +1931,9 @@ mod tests {
             is_public_repo: Set(false),
             git_url: Set(None),
             main_branch: Set("main".to_string()),
+            // Enable vulnerability scanning so the scan_vulnerabilities job is included
+            // in the workflow plan (the assertion below checks for it by name).
+            vulnerability_scanning_enabled: Set(true),
             ..Default::default()
         };
         let project = project.insert(db).await?;

--- a/crates/temps-deployments/src/services/workflow_planner.rs
+++ b/crates/temps-deployments/src/services/workflow_planner.rs
@@ -2040,7 +2040,7 @@ impl WorkflowPlanner {
         // has no image to scan)
         // This runs in parallel with other post-deployment jobs AFTER deployment is marked complete
         // NOT required for deployment completion - if it fails, deployment still succeeds
-        if has_git_info && needs_container_build {
+        if has_git_info && needs_container_build && project.vulnerability_scanning_enabled {
             jobs.push(JobDefinition {
                 job_id: "scan_vulnerabilities".to_string(),
                 job_type: "ScanVulnerabilitiesJob".to_string(),
@@ -2062,6 +2062,11 @@ impl WorkflowPlanner {
             });
             debug!(
                 "Added scan_vulnerabilities job to workflow (runs after deployment is marked complete)"
+            );
+        } else if !project.vulnerability_scanning_enabled {
+            debug!(
+                "Skipping vulnerability scan job - vulnerability scanning is disabled for project {}",
+                project.id
             );
         } else {
             debug!("Skipping vulnerability scan job - no git info available");

--- a/crates/temps-entities/src/projects.rs
+++ b/crates/temps-entities/src/projects.rs
@@ -61,6 +61,12 @@ pub struct Model {
     /// application source is always a deliberate choice.
     #[sea_orm(default_value = "false")]
     pub error_source_context_enabled: bool,
+    /// Opt-in Trivy vulnerability scanning of this project's deployed Docker
+    /// images (post-deployment scan + daily rescans). Off by default — scanning
+    /// costs CPU/time per image and requires the `trivy` binary; project owners
+    /// explicitly enable it when they want the coverage.
+    #[sea_orm(default_value = "false")]
+    pub vulnerability_scanning_enabled: bool,
     /// Where the auto-capture job reads source from, relative to the git
     /// checkout. NULL = default to the deployment's Docker build context (the
     /// directory the image was built from) — the correct root for Dockerfile

--- a/crates/temps-git/src/handlers/bitbucket.rs
+++ b/crates/temps-git/src/handlers/bitbucket.rs
@@ -428,6 +428,7 @@ mod tests {
             ai_write_actions_enabled: false,
             cross_project_trace_sharing: true,
             error_source_context_enabled: false,
+            vulnerability_scanning_enabled: false,
             error_source_root: None,
             image_retention_hours: None,
             enable_preview_environments: false,

--- a/crates/temps-git/src/handlers/generic.rs
+++ b/crates/temps-git/src/handlers/generic.rs
@@ -383,6 +383,7 @@ mod tests {
             ai_write_actions_enabled: false,
             cross_project_trace_sharing: true,
             error_source_context_enabled: false,
+            vulnerability_scanning_enabled: false,
             error_source_root: None,
             image_retention_hours: None,
             enable_preview_environments: false,

--- a/crates/temps-migrations/src/migration/m20260903_000001_add_vulnerability_scanning_enabled_to_projects.rs
+++ b/crates/temps-migrations/src/migration/m20260903_000001_add_vulnerability_scanning_enabled_to_projects.rs
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Per-project opt-in toggle for Trivy-based vulnerability scanning.
+//!
+//! Adds `projects.vulnerability_scanning_enabled` (default false). When enabled,
+//! Temps automatically scans the project's deployed Docker images after every
+//! deployment and on the nightly rescan schedule. Also permits on-demand manual
+//! scans via the API. Off by default — scanning costs CPU/time per image and
+//! requires the `trivy` binary; project owners explicitly enable it when they
+//! want the coverage.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Projects::Table)
+                    .add_column(
+                        ColumnDef::new(Projects::VulnerabilityScanningEnabled)
+                            .boolean()
+                            .not_null()
+                            .default(false),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Projects::Table)
+                    .drop_column(Projects::VulnerabilityScanningEnabled)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum Projects {
+    Table,
+    VulnerabilityScanningEnabled,
+}

--- a/crates/temps-migrations/src/migration/mod.rs
+++ b/crates/temps-migrations/src/migration/mod.rs
@@ -216,6 +216,7 @@ mod m20260831_000001_create_analytics_ingest_keys;
 mod m20260831_000001_create_traefik_route_certificates;
 mod m20260831_000002_backfill_acme_verification_method;
 mod m20260902_000001_backup_safety_and_provenance;
+mod m20260903_000001_add_vulnerability_scanning_enabled_to_projects;
 
 pub struct Migrator;
 
@@ -473,6 +474,9 @@ impl MigratorTrait for Migrator {
             // scheduler can dispatch them; "manual" is intentionally left untouched.
             Box::new(m20260831_000002_backfill_acme_verification_method::Migration),
             Box::new(m20260902_000001_backup_safety_and_provenance::Migration),
+            Box::new(
+                m20260903_000001_add_vulnerability_scanning_enabled_to_projects::Migration,
+            ),
         ]
     }
 }

--- a/crates/temps-notifications/src/vulnerability_notifications.rs
+++ b/crates/temps-notifications/src/vulnerability_notifications.rs
@@ -419,6 +419,7 @@ mod tests {
             preset_config: None,
             deployment_config: None,
             error_source_context_enabled: false,
+            vulnerability_scanning_enabled: false,
             error_source_root: None,
             enable_preview_environments: false,
             preview_envs_on_demand: false,

--- a/crates/temps-projects/src/handlers/types.rs
+++ b/crates/temps-projects/src/handlers/types.rs
@@ -357,6 +357,9 @@ pub struct ProjectResponse {
     /// Opt-in to native error-tracking source context (false = off). When on,
     /// Temps stores uploaded source files and shows source code in stack traces.
     pub error_source_context_enabled: bool,
+    /// Opt-in Trivy vulnerability scanning of this project's deployed Docker
+    /// images. Off by default — project owners explicitly enable it.
+    pub vulnerability_scanning_enabled: bool,
     /// Where auto-capture reads source from (relative to the checkout). Null =
     /// the deployment's Docker build context.
     pub error_source_root: Option<String>,
@@ -427,6 +430,7 @@ impl ProjectResponse {
             ai_write_actions_enabled: project.ai_write_actions_enabled,
             ai_api_traffic_summary_enabled: project.ai_api_traffic_summary_enabled,
             error_source_context_enabled: project.error_source_context_enabled,
+            vulnerability_scanning_enabled: project.vulnerability_scanning_enabled,
             error_source_root: project.error_source_root,
             enable_preview_environments: project.enable_preview_environments,
             preview_envs_on_demand: project.preview_envs_on_demand,
@@ -728,6 +732,9 @@ pub struct UpdateProjectSettingsRequest {
     /// Opt in to native error-tracking source context (source-file upload +
     /// source code shown in stack traces).
     pub error_source_context_enabled: Option<bool>,
+    /// Opt in to Trivy vulnerability scanning of this project's deployed Docker
+    /// images (post-deployment scan + daily rescans). Off by default.
+    pub vulnerability_scanning_enabled: Option<bool>,
     /// Set the auto-capture source root (relative to the checkout). Send an
     /// empty string to clear it back to the build-context default. Omit to
     /// leave unchanged.
@@ -793,6 +800,7 @@ impl From<UpdateProjectSettingsRequest> for crate::services::types::UpdateProjec
             ai_write_actions_enabled: request.ai_write_actions_enabled,
             cross_project_trace_sharing: request.cross_project_trace_sharing,
             error_source_context_enabled: request.error_source_context_enabled,
+            vulnerability_scanning_enabled: request.vulnerability_scanning_enabled,
             error_source_root: request.error_source_root,
             ai_api_traffic_summary_enabled: request.ai_api_traffic_summary_enabled,
             image_retention_hours: request.image_retention_hours,

--- a/crates/temps-projects/src/services/project.rs
+++ b/crates/temps-projects/src/services/project.rs
@@ -1410,6 +1410,7 @@ impl ProjectService {
             ai_write_actions_enabled,
             cross_project_trace_sharing,
             error_source_context_enabled,
+            vulnerability_scanning_enabled,
             error_source_root,
             ai_api_traffic_summary_enabled,
             image_retention_hours,
@@ -1643,6 +1644,7 @@ impl ProjectService {
             || ai_debug_chat_enabled.is_some()
             || ai_write_actions_enabled.is_some()
             || error_source_context_enabled.is_some()
+            || vulnerability_scanning_enabled.is_some()
             || error_source_root.is_some()
             || ai_api_traffic_summary_enabled.is_some()
         {
@@ -1669,6 +1671,10 @@ impl ProjectService {
             // Opt-in for native error-tracking source context (non-null bool).
             if let Some(v) = error_source_context_enabled {
                 active_project.error_source_context_enabled = Set(v);
+            }
+            // Opt-in for Trivy vulnerability scanning (non-null bool, default false).
+            if let Some(v) = vulnerability_scanning_enabled {
+                active_project.vulnerability_scanning_enabled = Set(v);
             }
             // Auto-capture source root (nullable). Empty string clears it back
             // to the build-context default.
@@ -3669,6 +3675,7 @@ impl ProjectService {
             ai_write_actions_enabled: db_project.ai_write_actions_enabled,
             ai_api_traffic_summary_enabled: db_project.ai_api_traffic_summary_enabled,
             error_source_context_enabled: db_project.error_source_context_enabled,
+            vulnerability_scanning_enabled: db_project.vulnerability_scanning_enabled,
             error_source_root: db_project.error_source_root,
             enable_preview_environments: db_project.enable_preview_environments,
             preview_envs_on_demand: db_project.preview_envs_on_demand,

--- a/crates/temps-projects/src/services/types.rs
+++ b/crates/temps-projects/src/services/types.rs
@@ -83,6 +83,9 @@ pub struct Project {
     pub ai_api_traffic_summary_enabled: Option<bool>,
     /// Opt-in for native error-tracking source context.
     pub error_source_context_enabled: bool,
+    /// Opt-in Trivy vulnerability scanning (post-deployment scan + daily rescans).
+    /// Off by default — project owners explicitly enable it.
+    pub vulnerability_scanning_enabled: bool,
     /// Auto-capture source root (relative to the checkout); None = build context.
     pub error_source_root: Option<String>,
     pub enable_preview_environments: bool,
@@ -140,6 +143,7 @@ pub struct UpdateProjectSettingsParams {
     pub ai_write_actions_enabled: Option<bool>,
     pub cross_project_trace_sharing: Option<bool>,
     pub error_source_context_enabled: Option<bool>,
+    pub vulnerability_scanning_enabled: Option<bool>,
     pub error_source_root: Option<String>,
     pub ai_api_traffic_summary_enabled: Option<bool>,
     /// Outer `None` leaves the retention window unchanged; `Some(None)` clears

--- a/crates/temps-sandbox/src/services/sandbox_service.rs
+++ b/crates/temps-sandbox/src/services/sandbox_service.rs
@@ -3176,6 +3176,7 @@ mod storage_cleanup_tests {
             ai_debug_chat_enabled: None,
             ai_write_actions_enabled: false,
             error_source_context_enabled: false,
+            vulnerability_scanning_enabled: false,
             error_source_root: None,
             enable_preview_environments: false,
             preview_envs_on_demand: false,

--- a/crates/temps-vulnerability-scanner/src/daily_scanner.rs
+++ b/crates/temps-vulnerability-scanner/src/daily_scanner.rs
@@ -9,7 +9,7 @@ use chrono::{Timelike, Utc};
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use std::sync::Arc;
 use temps_database::DbConnection;
-use temps_entities::{deployments, environments};
+use temps_entities::{deployments, environments, projects};
 use tokio::time::{self, Duration};
 use tracing::{debug, error, info, warn};
 
@@ -62,10 +62,14 @@ impl DailyVulnerabilityScannerService {
 
     /// Scan all environments with current deployments
     async fn scan_all_deployed_environments(&self) -> Result<(), Box<dyn std::error::Error>> {
-        // Get all environments with current deployments
+        // Get all environments whose project has vulnerability scanning enabled.
+        // Inner join against projects filters out any environment whose project
+        // has the toggle off, so we never scan unless the owner opted in.
         let environments_with_deployments = environments::Entity::find()
+            .inner_join(projects::Entity)
             .filter(environments::Column::CurrentDeploymentId.is_not_null())
             .filter(environments::Column::DeletedAt.is_null())
+            .filter(projects::Column::VulnerabilityScanningEnabled.eq(true))
             .all(self.db.as_ref())
             .await?;
 

--- a/crates/temps-vulnerability-scanner/src/handlers/scans_handler.rs
+++ b/crates/temps-vulnerability-scanner/src/handlers/scans_handler.rs
@@ -43,6 +43,13 @@ impl From<ServiceError> for Problem {
             ServiceError::Internal(msg) => problemdetails::new(StatusCode::INTERNAL_SERVER_ERROR)
                 .with_title("Internal Server Error")
                 .with_detail(msg),
+
+            ServiceError::Disabled { project_id } => problemdetails::new(StatusCode::CONFLICT)
+                .with_title("Vulnerability Scanning Disabled")
+                .with_detail(format!(
+                    "Vulnerability scanning is disabled for project {project_id}. \
+                     Enable it in the project's Settings to run scans."
+                )),
         }
     }
 }
@@ -315,10 +322,31 @@ async fn trigger_scan(
     Json(request): Json<TriggerScanRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     use sea_orm::EntityTrait;
-    use temps_entities::{deployments, environments};
+    use temps_entities::{deployments, environments, projects};
 
     permission_guard!(auth, VulnerabilityScansCreate);
     project_access_guard!(auth, project_id, app_state.project_access_checker);
+
+    // Check that vulnerability scanning is enabled for this project before
+    // doing any further work — read-only endpoints (list/get/delete) are
+    // intentionally NOT gated so historical scan data remains accessible.
+    let project = projects::Entity::find_by_id(project_id)
+        .one(app_state.db.as_ref())
+        .await
+        .map_err(|e| {
+            Problem::from(ServiceError::Internal(format!(
+                "Failed to fetch project {project_id}: {e}"
+            )))
+        })?
+        .ok_or_else(|| {
+            Problem::from(ServiceError::NotFound(format!(
+                "Project {project_id} not found"
+            )))
+        })?;
+
+    if !project.vulnerability_scanning_enabled {
+        return Err(Problem::from(ServiceError::Disabled { project_id }));
+    }
 
     // Fetch environment to get current deployment
     let environment = environments::Entity::find_by_id(request.environment_id)

--- a/crates/temps-vulnerability-scanner/src/handlers/scans_handler.rs
+++ b/crates/temps-vulnerability-scanner/src/handlers/scans_handler.rs
@@ -322,7 +322,7 @@ async fn trigger_scan(
     Json(request): Json<TriggerScanRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     use sea_orm::EntityTrait;
-    use temps_entities::{deployments, environments, projects};
+    use temps_entities::{deployments, environments};
 
     permission_guard!(auth, VulnerabilityScansCreate);
     project_access_guard!(auth, project_id, app_state.project_access_checker);
@@ -330,23 +330,10 @@ async fn trigger_scan(
     // Check that vulnerability scanning is enabled for this project before
     // doing any further work — read-only endpoints (list/get/delete) are
     // intentionally NOT gated so historical scan data remains accessible.
-    let project = projects::Entity::find_by_id(project_id)
-        .one(app_state.db.as_ref())
-        .await
-        .map_err(|e| {
-            Problem::from(ServiceError::Internal(format!(
-                "Failed to fetch project {project_id}: {e}"
-            )))
-        })?
-        .ok_or_else(|| {
-            Problem::from(ServiceError::NotFound(format!(
-                "Project {project_id} not found"
-            )))
-        })?;
-
-    if !project.vulnerability_scanning_enabled {
-        return Err(Problem::from(ServiceError::Disabled { project_id }));
-    }
+    app_state
+        .scan_service
+        .ensure_scanning_enabled(project_id)
+        .await?;
 
     // Fetch environment to get current deployment
     let environment = environments::Entity::find_by_id(request.environment_id)

--- a/crates/temps-vulnerability-scanner/src/service.rs
+++ b/crates/temps-vulnerability-scanner/src/service.rs
@@ -60,6 +60,23 @@ impl VulnerabilityScanService {
         }
     }
 
+    /// Verify vulnerability scanning is opted into for `project_id`. Used by
+    /// the manual trigger endpoint to reject requests before doing further
+    /// work, keeping the project lookup and policy check in the service
+    /// layer rather than the HTTP handler.
+    pub async fn ensure_scanning_enabled(&self, project_id: i32) -> Result<(), ServiceError> {
+        let project = temps_entities::projects::Entity::find_by_id(project_id)
+            .one(self.db.as_ref())
+            .await?
+            .ok_or_else(|| ServiceError::NotFound(format!("Project {project_id} not found")))?;
+
+        if !project.vulnerability_scanning_enabled {
+            return Err(ServiceError::Disabled { project_id });
+        }
+
+        Ok(())
+    }
+
     /// Create a new scan record
     pub async fn create_scan(
         &self,

--- a/crates/temps-vulnerability-scanner/src/service.rs
+++ b/crates/temps-vulnerability-scanner/src/service.rs
@@ -27,6 +27,9 @@ pub enum ServiceError {
 
     #[error("Internal error: {0}")]
     Internal(String),
+
+    #[error("Vulnerability scanning is disabled for project {project_id}")]
+    Disabled { project_id: i32 },
 }
 
 /// Service for managing vulnerability scans

--- a/web/src/api/client/types.gen.ts
+++ b/web/src/api/client/types.gen.ts
@@ -13921,6 +13921,11 @@ export type ProjectResponse = {
      */
     source_type: SourceType;
     updated_at: number;
+    /**
+     * Opt-in Trivy vulnerability scanning of this project's deployed Docker
+     * images. Off by default — project owners explicitly enable it.
+     */
+    vulnerability_scanning_enabled: boolean;
 };
 
 export type ProjectSecretEnvironmentInfo = {
@@ -20729,6 +20734,11 @@ export type UpdateProjectSettingsRequest = {
     repo_name?: string | null;
     repo_owner?: string | null;
     slug?: string | null;
+    /**
+     * Opt in to Trivy vulnerability scanning of this project's deployed Docker
+     * images (post-deployment scan + daily rescans). Off by default.
+     */
+    vulnerability_scanning_enabled?: boolean | null;
 };
 
 /**

--- a/web/src/components/project/settings/ProjectSecuritySettings.tsx
+++ b/web/src/components/project/settings/ProjectSecuritySettings.tsx
@@ -28,6 +28,7 @@ import {
 import { Separator } from '@/components/ui/separator'
 import { Switch } from '@/components/ui/switch'
 import { InfoIcon, MessageSquare, Shield } from 'lucide-react'
+import { useEffect, useRef } from 'react'
 import { useForm, Controller, useWatch } from 'react-hook-form'
 import { toast } from 'sonner'
 import { useMutation } from '@tanstack/react-query'
@@ -92,6 +93,7 @@ export function ProjectSecuritySettings({
     handleSubmit,
     setValue,
     watch,
+    reset,
     formState: { isDirty, isSubmitting },
   } = useForm<FormData>({
     defaultValues: {
@@ -138,6 +140,65 @@ export function ProjectSecuritySettings({
       },
     },
   })
+
+  // `defaultValues` are only read on mount, but this component stays mounted
+  // when the route switches between two projects' settings pages. Without
+  // this reset the form would still hold the previous project's toggles, and
+  // Save would apply the old project's attack mode / AI / vulnerability
+  // scanning choices to the newly-selected project.
+  //
+  // Keyed on the project *identity*, not its values: a plain refetch of the
+  // same project must not overwrite whatever the user is currently editing.
+  const syncedProjectId = useRef<number | undefined>(undefined)
+  useEffect(() => {
+    if (project?.id === undefined || syncedProjectId.current === project.id) {
+      return
+    }
+    syncedProjectId.current = project.id
+    reset({
+      attack_mode: project.attack_mode ?? false,
+      ai_debug_chat_enabled: project.ai_debug_chat_enabled ?? true,
+      ai_alert_summaries_enabled: project.ai_alert_summaries_enabled ?? false,
+      ai_api_traffic_summary_enabled:
+        project.ai_api_traffic_summary_enabled ?? false,
+      ai_write_actions_enabled: project.ai_write_actions_enabled ?? false,
+      vulnerability_scanning_enabled:
+        project.vulnerability_scanning_enabled ?? false,
+      security: {
+        enabled: project.deployment_config?.security?.enabled ?? undefined,
+        headers: {
+          preset:
+            project.deployment_config?.security?.headers?.preset ?? undefined,
+          contentSecurityPolicy:
+            project.deployment_config?.security?.headers
+              ?.contentSecurityPolicy ?? undefined,
+          xFrameOptions:
+            project.deployment_config?.security?.headers?.xFrameOptions ??
+            undefined,
+          strictTransportSecurity:
+            project.deployment_config?.security?.headers
+              ?.strictTransportSecurity ?? undefined,
+          referrerPolicy:
+            project.deployment_config?.security?.headers?.referrerPolicy ??
+            undefined,
+        },
+        rateLimiting: {
+          maxRequestsPerMinute:
+            project.deployment_config?.security?.rateLimiting
+              ?.maxRequestsPerMinute ?? undefined,
+          maxRequestsPerHour:
+            project.deployment_config?.security?.rateLimiting
+              ?.maxRequestsPerHour ?? undefined,
+          whitelistIps:
+            project.deployment_config?.security?.rateLimiting?.whitelistIps ??
+            [],
+          blacklistIps:
+            project.deployment_config?.security?.rateLimiting?.blacklistIps ??
+            [],
+        },
+      },
+    })
+  }, [project, reset])
 
   const securityConfig = useWatch({ control, name: 'security' })
 

--- a/web/src/components/project/settings/ProjectSecuritySettings.tsx
+++ b/web/src/components/project/settings/ProjectSecuritySettings.tsx
@@ -65,6 +65,7 @@ interface FormData {
   ai_alert_summaries_enabled?: boolean
   ai_api_traffic_summary_enabled?: boolean
   ai_write_actions_enabled?: boolean
+  vulnerability_scanning_enabled?: boolean
 }
 
 export function ProjectSecuritySettings({
@@ -100,6 +101,8 @@ export function ProjectSecuritySettings({
       ai_api_traffic_summary_enabled:
         project.ai_api_traffic_summary_enabled ?? false,
       ai_write_actions_enabled: project.ai_write_actions_enabled ?? false,
+      vulnerability_scanning_enabled:
+        project.vulnerability_scanning_enabled ?? false,
       security: {
         enabled: project.deployment_config?.security?.enabled ?? undefined,
         headers: {
@@ -149,6 +152,7 @@ export function ProjectSecuritySettings({
         ai_alert_summaries_enabled?: boolean
         ai_api_traffic_summary_enabled?: boolean
         ai_write_actions_enabled?: boolean
+        vulnerability_scanning_enabled?: boolean
       } = {}
       if (data.attack_mode !== project.attack_mode) {
         projectSettings.attack_mode = data.attack_mode
@@ -178,6 +182,13 @@ export function ProjectSecuritySettings({
         (project.ai_write_actions_enabled ?? false)
       ) {
         projectSettings.ai_write_actions_enabled = data.ai_write_actions_enabled
+      }
+      if (
+        (data.vulnerability_scanning_enabled ?? false) !==
+        (project.vulnerability_scanning_enabled ?? false)
+      ) {
+        projectSettings.vulnerability_scanning_enabled =
+          data.vulnerability_scanning_enabled
       }
 
       if (Object.keys(projectSettings).length > 0) {
@@ -440,6 +451,48 @@ export function ProjectSecuritySettings({
         <CardFooter>
           <Button type="submit" disabled={!isDirty || isSubmitting}>
             Save AI Settings
+          </Button>
+        </CardFooter>
+      </Card>
+
+      {/* Vulnerability Scanning Card */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Shield className="h-5 w-5" />
+            Vulnerability Scanning
+          </CardTitle>
+          <CardDescription>
+            Automatically scan deployed Docker images for known vulnerabilities
+            using Trivy, after every deployment and daily
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label htmlFor="vulnerability-scanning">
+                Enable vulnerability scanning
+              </Label>
+              <p className="text-sm text-muted-foreground">
+                Scan this project&apos;s deployed Docker images for known CVEs,
+                categorized by severity, after every deploy and once daily. Off
+                by default.
+              </p>
+            </div>
+            <Switch
+              id="vulnerability-scanning"
+              checked={watch('vulnerability_scanning_enabled') ?? false}
+              onCheckedChange={(checked) =>
+                setValue('vulnerability_scanning_enabled', checked, {
+                  shouldDirty: true,
+                })
+              }
+            />
+          </div>
+        </CardContent>
+        <CardFooter>
+          <Button type="submit" disabled={!isDirty || isSubmitting}>
+            Save Vulnerability Scanning Settings
           </Button>
         </CardFooter>
       </Card>

--- a/web/src/pages/security/SecurityOverview.tsx
+++ b/web/src/pages/security/SecurityOverview.tsx
@@ -15,11 +15,18 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Progress } from '@/components/ui/progress'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Shield, AlertTriangle, CheckCircle2, Play, Loader2, Clock } from 'lucide-react'
-import { useParams } from 'react-router'
+import { Link, useParams } from 'react-router'
 import { toast } from 'sonner'
-import { useEffect } from 'react'
+import { useEffect, type ReactNode } from 'react'
+import { getErrorMessage } from '@/utils/errorHandling'
 
 interface SecurityOverviewProps {
   project: ProjectResponse
@@ -160,12 +167,18 @@ export function SecurityOverview({ project }: SecurityOverviewProps) {
         }).queryKey,
       })
     },
-    onError: (error: any) => {
+    onError: (error) => {
       toast.error('Failed to start scan', {
-        description: error?.message || 'An error occurred while starting the vulnerability scan',
+        description: getErrorMessage(
+          error,
+          'An error occurred while starting the vulnerability scan'
+        ),
       })
     },
   })
+
+  const scanningEnabled = project.vulnerability_scanning_enabled ?? false
+  const settingsHref = `/projects/${slug}/settings/security`
 
   const isLoading = isLoadingEnvironments || isLoadingScans
 
@@ -203,6 +216,9 @@ export function SecurityOverview({ project }: SecurityOverviewProps) {
             Vulnerability scan results for each environment
           </p>
         </div>
+        {!scanningEnabled && (
+          <VulnerabilityScanningDisabledAlert settingsHref={settingsHref} />
+        )}
         <Card>
           <CardContent className="flex flex-col items-center justify-center py-12">
             <Shield className="h-12 w-12 text-muted-foreground mb-4" />
@@ -228,6 +244,10 @@ export function SecurityOverview({ project }: SecurityOverviewProps) {
           Vulnerability scan results for each environment
         </p>
       </div>
+
+      {!scanningEnabled && (
+        <VulnerabilityScanningDisabledAlert settingsHref={settingsHref} />
+      )}
 
       {/* Environment Tabs */}
       <Tabs defaultValue={environments[0]?.id.toString()} className="w-full">
@@ -269,7 +289,7 @@ export function SecurityOverview({ project }: SecurityOverviewProps) {
                       Vulnerability scans will appear here after your first deployment to{' '}
                       <span className="font-medium">{env.name}</span>
                     </p>
-                    <Button
+                    <TriggerScanButton
                       onClick={() => {
                         triggerScan.mutate({
                           path: { project_id: project.id },
@@ -277,19 +297,13 @@ export function SecurityOverview({ project }: SecurityOverviewProps) {
                         })
                       }}
                       disabled={triggerScan.isPending}
+                      isPending={isScanningThisEnv}
+                      scanningEnabled={scanningEnabled}
+                      settingsHref={settingsHref}
                     >
-                      {isScanningThisEnv ? (
-                        <>
-                          <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                          Starting Scan...
-                        </>
-                      ) : (
-                        <>
-                          <Play className="h-4 w-4 mr-2" />
-                          Create Scan
-                        </>
-                      )}
-                    </Button>
+                      <Play className="h-4 w-4 mr-2" />
+                      Create Scan
+                    </TriggerScanButton>
                   </CardContent>
                 </Card>
               ) : (
@@ -312,7 +326,7 @@ export function SecurityOverview({ project }: SecurityOverviewProps) {
                   )}
 
                   <div className="flex justify-end">
-                    <Button
+                    <TriggerScanButton
                       onClick={() => {
                         triggerScan.mutate({
                           path: { project_id: project.id },
@@ -320,20 +334,14 @@ export function SecurityOverview({ project }: SecurityOverviewProps) {
                         })
                       }}
                       disabled={triggerScan.isPending || isScanInProgress(scan)}
+                      isPending={isScanningThisEnv}
+                      scanningEnabled={scanningEnabled}
+                      settingsHref={settingsHref}
                       variant="outline"
                     >
-                      {isScanningThisEnv ? (
-                        <>
-                          <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                          Starting Scan...
-                        </>
-                      ) : (
-                        <>
-                          <Play className="h-4 w-4 mr-2" />
-                          Run New Scan
-                        </>
-                      )}
-                    </Button>
+                      <Play className="h-4 w-4 mr-2" />
+                      Run New Scan
+                    </TriggerScanButton>
                   </div>
 
                   {/* Only show scan card if scan is completed or failed */}
@@ -353,5 +361,104 @@ export function SecurityOverview({ project }: SecurityOverviewProps) {
         })}
       </Tabs>
     </div>
+  )
+}
+
+/**
+ * Onboarding state for the disabled feature. Per the discoverability rules:
+ * never render nothing — show what the feature would do, state precisely
+ * what's off, and deep-link to the exact settings toggle that turns it on.
+ */
+function VulnerabilityScanningDisabledAlert({
+  settingsHref,
+}: {
+  settingsHref: string
+}) {
+  return (
+    <Alert className="border-amber-500/20 bg-amber-500/10">
+      <Shield className="h-4 w-4 text-amber-600 dark:text-amber-400" />
+      <AlertDescription className="text-amber-700 dark:text-amber-400">
+        <div className="font-medium">
+          Vulnerability scanning is disabled for this project
+        </div>
+        <p className="text-sm text-muted-foreground mt-1">
+          Scan your deployed Docker images for known CVEs, categorized by
+          severity, after every deploy and daily.
+        </p>
+        <Link
+          to={settingsHref}
+          className="text-sm font-medium text-primary hover:underline mt-2 inline-block"
+        >
+          Enable vulnerability scanning in Settings &rarr;
+        </Link>
+      </AlertDescription>
+    </Alert>
+  )
+}
+
+interface TriggerScanButtonProps {
+  onClick: () => void
+  disabled: boolean
+  isPending: boolean
+  scanningEnabled: boolean
+  settingsHref: string
+  variant?: 'default' | 'outline'
+  children: ReactNode
+}
+
+/**
+ * "Trigger scan" button, gated by the project's opt-in toggle. When scanning
+ * is disabled the button stays disabled with a tooltip pointing at the exact
+ * settings toggle, rather than either disappearing or letting the click hang
+ * on a 409 the user has no way to explain.
+ */
+function TriggerScanButton({
+  onClick,
+  disabled,
+  isPending,
+  scanningEnabled,
+  settingsHref,
+  variant,
+  children,
+}: TriggerScanButtonProps) {
+  const button = (
+    <Button
+      onClick={onClick}
+      disabled={disabled || !scanningEnabled}
+      variant={variant}
+    >
+      {isPending ? (
+        <>
+          <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+          Starting Scan...
+        </>
+      ) : (
+        children
+      )}
+    </Button>
+  )
+
+  if (scanningEnabled) {
+    return button
+  }
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          {/* Wrap in a span: a disabled button doesn't fire hover/focus
+              events, which would otherwise make the tooltip unreachable. */}
+          <span tabIndex={0}>{button}</span>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>
+            Vulnerability scanning is disabled for this project.{' '}
+            <Link to={settingsHref} className="underline">
+              Enable it in Settings
+            </Link>
+          </p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   )
 }


### PR DESCRIPTION
## Summary
- Adds `projects.vulnerability_scanning_enabled` (default `false`) so each project owner explicitly opts in to Trivy-based vulnerability scanning, rather than every project being scanned automatically.
- Gates all three scan paths on the new flag: the post-deployment scan job, the daily rescan of all deployed environments, and the manual "trigger scan" API (which now returns `409 Conflict` with a clear message when the project hasn't opted in).
- Adds the toggle to project Security Settings, and updates the project's Security/Scans page to always render with an onboarding state (what scanning does + a deep link to enable it) instead of disappearing when the feature is off, per this repo's Feature Discoverability rules.
- Adds CLI parity: `--vulnerability-scanning`/`--no-vulnerability-scanning` on `temps projects settings`, surfaced in `temps projects show`.
- Regenerates both OpenAPI clients (`web/src/api/client`, `apps/temps-cli`) to pick up the new field.

## Why per-project (not a global switch)
Scanning is inherently about a specific project's deployed image and costs CPU/time per scan, requiring the `trivy` binary. This mirrors the existing per-project opt-in pattern already used for `error_source_context_enabled` / `ai_debug_chat_enabled`, letting each project owner decide independently rather than one platform-wide switch.

## Test plan
- [x] `cargo check --lib` clean workspace-wide
- [x] `cargo test --lib -p temps-projects` — 144 passed
- [x] `cargo test --lib -p temps-deployments` — 751 passed, 3 ignored
- [x] `cargo test --lib -p temps-vulnerability-scanner` — 6 passed
- [x] `web` and `apps/temps-cli` typecheck clean (`tsc --noEmit`)
- [x] Live end-to-end against a local server: created a project (defaults to `vulnerability_scanning_enabled: false`), confirmed `POST /projects/{id}/vulnerability-scans` returns 409 with the disabled-project detail message, confirmed `POST /projects/{id}/settings {"vulnerability_scanning_enabled": true}` flips it and the 409 gate clears