### PR TITLE
fix(console): unify navigation and responsive page chrome

### DIFF
--- a/web/src/components/backups/S3SourcesManagement.test.ts
+++ b/web/src/components/backups/S3SourcesManagement.test.ts
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+import { describe, expect, test } from 'bun:test'
+
+import { shouldShowS3SourceHeaderAction } from '@/lib/s3-source-presentation'
+
+describe('shouldShowS3SourceHeaderAction', () => {
+  test('avoids duplicating the create action in the empty state', () => {
+    expect(shouldShowS3SourceHeaderAction(false, 0)).toBe(false)
+    expect(shouldShowS3SourceHeaderAction(true, 0)).toBe(false)
+    expect(shouldShowS3SourceHeaderAction(false, 1)).toBe(true)
+  })
+})

--- a/web/src/components/backups/S3SourcesManagement.tsx
+++ b/web/src/components/backups/S3SourcesManagement.tsx
@@ -33,11 +33,9 @@ import {
 import { EmptyState } from '@/components/ui/empty-state'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import {
-  setDefaultS3Source,
-  testS3SourceConnection,
-} from '@/lib/s3-sources'
+import { setDefaultS3Source, testS3SourceConnection } from '@/lib/s3-sources'
 import { cn } from '@/lib/utils'
+import { shouldShowS3SourceHeaderAction } from '@/lib/s3-source-presentation'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import {
   CheckCircle2,
@@ -214,10 +212,11 @@ export function S3SourcesManagement() {
     (Partial<NewS3Source> & { id?: number }) | null
   >(null)
   const [pendingDefault, setPendingDefault] = useState<S3SourceResponse | null>(
-    null,
+    null
   )
-  const [sourceToDelete, setSourceToDelete] =
-    useState<S3SourceResponse | null>(null)
+  const [sourceToDelete, setSourceToDelete] = useState<S3SourceResponse | null>(
+    null
+  )
 
   const {
     data: sources = [],
@@ -343,16 +342,18 @@ export function S3SourcesManagement() {
     <div className="space-y-6">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h2 className="text-lg font-semibold">S3 Sources</h2>
+          <h2 className="text-lg font-semibold">S3 sources</h2>
           <p className="text-sm text-muted-foreground">
             Configure S3 storage for backups
           </p>
         </div>
-        <CreateActionButton
-          to="/backups/s3-sources/new"
-          label="Add S3 Source"
-          className="w-full sm:w-auto"
-        />
+        {shouldShowS3SourceHeaderAction(isLoading, sources.length) ? (
+          <CreateActionButton
+            to="/backups/s3-sources/new"
+            label="Add S3 Source"
+            className="w-full sm:w-auto"
+          />
+        ) : null}
       </div>
 
       <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
@@ -388,8 +389,8 @@ export function S3SourcesManagement() {
               <p className="text-muted-foreground">
                 Existing backup schedules keep their explicitly-configured
                 source. External services (like Postgres WAL archiving) that
-                track the default source will begin writing to the new
-                location on their next backup.
+                track the default source will begin writing to the new location
+                on their next backup.
               </p>
             </div>
           ) : null}
@@ -416,7 +417,10 @@ export function S3SourcesManagement() {
       {isLoading ? (
         <div className="divide-y rounded-lg border">
           {Array.from({ length: 3 }).map((_, i) => (
-            <div key={i} className="flex items-center gap-4 px-4 py-3 animate-pulse">
+            <div
+              key={i}
+              className="flex items-center gap-4 px-4 py-3 animate-pulse"
+            >
               <div className="size-9 shrink-0 rounded-md bg-muted" />
               <div className="flex-1 min-w-0 space-y-1.5">
                 <div className="h-4 w-48 bg-muted rounded" />
@@ -470,7 +474,10 @@ export function S3SourcesManagement() {
                           <p className="truncate text-sm font-medium">
                             {source.name}
                           </p>
-                          <Badge variant="secondary" className="font-mono text-xs">
+                          <Badge
+                            variant="secondary"
+                            className="font-mono text-xs"
+                          >
                             {source.bucket_name}
                           </Badge>
                           {isDefault && (
@@ -593,11 +600,10 @@ export function S3SourcesManagement() {
                   (<code>{sourceToDelete.bucket_name}</code>)
                 </>
               ) : null}{' '}
-              from Temps. Backup schedules pointing at this source will fail
-              on their next run, and services that rely on it for WAL
-              archiving will stop shipping new data until reconfigured. Objects
-              already in the bucket will not be deleted. This action cannot be
-              undone.
+              from Temps. Backup schedules pointing at this source will fail on
+              their next run, and services that rely on it for WAL archiving
+              will stop shipping new data until reconfigured. Objects already in
+              the bucket will not be deleted. This action cannot be undone.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/web/src/components/command/CommandPalette.test.tsx
+++ b/web/src/components/command/CommandPalette.test.tsx
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+import { describe, expect, test } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import { Command, CommandList } from '@/components/ui/command'
+import { CommandPaletteSuggestions } from './CommandPalette'
+
+describe('CommandPaletteSuggestions', () => {
+  test('renders natural-language prompts as compact command rows', () => {
+    const markup = renderToStaticMarkup(
+      <Command>
+        <CommandList>
+          <CommandPaletteSuggestions
+            queries={['Show me all projects', 'Open platform monitoring']}
+            onSelect={() => undefined}
+          />
+        </CommandList>
+      </Command>
+    )
+
+    expect(markup).toContain('Suggested searches')
+    expect(markup).toContain('Show me all projects')
+    expect(markup).toContain('gap-3 py-2.5')
+    expect(markup).not.toContain('uppercase')
+    expect(markup).not.toContain('min-h-20')
+  })
+})

--- a/web/src/components/command/CommandPalette.tsx
+++ b/web/src/components/command/CommandPalette.tsx
@@ -32,6 +32,10 @@ import {
   type CommandDestination,
 } from '@/lib/command-navigation'
 import {
+  buildAccessibleNavigationMap,
+  excludeNavigationUrls,
+  filterRestrictedNavigationItems,
+  isSettingsNavigationUrl,
   mergeNavigationItems,
   platformToolNavigationItems,
   settingsPageNavigationItems,
@@ -652,14 +656,21 @@ const observeNavItems: NavigationItem[] = [
   },
 ]
 
-const observeUrls = new Set(observeNavItems.map((item) => item.url))
-const indexedMainNavItems = mergeNavigationItems(
-  mainNavItems,
-  platformToolNavigationItems.filter((item) => !observeUrls.has(item.url))
-)
 const indexedSettingsNavItems = mergeNavigationItems(
-  settingsNavItems,
+  settingsNavItems.filter((item) => isSettingsNavigationUrl(item.url)),
   settingsPageNavigationItems
+)
+const secondaryNavigationUrls = new Set([
+  ...observeNavItems.map((item) => item.url),
+  ...indexedSettingsNavItems.map((item) => item.url),
+])
+const indexedMainNavItems = excludeNavigationUrls(
+  mergeNavigationItems(
+    mainNavItems,
+    settingsNavItems.filter((item) => !isSettingsNavigationUrl(item.url)),
+    platformToolNavigationItems
+  ),
+  secondaryNavigationUrls
 )
 
 const accountNavItems: NavigationItem[] = [
@@ -1210,23 +1221,26 @@ export function CommandPalette() {
   )
 
   const canViewAuditLogs = useCanViewAuditLogs()
+  const visibleObserveNavItems = useMemo(
+    () => filterRestrictedNavigationItems(observeNavItems, canViewAuditLogs),
+    [canViewAuditLogs]
+  )
 
   // Create Fuse instances for fuzzy search
   const navFuse = useMemo(() => {
     const allNavItems = [
-      ...indexedMainNavItems
-        .filter((item) => canViewAuditLogs || item.url !== '/audit-logs')
-        .map((item) => ({
-          ...item,
-          category: 'Navigation',
-        })),
+      ...indexedMainNavItems.map((item) => ({
+        ...item,
+        category: 'Navigation',
+      })),
       ...indexedSettingsNavItems.map((item) => ({
         ...item,
         category: 'Settings',
       })),
-      ...observeNavItems
-        .filter((item) => canViewAuditLogs || item.url !== '/audit-logs')
-        .map((item) => ({ ...item, category: 'Observe' })),
+      ...visibleObserveNavItems.map((item) => ({
+        ...item,
+        category: 'Observe',
+      })),
       ...accountNavItems.map((item) => ({ ...item, category: 'Account' })),
       ...pluginNavItems.map((item) => ({ ...item, category: 'Plugins' })),
     ]
@@ -1261,7 +1275,7 @@ export function CommandPalette() {
     currentProject,
     pluginNavItems,
     projectPluginNavItems,
-    canViewAuditLogs,
+    visibleObserveNavItems,
   ])
 
   const projectsFuse = useMemo(() => {
@@ -1353,13 +1367,9 @@ export function CommandPalette() {
         : []
 
     return {
-      navigation: indexedMainNavItems.filter(
-        (item) => canViewAuditLogs || item.url !== '/audit-logs'
-      ),
+      navigation: indexedMainNavItems,
       settings: indexedSettingsNavItems,
-      observe: observeNavItems.filter(
-        (item) => canViewAuditLogs || item.url !== '/audit-logs'
-      ),
+      observe: visibleObserveNavItems,
       account: accountNavItems,
       plugins: pluginNavItems,
       projectNav: projectNavigation,
@@ -1376,7 +1386,7 @@ export function CommandPalette() {
     projectPluginNavItems,
     currentProjectSlug,
     currentProject,
-    canViewAuditLogs,
+    visibleObserveNavItems,
   ])
 
   const commandDestinations = useMemo(() => {
@@ -1743,11 +1753,9 @@ export function CommandPalette() {
   const recentItems = useMemo<RecentEntry[]>(() => {
     if (search) return []
     const allNavItems: NavigationItem[] = [
-      ...indexedMainNavItems.filter(
-        (item) => canViewAuditLogs || item.url !== '/audit-logs'
-      ),
+      ...indexedMainNavItems,
       ...indexedSettingsNavItems,
-      ...observeNavItems,
+      ...visibleObserveNavItems,
       ...accountNavItems,
       ...pluginNavItems,
     ]
@@ -1758,10 +1766,10 @@ export function CommandPalette() {
             url: `/projects/${currentProjectSlug}/${item.url}`,
           }))
         : []
-    const navByUrl = new Map<string, NavigationItem>()
-    for (const nav of [...allNavItems, ...projectNavigation]) {
-      navByUrl.set(nav.url, nav)
-    }
+    const navByUrl = buildAccessibleNavigationMap(
+      [...allNavItems, ...projectNavigation],
+      canViewAuditLogs
+    )
     const projectsById = new Map(projects.map((p) => [String(p.id), p]))
     const skillsBySlug = new Map(globalSkills.map((s) => [s.slug, s]))
     const mcpBySlug = new Map(globalMcpServers.map((m) => [m.slug, m]))
@@ -1834,6 +1842,7 @@ export function CommandPalette() {
     globalSkills,
     globalMcpServers,
     canViewAuditLogs,
+    visibleObserveNavItems,
     navigate,
   ])
 

--- a/web/src/components/command/CommandPalette.tsx
+++ b/web/src/components/command/CommandPalette.tsx
@@ -31,6 +31,11 @@ import {
   toCommandExtendedQuery,
   type CommandDestination,
 } from '@/lib/command-navigation'
+import {
+  mergeNavigationItems,
+  platformToolNavigationItems,
+  settingsPageNavigationItems,
+} from '@/lib/command-navigation-catalog'
 import { resolvePluginIcon } from '@/lib/pluginIcons'
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
 import Fuse from 'fuse.js'
@@ -45,7 +50,6 @@ import {
   Boxes,
   Cloud,
   CreditCard,
-  CornerDownLeft,
   Database,
   DatabaseBackup,
   FileLock2,
@@ -95,6 +99,30 @@ interface NavigationItem {
   url: string
   icon: LucideIcon
   keywords?: string[]
+}
+
+export function CommandPaletteSuggestions({
+  queries,
+  onSelect,
+}: {
+  queries: string[]
+  onSelect: (query: string) => void
+}) {
+  return (
+    <CommandGroup heading="Suggested searches">
+      {queries.map((query) => (
+        <CommandItem
+          key={query}
+          value={`suggestion-${query}`}
+          onSelect={() => onSelect(query)}
+          className="gap-3 py-2.5"
+        >
+          <Search className="size-4 shrink-0 text-muted-foreground" />
+          <span className="min-w-0 truncate">{query}</span>
+        </CommandItem>
+      ))}
+    </CommandGroup>
+  )
 }
 
 interface CommandAction {
@@ -623,6 +651,16 @@ const observeNavItems: NavigationItem[] = [
     keywords: ['logs', 'audit', 'history', 'activity'],
   },
 ]
+
+const observeUrls = new Set(observeNavItems.map((item) => item.url))
+const indexedMainNavItems = mergeNavigationItems(
+  mainNavItems,
+  platformToolNavigationItems.filter((item) => !observeUrls.has(item.url))
+)
+const indexedSettingsNavItems = mergeNavigationItems(
+  settingsNavItems,
+  settingsPageNavigationItems
+)
 
 const accountNavItems: NavigationItem[] = [
   {
@@ -1176,8 +1214,16 @@ export function CommandPalette() {
   // Create Fuse instances for fuzzy search
   const navFuse = useMemo(() => {
     const allNavItems = [
-      ...mainNavItems.map((item) => ({ ...item, category: 'Navigation' })),
-      ...settingsNavItems.map((item) => ({ ...item, category: 'Settings' })),
+      ...indexedMainNavItems
+        .filter((item) => canViewAuditLogs || item.url !== '/audit-logs')
+        .map((item) => ({
+          ...item,
+          category: 'Navigation',
+        })),
+      ...indexedSettingsNavItems.map((item) => ({
+        ...item,
+        category: 'Settings',
+      })),
       ...observeNavItems
         .filter((item) => canViewAuditLogs || item.url !== '/audit-logs')
         .map((item) => ({ ...item, category: 'Observe' })),
@@ -1307,8 +1353,10 @@ export function CommandPalette() {
         : []
 
     return {
-      navigation: mainNavItems,
-      settings: settingsNavItems,
+      navigation: indexedMainNavItems.filter(
+        (item) => canViewAuditLogs || item.url !== '/audit-logs'
+      ),
+      settings: indexedSettingsNavItems,
       observe: observeNavItems.filter(
         (item) => canViewAuditLogs || item.url !== '/audit-logs'
       ),
@@ -1695,8 +1743,10 @@ export function CommandPalette() {
   const recentItems = useMemo<RecentEntry[]>(() => {
     if (search) return []
     const allNavItems: NavigationItem[] = [
-      ...mainNavItems,
-      ...settingsNavItems,
+      ...indexedMainNavItems.filter(
+        (item) => canViewAuditLogs || item.url !== '/audit-logs'
+      ),
+      ...indexedSettingsNavItems,
       ...observeNavItems,
       ...accountNavItems,
       ...pluginNavItems,
@@ -1783,6 +1833,7 @@ export function CommandPalette() {
     projects,
     globalSkills,
     globalMcpServers,
+    canViewAuditLogs,
     navigate,
   ])
 
@@ -1820,76 +1871,30 @@ export function CommandPalette() {
     <CommandDialog
       open={open}
       onOpenChange={handleOpenChange}
-      contentClassName="!inset-0 !left-0 !top-0 !h-dvh !max-h-dvh !w-screen !max-w-none !translate-x-0 !translate-y-0 gap-0 overflow-hidden !rounded-none !border-0 p-0 shadow-none sm:!inset-auto sm:!left-1/2 sm:!top-[12%] sm:!h-auto sm:!max-h-[calc(100dvh-1rem)] sm:!w-full sm:!max-w-3xl sm:!-translate-x-1/2 sm:!rounded-3xl sm:!border sm:border-white/40 sm:shadow-[0_32px_100px_rgba(16,20,30,0.28)]"
+      contentClassName="!bottom-auto !left-3 !right-3 !top-3 !h-auto !max-h-[calc(100dvh-1.5rem)] !w-auto !max-w-none !translate-x-0 !translate-y-0 gap-0 overflow-hidden rounded-xl p-0 shadow-lg dark:shadow-none sm:!inset-auto sm:!left-1/2 sm:!top-[18%] sm:!h-auto sm:!max-h-[min(70dvh,36rem)] sm:!w-full sm:!max-w-xl sm:!-translate-x-1/2"
     >
       <Command
-        className="rounded-none border-0 shadow-none"
+        className="rounded-xl border-0 shadow-none"
         loop
         shouldFilter={false}
         value={activeValue}
         onValueChange={setActiveValue}
       >
-        <div className="relative overflow-hidden border-b bg-muted/40 px-5 pb-4 pt-5 sm:px-6">
-          <div className="pointer-events-none absolute -right-16 -top-24 size-64 rounded-full bg-blue-500/10 blur-3xl" />
-          <div className="relative mb-4 flex items-center gap-3 pr-10">
-            <span className="grid size-9 shrink-0 place-items-center rounded-xl bg-foreground text-background">
-              <Search className="size-5" />
-            </span>
-            <div className="min-w-0">
-              <p className="truncate text-base font-semibold sm:text-lg">
-                Search this Temps instance
-              </p>
-              <p className="hidden text-xs text-muted-foreground sm:block">
-                Find projects, environments, services, settings, and tools
-              </p>
-            </div>
-            <span
-              className="ml-auto shrink-0 rounded-full border border-emerald-500/20 bg-emerald-500/10 px-3 py-1 font-mono text-[10px] font-semibold uppercase tracking-wider text-emerald-700 dark:text-emerald-300"
-              title="Instant local navigation is ready"
-            >
-              search · ready
-            </span>
-          </div>
-          <CommandInput
-            placeholder={'Try “production environment for project-slug”'}
-            value={search}
-            onValueChange={setSearch}
-            className="h-14 text-base font-medium"
-          />
-          <div className="mt-2 flex justify-end gap-2 pr-1 text-[10px] text-muted-foreground">
-            <kbd className="rounded-md border bg-background/70 px-2 py-1 font-mono">
-              <CornerDownLeft className="mr-1 inline size-3" /> open
-            </kbd>
-          </div>
-        </div>
-        <CommandList className="max-h-none min-h-0 flex-1 p-3 sm:max-h-[56vh] sm:min-h-80 sm:flex-none">
+        <CommandInput
+          aria-label="Search this Temps instance"
+          placeholder="Search projects, services, settings, and tools…"
+          value={search}
+          onValueChange={setSearch}
+          className="h-12 pr-10 text-base sm:text-sm"
+        />
+        <CommandList className="max-h-[calc(100dvh-7rem)] min-h-0 p-2 sm:max-h-[28rem] sm:min-h-72">
           {search && <CommandEmpty>No results found.</CommandEmpty>}
 
           {!search && (
-            <div className="p-2">
-              <p className="mb-3 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                Ask in your own words
-              </p>
-              <div className="grid gap-2 sm:grid-cols-2">
-                {sampleQueries.map((query) => (
-                  <button
-                    key={query}
-                    type="button"
-                    onClick={() => setSearch(query)}
-                    className="group flex min-h-20 items-start gap-3 rounded-xl border bg-muted/25 p-4 text-left transition-colors hover:border-ring/30 hover:bg-accent"
-                  >
-                    <Search className="mt-0.5 size-4 shrink-0 text-muted-foreground group-hover:text-foreground" />
-                    <span className="text-sm font-medium leading-relaxed">
-                      {query}
-                    </span>
-                  </button>
-                ))}
-              </div>
-              <div className="mt-4 flex items-center gap-3 rounded-xl bg-muted/50 px-4 py-3 text-xs text-muted-foreground">
-                <span className="size-2 shrink-0 rounded-full bg-emerald-500" />
-                Search is instant and matched locally against this instance.
-              </div>
-            </div>
+            <CommandPaletteSuggestions
+              queries={sampleQueries}
+              onSelect={setSearch}
+            />
           )}
 
           {/* Typing: one list, best match first, regardless of section. The
@@ -2192,11 +2197,14 @@ export function CommandPalette() {
               </CommandGroup>
             )}
         </CommandList>
-        <div className="flex items-center gap-2 border-t bg-muted/30 px-5 py-3 text-[10px] text-muted-foreground sm:text-xs">
-          <span className="size-1.5 rounded-full bg-emerald-500" />
-          <span>Local search</span>
-          <span className="hidden sm:inline">
-            {commandDestinations.length} destinations indexed
+        <div className="flex items-center justify-between gap-3 border-t px-3 py-2 text-xs text-muted-foreground">
+          <span className="truncate">
+            {commandDestinations.length} destinations
+          </span>
+          <span className="flex shrink-0 items-center gap-3">
+            <span>↑↓ navigate</span>
+            <span>↵ open</span>
+            <span className="hidden sm:inline">esc close</span>
           </span>
         </div>
       </Command>

--- a/web/src/components/dashboard/OnboardingNextStepCard.tsx
+++ b/web/src/components/dashboard/OnboardingNextStepCard.tsx
@@ -90,14 +90,14 @@ export function OnboardingNextStepCard() {
           </div>
         </div>
 
-        <div className="flex w-full shrink-0 items-center justify-end gap-2 pl-12 sm:w-auto sm:pl-0">
-          <Button asChild size="sm">
+        <div className="flex w-full shrink-0 flex-col items-stretch gap-2 sm:w-auto sm:flex-row sm:items-center sm:justify-end">
+          <Button asChild size="sm" className="w-full sm:w-auto">
             <Link to={selectedStep.href}>
-              {selectedStep.cta}
+              <span className="truncate">{selectedStep.cta}</span>
               <ArrowRight className="size-3.5" />
             </Link>
           </Button>
-          <div className="flex w-[7.5rem] shrink-0 items-center justify-end gap-2">
+          <div className="flex w-[7.5rem] shrink-0 self-end items-center justify-end gap-2">
             <Button
               variant="ghost"
               size="icon"

--- a/web/src/components/dashboard/Sidebar.tsx
+++ b/web/src/components/dashboard/Sidebar.tsx
@@ -20,14 +20,11 @@ import {
 import {
   Activity,
   ArrowLeft,
-  ArrowUpCircle,
   BadgeCheck,
   BarChart3,
-  Bell,
   Bot,
   Boxes,
   ChevronsUpDown,
-  Clock,
   Check,
   Database,
   DatabaseBackup,
@@ -36,31 +33,24 @@ import {
   GitBranch,
   GitFork,
   Globe,
-  HardDrive,
   Home,
-  Key,
   KeyRound,
   Layers,
   LogOut,
   Monitor,
   Moon,
   Network,
-  Puzzle,
   Search,
   ScrollText,
   MessageSquare,
   Server,
   Settings,
   Settings2,
-  Shield,
   ShieldAlert,
   Sun,
   Sparkles,
   Terminal,
-  Users,
-  UsersRound,
   Wand2,
-  Waypoints,
 } from 'lucide-react'
 
 import { ProjectResponse } from '@/api/client'
@@ -101,6 +91,7 @@ import {
 } from '../ui/dropdown-menu'
 import { useTheme } from 'next-themes'
 import { FeatureMaturityBadge } from '@/components/feature-maturity/FeatureMaturityBadge'
+import { settingsNavigationGroups } from '@/components/settings/settings-navigation'
 
 interface PlatformNavItem {
   title: string
@@ -155,95 +146,6 @@ const primaryPlatformGroups: PlatformNavGroup[] = [
         url: '/tools',
         icon: Boxes,
         activeWhen: isPlatformToolsRoute,
-      },
-    ],
-  },
-]
-
-// Full grouped settings tree — mirrors SettingsLayout
-interface SettingsGroupDef {
-  label: string
-  items: PlatformNavItem[]
-}
-// Settings drill-down contains instance configuration rather than runtime
-// tools, which live on the All platform tools page.
-const settingsGroups: SettingsGroupDef[] = [
-  {
-    label: 'General',
-    items: [
-      { title: 'Platform', url: '/settings', icon: Settings2 },
-      { title: 'Version', url: '/settings/version', icon: ArrowUpCircle },
-      { title: 'Notifications', url: '/settings/notifications', icon: Bell },
-    ],
-  },
-  {
-    label: 'Access',
-    items: [
-      { title: 'Users', url: '/settings/users', icon: Users },
-      {
-        title: 'Teams',
-        url: '/settings/teams',
-        icon: UsersRound,
-        featureKey: 'teams',
-      },
-      { title: 'Authentication', url: '/settings/auth', icon: KeyRound },
-      { title: 'API Keys', url: '/settings/keys', icon: Key },
-    ],
-  },
-  {
-    label: 'Infrastructure',
-    items: [
-      { title: 'Load Balancer', url: '/settings/load-balancer', icon: Server },
-      {
-        title: 'Docker Registry',
-        url: '/settings/docker-registry',
-        icon: Boxes,
-      },
-      { title: 'Build Limits', url: '/settings/build-limits', icon: Gauge },
-      {
-        title: 'Request Timeouts',
-        url: '/settings/request-timeouts',
-        icon: Clock,
-      },
-      {
-        title: 'Worker Nodes',
-        url: '/settings/nodes',
-        icon: Network,
-        featureKey: 'multi-node-worker-join',
-      },
-      {
-        title: 'Traefik Discovery',
-        url: '/settings/traefik-discovery',
-        icon: Waypoints,
-      },
-      {
-        title: 'Plugins',
-        url: '/settings/plugins',
-        icon: Puzzle,
-        featureKey: 'plugin-system',
-      },
-      { title: 'MCP Server', url: '/settings/mcp-server', icon: Bot },
-    ],
-  },
-  {
-    label: 'Security',
-    items: [
-      { title: 'Security Headers', url: '/settings/security', icon: Shield },
-      { title: 'Rate Limiting', url: '/settings/rate-limiting', icon: Monitor },
-      {
-        title: 'Disk Monitoring',
-        url: '/settings/disk-monitoring',
-        icon: HardDrive,
-      },
-      {
-        title: 'Metrics Monitoring',
-        url: '/settings/metrics-monitoring',
-        icon: BarChart3,
-      },
-      {
-        title: 'OTel Pipeline',
-        url: '/settings/otel-pipeline',
-        icon: Activity,
       },
     ],
   },
@@ -976,13 +878,13 @@ function SettingsNav({ onBack }: { onBack: () => void }) {
   // Every url across every settings group. Each section gets the list
   // minus its own items so active-state resolution sees the full tree
   // (prevents `/settings` lighting up on `/settings/keys`).
-  const allSettingsUrls = settingsGroups.flatMap((g) =>
+  const allSettingsUrls = settingsNavigationGroups.flatMap((g) =>
     g.items.map((i) => i.url)
   )
   return (
     <>
       <SwapHeader title="Settings" onBack={onBack} backLabel="Back to menu" />
-      {settingsGroups.map((group) => {
+      {settingsNavigationGroups.map((group) => {
         const ownUrls = new Set(group.items.map((i) => i.url))
         const siblings = allSettingsUrls.filter((u) => !ownUrls.has(u))
         return (

--- a/web/src/components/layout/PageContainer.test.tsx
+++ b/web/src/components/layout/PageContainer.test.tsx
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+import { describe, expect, test } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import { PageContainer, PageHeader } from './PageContainer'
+
+describe('PageContainer', () => {
+  test('owns responsive page gutters and renders one consistent page title', () => {
+    const markup = renderToStaticMarkup(
+      <PageContainer width="wide">
+        <PageHeader
+          title="Backups"
+          description="Manage backup storage"
+          actions={<button type="button">Add source</button>}
+        />
+      </PageContainer>
+    )
+
+    expect(markup).toContain('px-4 py-6 sm:px-6 lg:px-8')
+    expect(markup).toContain('max-w-7xl mx-auto')
+    expect(markup).toContain(
+      '<h1 class="text-2xl font-semibold tracking-tight">Backups</h1>'
+    )
+    expect(markup).toContain('sm:flex-row sm:items-start sm:justify-between')
+  })
+})

--- a/web/src/components/layout/PageContainer.tsx
+++ b/web/src/components/layout/PageContainer.tsx
@@ -47,3 +47,43 @@ export function PageContainer({
     </div>
   )
 }
+
+/**
+ * Standard heading block for top-level console pages.
+ *
+ * Actions stack below the title on narrow screens and align to the right once
+ * there is enough room. Keeping the visible page title here also guarantees a
+ * single h1 with consistent typography across platform sections.
+ */
+export function PageHeader({
+  title,
+  description,
+  actions,
+  className,
+}: {
+  title: ReactNode
+  description?: ReactNode
+  actions?: ReactNode
+  className?: string
+}) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between',
+        className
+      )}
+    >
+      <div className="min-w-0">
+        <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
+        {description ? (
+          <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+        ) : null}
+      </div>
+      {actions ? (
+        <div className="flex min-w-0 flex-wrap items-center gap-2 sm:justify-end">
+          {actions}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/web/src/components/monitoring/MonitoringSettings.tsx
+++ b/web/src/components/monitoring/MonitoringSettings.tsx
@@ -28,7 +28,7 @@ import { Switch } from '@/components/ui/switch'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useQuery } from '@tanstack/react-query'
-import { useForm } from 'react-hook-form'
+import { useForm, useWatch } from 'react-hook-form'
 import { useNavigate, useParams } from 'react-router'
 import { toast } from 'sonner'
 import {
@@ -52,6 +52,7 @@ import {
   MONITORING_SECTIONS,
   monitoringSectionLabel,
 } from './monitoring-sections'
+import { PageHeader } from '@/components/layout/PageContainer'
 
 interface AlertComponentProps<T> {
   onSave: (data: T) => Promise<void>
@@ -649,7 +650,10 @@ function WeeklyDigest({
     form.reset(data)
   }
 
-  const digestEnabled = form.watch('weeklyDigestEnabled')
+  const digestEnabled = useWatch({
+    control: form.control,
+    name: 'weeklyDigestEnabled',
+  })
 
   return (
     <Form {...form}>
@@ -1159,12 +1163,10 @@ export function MonitoringSettings() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h2 className="text-lg font-semibold">Monitoring & Alerts</h2>
-        <p className="text-sm text-muted-foreground">
-          Configure monitoring thresholds and alert notifications
-        </p>
-      </div>
+      <PageHeader
+        title="Monitoring & Alerts"
+        description="Configure monitoring thresholds and alert notifications"
+      />
 
       {/* Mobile Select */}
       <div className="sm:hidden">

--- a/web/src/components/project/ProjectTour.test.ts
+++ b/web/src/components/project/ProjectTour.test.ts
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+import { describe, expect, test } from 'bun:test'
+
+import { getProjectTourCardStyle } from '@/lib/project-tour'
+
+describe('getProjectTourCardStyle', () => {
+  test('uses viewport gutters and a bottom sheet on mobile', () => {
+    expect(
+      getProjectTourCardStyle({
+        isMobile: true,
+        anchor: null,
+        viewportWidth: 320,
+        viewportHeight: 568,
+      })
+    ).toEqual({ left: 16, right: 16, bottom: 16 })
+  })
+
+  test('never places the desktop coachmark outside a narrow viewport', () => {
+    const style = getProjectTourCardStyle({
+      isMobile: false,
+      anchor: { top: 800, right: 1_200 },
+      viewportWidth: 1_024,
+      viewportHeight: 768,
+    })
+
+    expect(style.left).toBe(692)
+    expect(style.top).toBe(576)
+  })
+})

--- a/web/src/components/project/ProjectTour.test.ts
+++ b/web/src/components/project/ProjectTour.test.ts
@@ -3,7 +3,11 @@
 
 import { describe, expect, test } from 'bun:test'
 
-import { getProjectTourCardStyle } from '@/lib/project-tour'
+import {
+  getProjectTourCardStyle,
+  getProjectTourNavigationTarget,
+  isProjectTourHomePage,
+} from '@/lib/project-tour'
 
 describe('getProjectTourCardStyle', () => {
   test('uses viewport gutters and a bottom sheet on mobile', () => {
@@ -27,5 +31,45 @@ describe('getProjectTourCardStyle', () => {
 
     expect(style.left).toBe(692)
     expect(style.top).toBe(576)
+  })
+})
+
+describe('project tour navigation guards', () => {
+  test('auto-starts only from the project home routes', () => {
+    expect(isProjectTourHomePage('example', '/projects/example')).toBe(true)
+    expect(isProjectTourHomePage('example', '/projects/example/project')).toBe(
+      true
+    )
+    expect(
+      isProjectTourHomePage('example', '/projects/example/deployments')
+    ).toBe(false)
+    expect(isProjectTourHomePage(undefined, '/projects/example')).toBe(false)
+  })
+
+  test('does not navigate repeatedly after a tour route redirects', () => {
+    const target = getProjectTourNavigationTarget({
+      active: true,
+      slug: 'example',
+      route: 'metrics',
+      lastTarget: null,
+    })
+
+    expect(target).toBe('/projects/example/metrics')
+    expect(
+      getProjectTourNavigationTarget({
+        active: true,
+        slug: 'example',
+        route: 'metrics',
+        lastTarget: target,
+      })
+    ).toBeNull()
+    expect(
+      getProjectTourNavigationTarget({
+        active: false,
+        slug: 'example',
+        route: 'metrics',
+        lastTarget: null,
+      })
+    ).toBeNull()
   })
 })

--- a/web/src/components/project/ProjectTour.tsx
+++ b/web/src/components/project/ProjectTour.tsx
@@ -4,16 +4,25 @@
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { Sparkles, X } from 'lucide-react'
-import {
-  type CSSProperties,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  useSyncExternalStore,
-} from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useNavigate, useParams } from 'react-router'
+import { useIsMobile } from '@/components/hooks/use-mobile'
+import {
+  getProjectTourCardStyle,
+  PROJECT_TOUR_EVENT,
+  setProjectTourActive,
+} from '@/lib/project-tour'
+
+// Keep the existing module API for consumers while the shared state lives in a
+// non-component module that remains safe for React Fast Refresh.
+/* eslint-disable react-refresh/only-export-components */
+export {
+  PROJECT_TOUR_EVENT,
+  isProjectTourActive,
+  useProjectTourActive,
+} from '@/lib/project-tour'
+/* eslint-enable react-refresh/only-export-components */
 
 /**
  * A lightweight, dependency-free guided tour for new projects. It walks the user
@@ -25,30 +34,6 @@ import { useNavigate, useParams } from 'react-router'
  */
 
 const SEEN_KEY = 'temps.project-tour.v1'
-export const PROJECT_TOUR_EVENT = 'temps:project-tour'
-
-// Shared active-state so pages the tour visits (analytics, errors) can skip
-// their own "no data yet, redirect to setup" logic while the tour is
-// showing them off — otherwise the tour lands on a page that immediately
-// navigates itself away to a /setup route the tour never asked for.
-let tourActive = false
-const tourActiveListeners = new Set<() => void>()
-function setTourActive(value: boolean) {
-  tourActive = value
-  for (const listener of tourActiveListeners) listener()
-}
-export function isProjectTourActive() {
-  return tourActive
-}
-export function useProjectTourActive() {
-  return useSyncExternalStore(
-    (listener) => {
-      tourActiveListeners.add(listener)
-      return () => tourActiveListeners.delete(listener)
-    },
-    () => tourActive
-  )
-}
 
 interface TourStep {
   route: string
@@ -96,12 +81,10 @@ const STEPS: TourStep[] = [
   },
 ]
 
-const CARD_WIDTH = 320 // matches w-80
-const CARD_EST_HEIGHT = 180
-
 export function ProjectTour() {
   const navigate = useNavigate()
   const { slug } = useParams<{ slug: string }>()
+  const isMobile = useIsMobile()
   const [active, setActive] = useState(false)
   const [idx, setIdx] = useState(0)
   const [rect, setRect] = useState<DOMRect | null>(null)
@@ -109,12 +92,12 @@ export function ProjectTour() {
   const start = useCallback(() => {
     setIdx(0)
     setActive(true)
-    setTourActive(true)
+    setProjectTourActive(true)
   }, [])
 
   const finish = useCallback(() => {
     setActive(false)
-    setTourActive(false)
+    setProjectTourActive(false)
     try {
       window.localStorage.setItem(SEEN_KEY, '1')
     } catch {
@@ -141,13 +124,14 @@ export function ProjectTour() {
     const onHomePage =
       !!slug &&
       (path === `/projects/${slug}` || path === `/projects/${slug}/project`)
-    const timer = seen || !onHomePage ? undefined : window.setTimeout(start, 800)
+    const timer =
+      seen || !onHomePage ? undefined : window.setTimeout(start, 800)
 
     return () => {
       window.removeEventListener(PROJECT_TOUR_EVENT, onStart)
       if (timer) window.clearTimeout(timer)
     }
-  }, [start])
+  }, [slug, start])
 
   // Navigate to each step's page as the tour advances, so the user sees it.
   //
@@ -204,19 +188,16 @@ export function ProjectTour() {
   const step = STEPS[idx]
   const isLast = idx === STEPS.length - 1
 
-  const cardStyle: CSSProperties = rect
-    ? {
-        top: Math.min(
-          Math.max(12, rect.top),
-          window.innerHeight - CARD_EST_HEIGHT - 12
-        ),
-        left: Math.min(rect.right + 12, window.innerWidth - CARD_WIDTH - 12),
-      }
-    : { top: 88, left: 24 }
+  const cardStyle = getProjectTourCardStyle({
+    isMobile,
+    anchor: rect,
+    viewportWidth: window.innerWidth,
+    viewportHeight: window.innerHeight,
+  })
 
   return createPortal(
     <>
-      {rect && (
+      {rect && !isMobile && (
         <div
           className="pointer-events-none fixed z-[95] rounded-md ring-2 ring-primary ring-offset-2 ring-offset-background transition-all"
           style={{
@@ -228,7 +209,8 @@ export function ProjectTour() {
         />
       )}
       <div
-        className="fixed z-[100] w-80 rounded-xl border bg-popover p-4 text-popover-foreground shadow-2xl"
+        data-testid="project-tour-card"
+        className="fixed z-[100] w-auto rounded-xl border bg-popover p-4 text-popover-foreground shadow-2xl md:w-80"
         style={cardStyle}
       >
         <div className="flex items-center justify-between">

--- a/web/src/components/project/ProjectTour.tsx
+++ b/web/src/components/project/ProjectTour.tsx
@@ -9,7 +9,9 @@ import { createPortal } from 'react-dom'
 import { useNavigate, useParams } from 'react-router'
 import { useIsMobile } from '@/components/hooks/use-mobile'
 import {
+  getProjectTourNavigationTarget,
   getProjectTourCardStyle,
+  isProjectTourHomePage,
   PROJECT_TOUR_EVENT,
   setProjectTourActive,
 } from '@/lib/project-tour'
@@ -120,10 +122,7 @@ export function ProjectTour() {
     // Only auto-start from the project's home page. A deep link straight into a
     // specific sub-page — a shared deployment URL, a bookmark, browser back —
     // must never be hijacked by the tour's own forced navigation to "project".
-    const path = window.location.pathname
-    const onHomePage =
-      !!slug &&
-      (path === `/projects/${slug}` || path === `/projects/${slug}/project`)
+    const onHomePage = isProjectTourHomePage(slug, window.location.pathname)
     const timer =
       seen || !onHomePage ? undefined : window.setTimeout(start, 800)
 
@@ -147,8 +146,13 @@ export function ProjectTour() {
       navigatedFor.current = null
       return
     }
-    const target = `/projects/${slug}/${STEPS[idx].route}`
-    if (navigatedFor.current === target) return
+    const target = getProjectTourNavigationTarget({
+      active,
+      slug,
+      route: STEPS[idx].route,
+      lastTarget: navigatedFor.current,
+    })
+    if (!target) return
     navigatedFor.current = target
     navigate(target)
   }, [active, idx, slug, navigate])

--- a/web/src/components/settings/SettingsLayout.tsx
+++ b/web/src/components/settings/SettingsLayout.tsx
@@ -2,15 +2,14 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 import { Outlet } from 'react-router'
+import { PageContainer } from '@/components/layout/PageContainer'
 
 // The settings nav lives in the main app sidebar (see Sidebar.tsx —
 // settings drill-down). This layout is a content-only wrapper.
 export function SettingsLayout() {
   return (
-    <div className="w-full px-4 sm:px-6 lg:px-8 py-6">
-      <div className="max-w-7xl mx-auto min-w-0">
-        <Outlet />
-      </div>
-    </div>
+    <PageContainer width="wide">
+      <Outlet />
+    </PageContainer>
   )
 }

--- a/web/src/components/settings/settings-navigation.ts
+++ b/web/src/components/settings/settings-navigation.ts
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+import {
+  Activity,
+  ArrowUpCircle,
+  BarChart3,
+  Bell,
+  Bot,
+  Boxes,
+  Clock,
+  Gauge,
+  HardDrive,
+  Key,
+  KeyRound,
+  Monitor,
+  Network,
+  Puzzle,
+  Server,
+  Settings2,
+  Shield,
+  Users,
+  UsersRound,
+  Waypoints,
+  type LucideIcon,
+} from 'lucide-react'
+
+export interface SettingsNavigationItem {
+  title: string
+  url: string
+  icon: LucideIcon
+  featureKey?: string
+}
+
+export interface SettingsNavigationGroup {
+  label: string
+  items: SettingsNavigationItem[]
+}
+
+/**
+ * Canonical instance-settings navigation.
+ *
+ * Both the Settings sidebar and Cmd+K consume this registry so a settings
+ * page cannot be visible in one surface and silently absent from the other.
+ */
+export const settingsNavigationGroups: SettingsNavigationGroup[] = [
+  {
+    label: 'General',
+    items: [
+      { title: 'Platform', url: '/settings', icon: Settings2 },
+      { title: 'Version', url: '/settings/version', icon: ArrowUpCircle },
+      { title: 'Notifications', url: '/settings/notifications', icon: Bell },
+    ],
+  },
+  {
+    label: 'Access',
+    items: [
+      { title: 'Users', url: '/settings/users', icon: Users },
+      {
+        title: 'Teams',
+        url: '/settings/teams',
+        icon: UsersRound,
+        featureKey: 'teams',
+      },
+      { title: 'Authentication', url: '/settings/auth', icon: KeyRound },
+      { title: 'API Keys', url: '/settings/keys', icon: Key },
+    ],
+  },
+  {
+    label: 'Infrastructure',
+    items: [
+      { title: 'Load Balancer', url: '/settings/load-balancer', icon: Server },
+      {
+        title: 'Docker Registry',
+        url: '/settings/docker-registry',
+        icon: Boxes,
+      },
+      { title: 'Build Limits', url: '/settings/build-limits', icon: Gauge },
+      {
+        title: 'Request Timeouts',
+        url: '/settings/request-timeouts',
+        icon: Clock,
+      },
+      {
+        title: 'Worker Nodes',
+        url: '/settings/nodes',
+        icon: Network,
+        featureKey: 'multi-node-worker-join',
+      },
+      {
+        title: 'Traefik Discovery',
+        url: '/settings/traefik-discovery',
+        icon: Waypoints,
+      },
+      {
+        title: 'Plugins',
+        url: '/settings/plugins',
+        icon: Puzzle,
+        featureKey: 'plugin-system',
+      },
+      { title: 'MCP Server', url: '/settings/mcp-server', icon: Bot },
+    ],
+  },
+  {
+    label: 'Security',
+    items: [
+      { title: 'Security Headers', url: '/settings/security', icon: Shield },
+      { title: 'Rate Limiting', url: '/settings/rate-limiting', icon: Monitor },
+      {
+        title: 'Disk Monitoring',
+        url: '/settings/disk-monitoring',
+        icon: HardDrive,
+      },
+      {
+        title: 'Metrics Monitoring',
+        url: '/settings/metrics-monitoring',
+        icon: BarChart3,
+      },
+      {
+        title: 'OTel Pipeline',
+        url: '/settings/otel-pipeline',
+        icon: Activity,
+      },
+    ],
+  },
+]

--- a/web/src/lib/command-navigation-catalog.test.ts
+++ b/web/src/lib/command-navigation-catalog.test.ts
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+import { describe, expect, test } from 'bun:test'
+import { platformToolGroups } from '@/components/platform/platform-tools'
+import { settingsNavigationGroups } from '@/components/settings/settings-navigation'
+import {
+  mergeNavigationItems,
+  platformToolNavigationItems,
+  settingsPageNavigationItems,
+} from './command-navigation-catalog'
+
+describe('command navigation catalog', () => {
+  test('indexes every platform tool from the page registry', () => {
+    const expectedUrls = platformToolGroups.flatMap((group) =>
+      group.items.map((item) => item.url)
+    )
+    const indexedUrls = new Set(
+      platformToolNavigationItems.map((item) => item.url)
+    )
+
+    expect(expectedUrls.every((url) => indexedUrls.has(url))).toBe(true)
+    expect(indexedUrls.has('/certificates')).toBe(true)
+  })
+
+  test('indexes every page rendered by the settings sidebar', () => {
+    const expectedUrls = settingsNavigationGroups.flatMap((group) =>
+      group.items.map((item) => item.url)
+    )
+    const indexedUrls = new Set(
+      settingsPageNavigationItems.map((item) => item.url)
+    )
+
+    expect(expectedUrls.every((url) => indexedUrls.has(url))).toBe(true)
+    for (const url of [
+      '/settings/version',
+      '/settings/request-timeouts',
+      '/settings/traefik-discovery',
+      '/settings/mcp-server',
+      '/settings/otel-pipeline',
+    ]) {
+      expect(indexedUrls.has(url)).toBe(true)
+    }
+  })
+
+  test('keeps one result per URL and combines search keywords', () => {
+    const [canonical] = settingsPageNavigationItems.filter(
+      (item) => item.url === '/settings'
+    )
+    const [result] = mergeNavigationItems(
+      [
+        {
+          ...canonical,
+          title: 'Platform Settings',
+          keywords: ['configuration'],
+        },
+      ],
+      [canonical]
+    )
+
+    expect(result.title).toBe('Platform Settings')
+    expect(result.keywords).toContain('configuration')
+    expect(result.keywords).toContain('settings')
+  })
+})

--- a/web/src/lib/command-navigation-catalog.test.ts
+++ b/web/src/lib/command-navigation-catalog.test.ts
@@ -5,6 +5,11 @@ import { describe, expect, test } from 'bun:test'
 import { platformToolGroups } from '@/components/platform/platform-tools'
 import { settingsNavigationGroups } from '@/components/settings/settings-navigation'
 import {
+  AUDIT_LOGS_URL,
+  buildAccessibleNavigationMap,
+  excludeNavigationUrls,
+  filterRestrictedNavigationItems,
+  isSettingsNavigationUrl,
   mergeNavigationItems,
   platformToolNavigationItems,
   settingsPageNavigationItems,
@@ -47,7 +52,7 @@ describe('command navigation catalog', () => {
     const [canonical] = settingsPageNavigationItems.filter(
       (item) => item.url === '/settings'
     )
-    const [result] = mergeNavigationItems(
+    const results = mergeNavigationItems(
       [
         {
           ...canonical,
@@ -57,9 +62,58 @@ describe('command navigation catalog', () => {
       ],
       [canonical]
     )
+    const [result] = results
 
+    expect(results).toHaveLength(1)
+    expect(new Set(results.map((item) => item.url)).size).toBe(results.length)
     expect(result.title).toBe('Platform Settings')
     expect(result.keywords).toContain('configuration')
     expect(result.keywords).toContain('settings')
+  })
+
+  test('keeps settings pages out of the main navigation category', () => {
+    const settingsUrls = new Set(
+      settingsPageNavigationItems.map((item) => item.url)
+    )
+    const mainItems = excludeNavigationUrls(
+      platformToolNavigationItems,
+      settingsUrls
+    )
+
+    expect(mainItems.some((item) => item.url === '/settings')).toBe(false)
+    expect(mainItems.some((item) => item.url === '/settings/mcp-server')).toBe(
+      false
+    )
+    expect(mainItems.some((item) => item.url === '/projects')).toBe(true)
+    expect(isSettingsNavigationUrl('/settings')).toBe(true)
+    expect(isSettingsNavigationUrl('/settings/mcp-server')).toBe(true)
+    expect(isSettingsNavigationUrl('/storage')).toBe(false)
+  })
+
+  test('removes restricted audit navigation for users without access', () => {
+    const items = [
+      { title: 'Proxy logs', url: '/proxy-logs' },
+      { title: 'Audit logs', url: AUDIT_LOGS_URL },
+    ]
+
+    expect(filterRestrictedNavigationItems(items, false)).toEqual([items[0]])
+    expect(filterRestrictedNavigationItems(items, true)).toEqual(items)
+  })
+
+  test('does not resolve a persisted audit-log recent for a restricted user', () => {
+    const recentUrls = [AUDIT_LOGS_URL]
+    const navigationByUrl = buildAccessibleNavigationMap(
+      [
+        { title: 'Proxy logs', url: '/proxy-logs' },
+        { title: 'Audit logs', url: AUDIT_LOGS_URL },
+      ],
+      false
+    )
+    const resolvedRecents = recentUrls.flatMap((url) => {
+      const item = navigationByUrl.get(url)
+      return item ? [item] : []
+    })
+
+    expect(resolvedRecents).toEqual([])
   })
 })

--- a/web/src/lib/command-navigation-catalog.ts
+++ b/web/src/lib/command-navigation-catalog.ts
@@ -12,6 +12,12 @@ export interface IndexedNavigationItem {
   keywords?: string[]
 }
 
+export const AUDIT_LOGS_URL = '/audit-logs'
+
+export function isSettingsNavigationUrl(url: string): boolean {
+  return url === '/settings' || url.startsWith('/settings/')
+}
+
 export const platformToolNavigationItems: IndexedNavigationItem[] =
   platformToolGroups.flatMap((group) =>
     group.items.map((item) => ({
@@ -60,4 +66,32 @@ export function mergeNavigationItems(
     })
   }
   return [...byUrl.values()]
+}
+
+export function excludeNavigationUrls<T extends { url: string }>(
+  items: readonly T[],
+  excludedUrls: ReadonlySet<string>
+): T[] {
+  return items.filter((item) => !excludedUrls.has(item.url))
+}
+
+export function filterRestrictedNavigationItems<T extends { url: string }>(
+  items: readonly T[],
+  canViewAuditLogs: boolean
+): T[] {
+  return canViewAuditLogs
+    ? [...items]
+    : items.filter((item) => item.url !== AUDIT_LOGS_URL)
+}
+
+export function buildAccessibleNavigationMap<T extends { url: string }>(
+  items: readonly T[],
+  canViewAuditLogs: boolean
+): Map<string, T> {
+  return new Map(
+    filterRestrictedNavigationItems(items, canViewAuditLogs).map((item) => [
+      item.url,
+      item,
+    ])
+  )
 }

--- a/web/src/lib/command-navigation-catalog.ts
+++ b/web/src/lib/command-navigation-catalog.ts
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+import { platformToolGroups } from '@/components/platform/platform-tools'
+import { settingsNavigationGroups } from '@/components/settings/settings-navigation'
+import type { LucideIcon } from 'lucide-react'
+
+export interface IndexedNavigationItem {
+  title: string
+  url: string
+  icon: LucideIcon
+  keywords?: string[]
+}
+
+export const platformToolNavigationItems: IndexedNavigationItem[] =
+  platformToolGroups.flatMap((group) =>
+    group.items.map((item) => ({
+      title: item.title,
+      url: item.url,
+      icon: item.icon,
+      keywords: [
+        group.label,
+        group.description,
+        item.description,
+        ...(item.keywords ?? []),
+      ],
+    }))
+  )
+
+export const settingsPageNavigationItems: IndexedNavigationItem[] =
+  settingsNavigationGroups.flatMap((group) =>
+    group.items.map((item) => ({
+      title: item.title,
+      url: item.url,
+      icon: item.icon,
+      keywords: ['settings', group.label, item.title],
+    }))
+  )
+
+/**
+ * Prefer purpose-written command labels while merging the canonical page
+ * registry behind them. New canonical pages are appended automatically and
+ * duplicate URLs retain keywords from both sources.
+ */
+export function mergeNavigationItems(
+  ...groups: IndexedNavigationItem[][]
+): IndexedNavigationItem[] {
+  const byUrl = new Map<string, IndexedNavigationItem>()
+  for (const item of groups.flat()) {
+    const existing = byUrl.get(item.url)
+    if (!existing) {
+      byUrl.set(item.url, item)
+      continue
+    }
+    byUrl.set(item.url, {
+      ...existing,
+      keywords: [
+        ...new Set([...(existing.keywords ?? []), ...(item.keywords ?? [])]),
+      ],
+    })
+  }
+  return [...byUrl.values()]
+}

--- a/web/src/lib/project-tour.ts
+++ b/web/src/lib/project-tour.ts
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+import { useSyncExternalStore, type CSSProperties } from 'react'
+
+export const PROJECT_TOUR_EVENT = 'temps:project-tour'
+
+let tourActive = false
+const tourActiveListeners = new Set<() => void>()
+
+export function setProjectTourActive(value: boolean) {
+  tourActive = value
+  for (const listener of tourActiveListeners) listener()
+}
+
+export function isProjectTourActive() {
+  return tourActive
+}
+
+export function useProjectTourActive() {
+  return useSyncExternalStore(
+    (listener) => {
+      tourActiveListeners.add(listener)
+      return () => tourActiveListeners.delete(listener)
+    },
+    () => tourActive
+  )
+}
+
+const CARD_WIDTH = 320
+const CARD_EST_HEIGHT = 180
+const CARD_GUTTER = 16
+
+interface TourAnchorPosition {
+  top: number
+  right: number
+}
+
+export function getProjectTourCardStyle({
+  isMobile,
+  anchor,
+  viewportWidth,
+  viewportHeight,
+}: {
+  isMobile: boolean
+  anchor: TourAnchorPosition | null
+  viewportWidth: number
+  viewportHeight: number
+}): CSSProperties {
+  if (isMobile) {
+    return {
+      right: CARD_GUTTER,
+      bottom: CARD_GUTTER,
+      left: CARD_GUTTER,
+    }
+  }
+
+  const maxLeft = Math.max(12, viewportWidth - CARD_WIDTH - 12)
+  const maxTop = Math.max(12, viewportHeight - CARD_EST_HEIGHT - 12)
+
+  return {
+    top: Math.min(Math.max(12, anchor?.top ?? 88), maxTop),
+    left: Math.min(Math.max(12, anchor ? anchor.right + 12 : 24), maxLeft),
+  }
+}

--- a/web/src/lib/project-tour.ts
+++ b/web/src/lib/project-tour.ts
@@ -27,6 +27,34 @@ export function useProjectTourActive() {
   )
 }
 
+export function isProjectTourHomePage(
+  slug: string | undefined,
+  pathname: string
+): boolean {
+  return (
+    !!slug &&
+    (pathname === `/projects/${slug}` ||
+      pathname === `/projects/${slug}/project`)
+  )
+}
+
+export function getProjectTourNavigationTarget({
+  active,
+  slug,
+  route,
+  lastTarget,
+}: {
+  active: boolean
+  slug: string | undefined
+  route: string
+  lastTarget: string | null
+}): string | null {
+  if (!active || !slug) return null
+
+  const target = `/projects/${slug}/${route}`
+  return target === lastTarget ? null : target
+}
+
 const CARD_WIDTH = 320
 const CARD_EST_HEIGHT = 180
 const CARD_GUTTER = 16

--- a/web/src/lib/s3-source-presentation.ts
+++ b/web/src/lib/s3-source-presentation.ts
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+export function shouldShowS3SourceHeaderAction(
+  isLoading: boolean,
+  sourceCount: number
+) {
+  return !isLoading && sourceCount > 0
+}

--- a/web/src/pages/Backups.tsx
+++ b/web/src/pages/Backups.tsx
@@ -5,6 +5,7 @@ import { S3SourcesManagement } from '@/components/backups/S3SourcesManagement'
 import { useBreadcrumbs } from '@/contexts/BreadcrumbContext'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { useEffect } from 'react'
+import { PageContainer, PageHeader } from '@/components/layout/PageContainer'
 
 export function Backups() {
   const { setBreadcrumbs } = useBreadcrumbs()
@@ -19,7 +20,13 @@ export function Backups() {
   // so operators see overdue schedules / stalled jobs from any page.
   return (
     <div className="flex-1 overflow-auto">
-      <S3SourcesManagement />
+      <PageContainer innerClassName="space-y-6">
+        <PageHeader
+          title="Backups"
+          description="Configure where backups and WAL archives are stored"
+        />
+        <S3SourcesManagement />
+      </PageContainer>
     </div>
   )
 }

--- a/web/src/pages/Monitoring.tsx
+++ b/web/src/pages/Monitoring.tsx
@@ -6,6 +6,7 @@ import { usePageTitle } from '@/hooks/usePageTitle'
 import { monitoringSectionLabel } from '@/components/monitoring/monitoring-sections'
 import { useEffect } from 'react'
 import { Outlet, useLocation } from 'react-router'
+import { PageContainer } from '@/components/layout/PageContainer'
 
 export function Monitoring() {
   const { setBreadcrumbs } = useBreadcrumbs()
@@ -24,9 +25,9 @@ export function Monitoring() {
 
   return (
     <div className="flex-1 overflow-auto">
-      <div className="space-y-6">
+      <PageContainer innerClassName="space-y-6">
         <Outlet />
-      </div>
+      </PageContainer>
     </div>
   )
 }

--- a/web/src/pages/PlatformTools.tsx
+++ b/web/src/pages/PlatformTools.tsx
@@ -15,6 +15,7 @@ import {
   type PlatformToolGroup,
 } from '@/components/platform/platform-tools'
 import { FeatureMaturityBadge } from '@/components/feature-maturity/FeatureMaturityBadge'
+import { PageContainer, PageHeader } from '@/components/layout/PageContainer'
 
 export function PlatformTools() {
   const [query, setQuery] = useState('')
@@ -65,28 +66,24 @@ export function PlatformTools() {
     .filter((group) => group.items.length > 0)
 
   return (
-    <div className="mx-auto w-full max-w-7xl space-y-8 pb-12">
-      <div className="flex flex-col gap-5 border-b pb-6 lg:flex-row lg:items-end lg:justify-between">
-        <div className="max-w-2xl">
-          <h1 className="text-2xl font-semibold tracking-tight">
-            All platform tools
-          </h1>
-          <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
-            Every Temps capability remains available here while the main sidebar
-            stays focused on daily work.
-          </p>
-        </div>
-        <div className="relative w-full lg:max-w-md">
-          <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder="Search domains, backups, email, proxy…"
-            className="h-11 pl-10"
-            aria-label="Search platform tools"
-          />
-        </div>
-      </div>
+    <PageContainer width="wide" innerClassName="space-y-8 pb-6">
+      <PageHeader
+        title="All platform tools"
+        description="Every Temps capability remains available here while the main sidebar stays focused on daily work."
+        className="border-b pb-6 lg:items-end"
+        actions={
+          <div className="relative w-full sm:w-96 lg:w-[28rem]">
+            <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search domains, backups, email, proxy…"
+              className="h-11 pl-10"
+              aria-label="Search platform tools"
+            />
+          </div>
+        }
+      />
 
       {!normalizedQuery && (
         <section aria-labelledby="common-platform-tasks">
@@ -184,6 +181,6 @@ export function PlatformTools() {
           and search across projects, services, settings, and tools.
         </p>
       </div>
-    </div>
+    </PageContainer>
   )
 }

--- a/web/src/pages/Projects.tsx
+++ b/web/src/pages/Projects.tsx
@@ -17,6 +17,7 @@ import { Button } from '@/components/ui/button'
 import { CreateActionButton } from '@/components/ui/create-action-button'
 import { Input } from '@/components/ui/input'
 import { ResponsivePagination } from '@/components/ui/responsive-pagination'
+import { PageContainer, PageHeader } from '@/components/layout/PageContainer'
 import {
   getProjectsOptions,
   listGitProvidersOptions,
@@ -170,7 +171,7 @@ export function Projects() {
     ))
 
   return (
-    <div className="p-4 sm:p-8 space-y-6">
+    <PageContainer innerClassName="space-y-6">
       {/* Header */}
       <ProjectsHeader
         actions={
@@ -242,7 +243,7 @@ export function Projects() {
             onPageSizeChange={(nextPageSize) => setPagination(1, nextPageSize)}
           />
         )}
-    </div>
+    </PageContainer>
   )
 }
 
@@ -314,17 +315,11 @@ function ProjectSearch({
  */
 function ProjectsHeader({ actions }: { actions: React.ReactNode }) {
   return (
-    <div className="flex flex-col gap-3 sm:flex-row sm:justify-between sm:items-center">
-      <div>
-        <h1 className="text-2xl font-semibold tracking-tight">Projects</h1>
-        <p className="text-sm text-muted-foreground">
-          Manage your projects and their settings
-        </p>
-      </div>
-      <div className="flex flex-1 flex-wrap justify-start gap-2 sm:justify-end">
-        {actions}
-      </div>
-    </div>
+    <PageHeader
+      title="Projects"
+      description="Manage your projects and their settings"
+      actions={actions}
+    />
   )
 }
 

--- a/web/src/pages/ProxyMetrics.tsx
+++ b/web/src/pages/ProxyMetrics.tsx
@@ -68,6 +68,7 @@ import {
 import { useQueries, useQuery } from '@tanstack/react-query'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type { DateRange } from 'react-day-picker'
+import { PageContainer, PageHeader } from '@/components/layout/PageContainer'
 import {
   CartesianGrid,
   Line,
@@ -424,7 +425,7 @@ function useResolvedWindow(
 ) {
   return useMemo(
     () => resolveProxyWindow(range, custom, new Date()),
-    [range, custom?.from?.getTime(), custom?.to?.getTime()]
+    [range, custom]
   )
 }
 
@@ -1295,49 +1296,45 @@ export default function ProxyMetrics() {
 
   usePageTitle('Proxy')
 
-  // Full-width like Monitoring.tsx — the app layout wrapper supplies the
-  // outer padding, so no container/max-w here.
   return (
     <div className="flex-1 overflow-auto">
-      <div className="space-y-6">
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h2 className="text-2xl font-bold tracking-tight">Proxy</h2>
-            <p className="text-muted-foreground">
-              Hot-path traffic and latency metrics for the control-plane proxy
-            </p>
-          </div>
-          <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
-            <FilterBar filter={filter} onChange={setFilter} />
-            <div className="flex items-center gap-1">
-              {PROXY_RANGE_PRESETS.map((opt) => (
+      <PageContainer innerClassName="space-y-6">
+        <PageHeader
+          title="Proxy"
+          description="Hot-path traffic and latency metrics for the control-plane proxy"
+          actions={
+            <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:flex-wrap sm:items-center">
+              <FilterBar filter={filter} onChange={setFilter} />
+              <div className="flex items-center gap-1">
+                {PROXY_RANGE_PRESETS.map((opt) => (
+                  <Button
+                    key={opt.value}
+                    variant={range === opt.value ? 'default' : 'outline'}
+                    size="sm"
+                    onClick={() => setRange(opt.value)}
+                  >
+                    {opt.label}
+                  </Button>
+                ))}
                 <Button
-                  key={opt.value}
-                  variant={range === opt.value ? 'default' : 'outline'}
+                  variant={range === 'custom' ? 'default' : 'outline'}
                   size="sm"
-                  onClick={() => setRange(opt.value)}
+                  onClick={() => setRange('custom')}
                 >
-                  {opt.label}
+                  Custom
                 </Button>
-              ))}
-              <Button
-                variant={range === 'custom' ? 'default' : 'outline'}
-                size="sm"
-                onClick={() => setRange('custom')}
-              >
-                Custom
-              </Button>
+              </div>
+              {range === 'custom' && (
+                <DateRangePicker
+                  date={customRange}
+                  onDateChange={setCustomRange}
+                  showTime
+                  className="w-full sm:w-[300px]"
+                />
+              )}
             </div>
-            {range === 'custom' && (
-              <DateRangePicker
-                date={customRange}
-                onDateChange={setCustomRange}
-                showTime
-                className="w-full sm:w-[300px]"
-              />
-            )}
-          </div>
-        </div>
+          }
+        />
 
         {tooWide ? (
           <p className="rounded-md border border-dashed px-4 py-8 text-center text-sm text-muted-foreground">
@@ -1393,7 +1390,7 @@ export default function ProxyMetrics() {
         )}
 
         {!tooWide && <TrafficByProject window={resolved} filter={filter} />}
-      </div>
+      </PageContainer>
     </div>
   )
 }

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -41,6 +41,7 @@ import {
 import { useEffect, useState } from 'react'
 import { useForm, useWatch } from 'react-hook-form'
 import { toast } from 'sonner'
+import { PageHeader } from '@/components/layout/PageContainer'
 
 type SettingsFormData = Pick<
   PlatformSettings,
@@ -175,6 +176,10 @@ export function Settings() {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+      <PageHeader
+        title="Settings"
+        description="Configure this Temps instance"
+      />
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
@@ -224,7 +229,9 @@ export function Settings() {
           </div>
 
           <div className="space-y-2 pt-4">
-            <Label htmlFor="console-force-https">Redirect console to HTTPS</Label>
+            <Label htmlFor="console-force-https">
+              Redirect console to HTTPS
+            </Label>
             <Select
               value={consoleForceHttpsValue}
               onValueChange={(value) =>
@@ -235,7 +242,10 @@ export function Settings() {
                 )
               }
             >
-              <SelectTrigger id="console-force-https" className="w-full sm:w-[280px]">
+              <SelectTrigger
+                id="console-force-https"
+                className="w-full sm:w-[280px]"
+              >
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -248,8 +258,8 @@ export function Settings() {
             </Select>
             <p className="text-sm text-muted-foreground">
               Applies to plain-HTTP requests for the host above.{' '}
-              <strong>Automatic</strong> redirects only once that hostname has
-              a certificate issued through Temps, so HTTP-only installs keep
+              <strong>Automatic</strong> redirects only once that hostname has a
+              certificate issued through Temps, so HTTP-only installs keep
               working. Choose <strong>Always</strong> only if Temps itself
               terminates TLS — if a CDN or reverse proxy in front of Temps does,
               it will loop, because Temps sees a plain-HTTP connection and

--- a/web/src/pages/Setup.tsx
+++ b/web/src/pages/Setup.tsx
@@ -32,6 +32,7 @@ import {
 } from '@/hooks/useGettingStarted'
 import { useActivationSignals } from '@/hooks/useActivationSignals'
 import { nextIncompleteGettingStartedItem } from '@/components/dashboard/onboarding-next-step'
+import { PageContainer, PageHeader } from '@/components/layout/PageContainer'
 
 // Per-step icon so the checklist reads visually, not just as text rows.
 const STEP_ICONS: Record<string, LucideIcon> = {
@@ -149,15 +150,11 @@ export function Setup() {
   }
 
   return (
-    <div className="p-4 sm:p-8 space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold tracking-tight">
-          Finish setting up
-        </h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          A few one-time steps to get your platform production-ready.
-        </p>
-      </div>
+    <PageContainer innerClassName="space-y-6">
+      <PageHeader
+        title="Finish setting up"
+        description="A few one-time steps to get your platform production-ready."
+      />
 
       {!isLoaded ? (
         <div className="space-y-6">
@@ -344,7 +341,7 @@ export function Setup() {
           </div>
         </>
       )}
-    </div>
+    </PageContainer>
   )
 }
 

--- a/web/src/pages/Storage.tsx
+++ b/web/src/pages/Storage.tsx
@@ -39,13 +39,15 @@ import { cn } from '@/lib/utils'
 import { useEffect, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router'
 import { TimeAgo } from '@/components/utils/TimeAgo'
+import { PageContainer, PageHeader } from '@/components/layout/PageContainer'
 
 export function Storage() {
   const { setBreadcrumbs } = useBreadcrumbs()
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
-  const [selectedService, setSelectedService] = useState<ExternalServiceInfo | null>(null)
+  const [selectedService, setSelectedService] =
+    useState<ExternalServiceInfo | null>(null)
   const [isCreateDropdownOpen, setIsCreateDropdownOpen] = useState(false)
 
   // Get active tab from URL or default to 'external'
@@ -121,11 +123,7 @@ export function Storage() {
           <p className="text-sm text-muted-foreground mb-4">
             Failed to load services
           </p>
-          <Button
-            variant="outline"
-            onClick={() => refetch()}
-            className="gap-2"
-          >
+          <Button variant="outline" onClick={() => refetch()} className="gap-2">
             <RefreshCcw className="h-4 w-4" />
             Try again
           </Button>
@@ -166,12 +164,17 @@ export function Storage() {
 
   return (
     <div className="flex-1 overflow-auto">
-      <div className="sm:p-4 space-y-6 md:p-6">
-        <div className="flex items-center justify-between">
-          <h1 className="text-xl font-semibold sm:text-2xl">Databases</h1>
-        </div>
+      <PageContainer innerClassName="space-y-6">
+        <PageHeader
+          title="Databases"
+          description="Manage platform and external data services"
+        />
 
-        <Tabs value={activeTab} onValueChange={handleTabChange} className="space-y-6">
+        <Tabs
+          value={activeTab}
+          onValueChange={handleTabChange}
+          className="space-y-6"
+        >
           <TabsList>
             <TabsTrigger value="platform" className="gap-2">
               <Database className="h-4 w-4" />
@@ -209,7 +212,7 @@ export function Storage() {
             }}
           />
         )}
-      </div>
+      </PageContainer>
     </div>
   )
 }
@@ -328,7 +331,7 @@ function ServicesCardGrid({
         // probing (status === 'running'). Others haven't been checked.
         const health =
           service.status === 'running'
-            ? healthMap?.get(service.id)?.status ?? null
+            ? (healthMap?.get(service.id)?.status ?? null)
             : null
         return (
           <ServiceCard
@@ -455,11 +458,7 @@ function ServiceMetricsCell({ serviceId }: { serviceId: number }) {
     staleTime: 50_000,
   })
 
-  if (
-    stats.isPending ||
-    stats.isError ||
-    !stats.data?.members?.length
-  ) {
+  if (stats.isPending || stats.isError || !stats.data?.members?.length) {
     return null
   }
 
@@ -469,12 +468,12 @@ function ServiceMetricsCell({ serviceId }: { serviceId: number }) {
   // "% of cap" numbers.
   const cpuPercentTotal = stats.data.members.reduce(
     (sum, m) => sum + (m.cpu_percent ?? 0),
-    0,
+    0
   )
 
   const memBytes = stats.data.members.reduce(
     (sum, m) => sum + (m.memory_usage_bytes ?? 0),
-    0,
+    0
   )
   const hasCpu = stats.data.members.some((m) => m.cpu_percent != null)
   const hasMem = stats.data.members.some((m) => m.memory_usage_bytes != null)
@@ -483,12 +482,10 @@ function ServiceMetricsCell({ serviceId }: { serviceId: number }) {
   // so it composes with formatBytes. CPU cap in cores (sum across members).
   const memLimitMib = runtime.data?.members.reduce(
     (sum, r) => sum + (r.resource_limits?.memory_mb ?? 0),
-    0,
+    0
   )
   const memLimitBytes =
-    memLimitMib != null && memLimitMib > 0
-      ? memLimitMib * 1024 * 1024
-      : null
+    memLimitMib != null && memLimitMib > 0 ? memLimitMib * 1024 * 1024 : null
   const cpuLimitCores = runtime.data?.members.reduce((sum, r) => {
     const nano = r.resource_limits?.nano_cpus ?? 0
     return sum + (nano > 0 ? nano / 1_000_000_000 : 0)


### PR DESCRIPTION
## Summary

- standardize top-level console pages on the shared responsive page header
- make the project tour and onboarding controls stay within narrow viewports
- simplify Cmd+K into native compact command rows and index every platform tool and settings page from canonical registries
- remove the duplicate S3 source action from the empty backup state
- clean up monitoring and proxy memo/form behavior encountered during verification

## Root cause

Page chrome and command destinations were maintained independently across routes. That produced inconsistent spacing, a visually disconnected command palette, and search drift when new Settings or All Platform Tools destinations were added.

Settings navigation now has one shared registry, while Cmd+K consumes both that registry and the canonical platform-tools registry. Purpose-written labels and keywords are merged by URL.

## Evidence

Frontend regression suite:

    bun test src
    488 pass
    0 fail
    854 expect() calls

Type and changed-file lint gates:

    bunx tsc --noEmit
    exit 0

    bunx eslint <25 changed TypeScript and TSX files>
    exit 0

Runtime Cmd+K walkthrough against the local Temps stack:

    python3 scripts/verify-command-catalog.py
    checked: 36
    passed: 36
    failures: []

The one-off browser harness was removed before commit. It authenticated from the local slot password file without printing or recording the credential, opened the visible Find control, searched each canonical label, selected the result, and asserted the expected non-404 route.

Responsive browser verification covered 320, 390, and 1440 px with no horizontal overflow and no browser console errors. An annotated HTML/video report is served privately inside the test tailnet and is intentionally not linked from this public PR.

Video delivery was verified as seekable:

    HTTP/1.0 206 Partial Content
    Accept-Ranges: bytes
    Content-Length: 1024

## Safety

- commit is signed off
- no environment files, credentials, tokens, password files, local databases, reports, screenshots, videos, or generated assets are included
- git diff check passes
- Audit Logs remains permission-gated in Cmd+K


### Review-finding fixes

Commit `ac304394e` addresses the follow-up review findings:

- permission-filtered Observe destinations are shared by search, browse, and persisted recents
- a second access check is applied when recent URLs are resolved
- settings routes are partitioned into Settings instead of being duplicated in Navigation
- catalog uniqueness and project-tour deep-link/redirect guards have regression coverage

Regression and repository gates:

    bun test src
    493 pass
    0 fail
    872 expect() calls

    bun run lint
    exit 0

    cargo check --lib
    0 errors

Exact browser reproduction:

1. Signed in as an administrator and opened Audit Logs through Cmd+K, persisting `/audit-logs` in browser frecency.
2. Logged out and signed into a non-admin account in the same browser.
3. The direct Audit Logs route redirected to Projects.
4. Opened the opt-in full Cmd+K catalog: Audit Logs was absent from Recent, search/browse destinations, and the full catalog.
5. Platform Settings and MCP Server each appeared once, under Settings.

Secret/artifact gate:

    git diff | gitleaks stdin --no-banner --redact=100
    no leaks found

All changed paths are TypeScript source/tests; no reports, credentials, screenshots, videos, binaries, or generated assets were committed.

