### PR TITLE
fix(backup): use a GUC-compatible recovery_target_time format for PITR

### DIFF
--- a/crates/temps-providers/src/externalsvc/postgres.rs
+++ b/crates/temps-providers/src/externalsvc/postgres.rs
@@ -2867,8 +2867,15 @@ fn postgres_recovery_target_setting(recovery_target: Option<&super::RecoveryTarg
     match recovery_target {
         None => "recovery_target = 'immediate'".to_string(),
         Some(super::RecoveryTarget::Time { time }) => format!(
+            // PostgreSQL's recovery_target_time GUC is parsed by a stricter
+            // datetime parser than SQL's ::timestamptz cast: it rejects the
+            // ISO 8601 'T' separator / 'Z' suffix (`invalid value for
+            // parameter "recovery_target_time"`), even though the same
+            // string casts fine in a query. Use the space-separated,
+            // explicit-offset form Postgres's own output uses, with
+            // microsecond precision preserved.
             "recovery_target_time = '{}'",
-            time.to_rfc3339_opts(chrono::SecondsFormat::AutoSi, true)
+            time.format("%Y-%m-%d %H:%M:%S%.6f%:z")
         ),
         Some(super::RecoveryTarget::Xid { xid }) => {
             format!("recovery_target_xid = '{}'", xid.replace('\'', ""))
@@ -6500,7 +6507,7 @@ mod tests {
             postgres_recovery_target_setting(Some(&crate::externalsvc::RecoveryTarget::Time {
                 time: target,
             })),
-            "recovery_target_time = '2026-09-02T17:11:48.133085Z'"
+            "recovery_target_time = '2026-09-02 17:11:48.133085+00:00'"
         );
     }
 
@@ -6514,23 +6521,57 @@ mod tests {
             postgres_recovery_target_setting(Some(&crate::externalsvc::RecoveryTarget::Time {
                 time: target,
             })),
-            "recovery_target_time = '2026-09-02T17:11:48Z'"
+            "recovery_target_time = '2026-09-02 17:11:48.000000+00:00'"
         );
     }
 
     #[test]
     fn recovery_target_setting_preserves_microsecond_boundaries() {
-        for timestamp in ["2026-09-02T17:11:48.000001Z", "2026-09-02T17:11:48.999999Z"] {
-            let target = chrono::DateTime::parse_from_rfc3339(timestamp)
+        for (input, expected) in [
+            (
+                "2026-09-02T17:11:48.000001Z",
+                "2026-09-02 17:11:48.000001+00:00",
+            ),
+            (
+                "2026-09-02T17:11:48.999999Z",
+                "2026-09-02 17:11:48.999999+00:00",
+            ),
+        ] {
+            let target = chrono::DateTime::parse_from_rfc3339(input)
                 .expect("test timestamp must parse")
                 .with_timezone(&chrono::Utc);
             assert_eq!(
                 postgres_recovery_target_setting(Some(&crate::externalsvc::RecoveryTarget::Time {
                     time: target
                 })),
-                format!("recovery_target_time = '{timestamp}'")
+                format!("recovery_target_time = '{expected}'")
             );
         }
+    }
+
+    #[test]
+    fn recovery_target_setting_never_emits_iso8601_t_or_z() {
+        // Regression test: PostgreSQL's recovery_target_time GUC rejects the
+        // ISO 8601 'T' date/time separator and 'Z' UTC suffix with
+        // `FATAL: configuration file "postgresql.auto.conf" contains errors`
+        // / `invalid value for parameter "recovery_target_time"`, even
+        // though the identical string parses fine via `::timestamptz` in
+        // SQL. Confirmed against a real postgres:18-bookworm container.
+        let target = chrono::DateTime::parse_from_rfc3339("2026-09-02T17:11:48.133085Z")
+            .expect("test timestamp must parse")
+            .with_timezone(&chrono::Utc);
+        let setting =
+            postgres_recovery_target_setting(Some(&crate::externalsvc::RecoveryTarget::Time {
+                time: target,
+            }));
+        assert!(
+            !setting.contains('T'),
+            "must not use ISO 8601 'T' separator: {setting}"
+        );
+        assert!(
+            !setting.contains('Z'),
+            "must not use ISO 8601 'Z' UTC suffix: {setting}"
+        );
     }
 
     // -----------------------------------------------------------------


### PR DESCRIPTION
## Description

Fixes the `Scenario E2E / Scenarios (recovery)` job, which has failed on every push to `main` since PR #889 merged (starting with run https://github.com/gotempsh/temps/actions/runs/33731074656, and reproduced most recently in https://github.com/gotempsh/temps/actions/runs/33752430396/job/100660298548).

PR #889 changed `postgres_recovery_target_setting`'s `Time` branch from:

```rust
time.format("%Y-%m-%d %H:%M:%S%:z")
```

to:

```rust
time.to_rfc3339_opts(chrono::SecondsFormat::AutoSi, true)
```

to preserve fractional-second precision in `recovery_target_time`, e.g. `2026-09-03T13:09:28.722Z`.

PostgreSQL's `recovery_target_time` GUC is parsed by a stricter datetime parser than SQL's `::timestamptz` cast: it rejects the ISO 8601 `T` date/time separator and `Z` UTC suffix outright, even though the identical string casts fine in a query. On startup this produces:

```
LOG:  invalid value for parameter "recovery_target_time": "2026-09-03T13:09:28.722Z"
FATAL:  configuration file "postgresql.auto.conf" contains errors
```

The restored container then crash-loops on the malformed config. Because the crash/restart cycle is fast, Temps's `wait_for_container_health` poll (which only fast-fails on an observed `EXITED`/`DEAD` state) rarely samples the container mid-restart, so the failure surfaces 90s later as a generic `PostgreSQL container health check timed out` rather than a clear config error.

## Fix

Keep the space-separated, explicit-offset shape PostgreSQL's own output uses (`YYYY-MM-DD HH:MM:SS.ffffff+HH:MM`), which both parses correctly as a GUC value and preserves microsecond precision — satisfying the original PR's stated goal without the parser incompatibility.

## Verification

Reproduced against a real `postgres:18-bookworm` container outside of CI:

- Base backup + WAL archiving to a local directory, then a restore with `recovery.signal` + `postgresql.auto.conf` setting `recovery_target_time` to the exact string this code produces.
- **Old code's format** (`2026-09-03 13:48:19+00:00`, whole seconds only): starts recovery successfully.
- **PR #889's format** (`2026-09-03T13:48:19.445741Z`): `FATAL: configuration file "postgresql.auto.conf" contains errors` — reproduces the bug outside the E2E harness.
- **This PR's format** (`2026-09-03 13:48:19.445741+00:00`): starts recovery successfully, same as the old code, with fractional-second precision retained.

```bash
cargo test --lib -p temps-providers recovery_target_setting
```
```text
cargo test: 4 passed, 601 filtered out (1 suite, 0.00s)
```

Also ran `cargo check --lib -p temps-providers` (0 errors) and the repo's pre-commit hooks (`cargo fmt`, `cargo clippy --all-targets`) locally — both pass.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test plan

- [x] Added `recovery_target_setting_never_emits_iso8601_t_or_z` regression test asserting the produced string contains neither `T` nor `Z`
- [x] Updated the three existing precision tests (`recovery_target_setting_preserves_fractional_seconds`, `recovery_target_setting_keeps_exact_whole_second_boundary`, `recovery_target_setting_preserves_microsecond_boundaries`) to expect the corrected format
- [x] `cargo test --lib -p temps-providers` passes
- [ ] CI: `Scenario E2E / Scenarios (recovery)` should go green on this branch