### PR TITLE
fix(ai-agent-cli): use constant-time comparison for MCP bridge token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10404,6 +10404,7 @@ dependencies = [
  "temps-agents",
  "temps-ai",
  "tokio",
+ "tower",
  "tracing",
  "uuid",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10399,6 +10399,7 @@ dependencies = [
  "futures",
  "serde",
  "serde_json",
+ "subtle",
  "tempfile",
  "temps-agents",
  "temps-ai",

--- a/crates/temps-ai-agent-cli/Cargo.toml
+++ b/crates/temps-ai-agent-cli/Cargo.toml
@@ -23,6 +23,7 @@ axum = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
+subtle = "2.6"
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/temps-ai-agent-cli/Cargo.toml
+++ b/crates/temps-ai-agent-cli/Cargo.toml
@@ -27,3 +27,4 @@ subtle = "2.6"
 
 [dev-dependencies]
 serde_json = { workspace = true }
+tower = { workspace = true }

--- a/crates/temps-ai-agent-cli/src/service.rs
+++ b/crates/temps-ai-agent-cli/src/service.rs
@@ -47,6 +47,13 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     a.ct_eq(b).into()
 }
 
+fn build_bridge_router(path: &str, state: McpBridgeState) -> axum::Router {
+    axum::Router::new()
+        .route(path, axum::routing::post(mcp_bridge_handler))
+        .layer(axum::extract::DefaultBodyLimit::max(MCP_BODY_LIMIT_BYTES))
+        .with_state(state)
+}
+
 async fn mcp_bridge_handler(
     axum::extract::State(state): axum::extract::State<McpBridgeState>,
     headers: axum::http::HeaderMap,
@@ -212,10 +219,7 @@ impl ScopedMcpBridge {
             tool_slot: Arc::new(Semaphore::new(1)),
             tool_timeout: MCP_TOOL_TIMEOUT,
         };
-        let router = axum::Router::new()
-            .route(&path, axum::routing::post(mcp_bridge_handler))
-            .layer(axum::extract::DefaultBodyLimit::max(MCP_BODY_LIMIT_BYTES))
-            .with_state(state);
+        let router = build_bridge_router(&path, state);
         let (shutdown, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
         let task = tokio::spawn(async move {
             let _ = axum::serve(listener, router)
@@ -1665,6 +1669,61 @@ mod tests {
             events.recv().await,
             Some(Ok(ChatStreamDelta::ToolResult { result, .. })) if result.contains("timed out")
         ));
+    }
+
+    // These two tests exercise the built router (rather than calling
+    // `mcp_bridge_handler` directly, as the tests above do) because
+    // `DefaultBodyLimit` is enforced by the extractor via a `tower::Layer`,
+    // which only runs when a request actually passes through the router.
+    #[tokio::test]
+    async fn mcp_bridge_router_rejects_request_over_body_limit() {
+        use tower::ServiceExt;
+        let (state, _events) = test_mcp_state();
+        let router = build_bridge_router("/mcp/test", state);
+        let oversized_body = vec![b'a'; MCP_BODY_LIMIT_BYTES + 1];
+        let request = axum::http::Request::builder()
+            .method("POST")
+            .uri("/mcp/test")
+            .header(axum::http::header::AUTHORIZATION, "Bearer one-turn-token")
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(axum::body::Body::from(oversized_body))
+            .expect("valid request");
+
+        let response = router.oneshot(request).await.expect("router responds");
+
+        assert_eq!(response.status(), axum::http::StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn mcp_bridge_router_accepts_realistic_sized_tool_call() {
+        use tower::ServiceExt;
+        let (state, _events) = test_mcp_state();
+        let router = build_bridge_router("/mcp/test", state);
+        // Real MCP tool-call payloads (JSON-RPC envelope plus tool name and
+        // arguments) run from a few hundred bytes to a handful of KB --
+        // nowhere near MCP_BODY_LIMIT_BYTES. A large arguments blob (e.g. a
+        // pasted file) can reach the low hundreds of KB, still well under
+        // the 1 MiB limit; this asserts the limit doesn't clip that range.
+        let body = serde_json::json!({
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "temps",
+                "arguments": {"command": "projects list", "padding": "x".repeat(200 * 1024)}
+            }
+        })
+        .to_string();
+        let request = axum::http::Request::builder()
+            .method("POST")
+            .uri("/mcp/test")
+            .header(axum::http::header::AUTHORIZATION, "Bearer one-turn-token")
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(axum::body::Body::from(body))
+            .expect("valid request");
+
+        let response = router.oneshot(request).await.expect("router responds");
+
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
     }
 
     #[tokio::test]

--- a/crates/temps-ai-agent-cli/src/service.rs
+++ b/crates/temps-ai-agent-cli/src/service.rs
@@ -34,6 +34,18 @@ struct McpBridgeState {
 const MCP_EVENT_CAPACITY: usize = 32;
 const MCP_TOOL_TIMEOUT: Duration = Duration::from_secs(30);
 const MCP_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
+const MCP_BODY_LIMIT_BYTES: usize = 1024 * 1024;
+
+/// Constant-time equality for the bridge's bearer token check.
+///
+/// Same primitive `temps-routes` uses for its route-sync token check
+/// (`subtle::ConstantTimeEq`), applied here as defense-in-depth: the bridge
+/// already binds to loopback on an ephemeral port behind a random per-instance
+/// path and token, but a length-preserving `==` still leaks a timing signal.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    use subtle::ConstantTimeEq;
+    a.ct_eq(b).into()
+}
 
 async fn mcp_bridge_handler(
     axum::extract::State(state): axum::extract::State<McpBridgeState>,
@@ -43,7 +55,12 @@ async fn mcp_bridge_handler(
     let authorized = headers
         .get(axum::http::header::AUTHORIZATION)
         .and_then(|value| value.to_str().ok())
-        .is_some_and(|value| value == format!("Bearer {}", state.token));
+        .is_some_and(|value| {
+            constant_time_eq(
+                value.as_bytes(),
+                format!("Bearer {}", state.token).as_bytes(),
+            )
+        });
     if !authorized {
         return (
             axum::http::StatusCode::UNAUTHORIZED,
@@ -197,6 +214,7 @@ impl ScopedMcpBridge {
         };
         let router = axum::Router::new()
             .route(&path, axum::routing::post(mcp_bridge_handler))
+            .layer(axum::extract::DefaultBodyLimit::max(MCP_BODY_LIMIT_BYTES))
             .with_state(state);
         let (shutdown, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
         let task = tokio::spawn(async move {


### PR DESCRIPTION
## Summary
- The scoped MCP bridge's bearer-token check used a plain `==` string comparison (CWE-208 timing side channel). Replaced it with `subtle::ConstantTimeEq`, the same primitive already used for the token check in `temps-routes`' route-sync handler.
- Added a 1 MiB body size limit to the bridge's router to bound memory from an oversized `tools/call` payload (found during a follow-up security review of the same handler).

## Context
The bridge already binds to loopback on an OS-assigned ephemeral port, behind a random per-instance path (`/mcp/{uuid}`) and a random per-instance bearer token, so this is defense-in-depth rather than a fix for a reachable exploit — exploiting the timing channel would require an attacker to already have local code execution on the host, at which point simpler attacks are available.

Reported responsibly by an external security researcher (credited in the commit trailer).

## Test plan
- [x] `cargo check --lib -p temps-ai-agent-cli`
- [x] `cargo test --lib -p temps-ai-agent-cli` (32/32 passing, including existing auth tests for the bridge handler)
- [x] `cargo clippy -p temps-ai-agent-cli --lib -- -D warnings`
- [x] Follow-up security review of the bridge + its CLI-adapter consumers (`temps-agents/src/ai_cli/{claude,codex,opencode}.rs`) found no further issues in scope of this fix