### PR TITLE
fix(backup): skip S3 lifecycle reconcile for unscheduled operator buckets

### DIFF
--- a/crates/temps-backup/src/engines/v2_common.rs
+++ b/crates/temps-backup/src/engines/v2_common.rs
@@ -925,6 +925,7 @@ mod tests {
             force_path_style: Some(true),
             is_default: true,
             managed_by_cloud: false,
+            lifecycle_reconcile_failed_at: None,
             created_at: now,
             updated_at: now,
         }

--- a/crates/temps-backup/src/engines/v2_common.rs
+++ b/crates/temps-backup/src/engines/v2_common.rs
@@ -926,6 +926,7 @@ mod tests {
             is_default: true,
             managed_by_cloud: false,
             lifecycle_reconcile_failed_at: None,
+            lifecycle_reconcile_generation: 0,
             created_at: now,
             updated_at: now,
         }

--- a/crates/temps-backup/src/plugin.rs
+++ b/crates/temps-backup/src/plugin.rs
@@ -413,14 +413,18 @@ impl TempsPlugin for BackupPlugin {
             // App-side `enforce_retention` is still the primary cleanup
             // path; this only handles drift on the storage provider side.
             //
-            // Deliberately excludes sources with no enabled schedule and
-            // `managed_by_cloud = false`: those are buckets the operator
-            // configured with their own credentials but never attached to
-            // a Temps backup schedule (e.g. an unrelated production
-            // bucket), so `reconcile_bucket` has never had anything to
-            // apply for them and a `PutBucketLifecycleConfiguration` /
-            // `DeleteBucketLifecycle` call against them is pure waste —
-            // paid API operations on infrastructure Temps doesn't manage.
+            // Deliberately excludes sources with no enabled schedule,
+            // `managed_by_cloud = false`, and no pending retry: those are
+            // buckets the operator configured with their own credentials
+            // but never attached to a Temps backup schedule (e.g. an
+            // unrelated production bucket), so `reconcile_bucket` has never
+            // had anything to apply for them and a
+            // `PutBucketLifecycleConfiguration` / `DeleteBucketLifecycle`
+            // call against them is pure waste — paid API operations on
+            // infrastructure Temps doesn't manage. A source with a failed
+            // reconcile attempt stays in scope regardless of schedule state
+            // (see `S3LifecycleService::sources_in_scope`) so this sweep is
+            // also the retry path for a transient failure at disable time.
             let lifecycle_db = db.clone();
             let lifecycle_enc = encryption_service.clone();
             tokio::spawn(async move {

--- a/crates/temps-backup/src/plugin.rs
+++ b/crates/temps-backup/src/plugin.rs
@@ -404,27 +404,34 @@ impl TempsPlugin for BackupPlugin {
                 }
             });
 
-            // S3 lifecycle drift reconciler. Walks every S3 source hourly
-            // and re-pushes lifecycle rules so manual edits in the AWS
-            // console (or missed event-driven reconciles) eventually
-            // converge to the desired state. App-side `enforce_retention`
-            // is still the primary cleanup path; this only handles drift
-            // on the storage provider side.
+            // S3 lifecycle drift reconciler. Walks S3 sources that are
+            // actually in scope for Temps-managed lifecycle rules — those
+            // with at least one enabled backup schedule, plus Cloud's own
+            // managed bucket — hourly, and re-pushes lifecycle rules so
+            // manual edits in the AWS console (or missed event-driven
+            // reconciles) eventually converge to the desired state.
+            // App-side `enforce_retention` is still the primary cleanup
+            // path; this only handles drift on the storage provider side.
+            //
+            // Deliberately excludes sources with no enabled schedule and
+            // `managed_by_cloud = false`: those are buckets the operator
+            // configured with their own credentials but never attached to
+            // a Temps backup schedule (e.g. an unrelated production
+            // bucket), so `reconcile_bucket` has never had anything to
+            // apply for them and a `PutBucketLifecycleConfiguration` /
+            // `DeleteBucketLifecycle` call against them is pure waste —
+            // paid API operations on infrastructure Temps doesn't manage.
             let lifecycle_db = db.clone();
             let lifecycle_enc = encryption_service.clone();
             tokio::spawn(async move {
-                use sea_orm::EntityTrait;
                 // First tick is one interval out — give the rest of the
                 // server time to settle before hammering S3.
                 let mut tick = tokio::time::interval(std::time::Duration::from_secs(3600));
                 tick.tick().await;
-                let svc = S3LifecycleService::new(lifecycle_db.clone(), lifecycle_enc);
+                let svc = S3LifecycleService::new(lifecycle_db, lifecycle_enc);
                 loop {
                     tick.tick().await;
-                    let sources = match temps_entities::s3_sources::Entity::find()
-                        .all(lifecycle_db.as_ref())
-                        .await
-                    {
+                    let sources = match svc.sources_in_scope().await {
                         Ok(s) => s,
                         Err(e) => {
                             error!(

--- a/crates/temps-backup/src/services/backup.rs
+++ b/crates/temps-backup/src/services/backup.rs
@@ -9281,11 +9281,17 @@ ORDER BY a.opened_at DESC
                 detail: "Backup schedule not found".to_string(),
             })?;
 
+        let s3_source_id = schedule_model.s3_source_id;
         let mut schedule_update: temps_entities::backup_schedules::ActiveModel =
             schedule_model.into_active_model();
         schedule_update.enabled = sea_orm::Set(false);
         schedule_update.updated_at = sea_orm::Set(Utc::now());
         schedule_update.update(self.db.as_ref()).await?;
+
+        // Disabling may have been this source's last enabled schedule —
+        // reconcile now so a stale S3-side lifecycle rule doesn't keep
+        // expiring objects after the schedule stops running.
+        self.fire_lifecycle_reconcile(s3_source_id);
 
         self.get_backup_schedule(id).await
     }
@@ -9350,6 +9356,12 @@ ORDER BY a.opened_at DESC
         schedule_update.next_run = sea_orm::Set(next_run);
 
         let updated_schedule = schedule_update.update(self.db.as_ref()).await?;
+
+        // Re-enabling puts this source back in scope for lifecycle
+        // reconciliation — push the rule immediately rather than waiting
+        // for the hourly sweep to notice.
+        self.fire_lifecycle_reconcile(updated_schedule.s3_source_id);
+
         Ok(updated_schedule)
     }
 }
@@ -11185,6 +11197,230 @@ mod tests {
         println!("  - Decompressed size: {} bytes", decompressed.len());
         println!("  - Backup format: valid gzip-compressed pg_dump custom format (PGDMP)");
         println!("  - Objects in bucket before deletion: {}", object_count);
+    }
+
+    /// Regression: `disable_backup_schedule` and `enable_backup_schedule`
+    /// must trigger the same S3 lifecycle reconcile that
+    /// `create_backup_schedule`/`update_backup_schedule`/
+    /// `delete_backup_schedule` already do. Without it, disabling a
+    /// source's last enabled schedule leaves a stale
+    /// `PutBucketLifecycleConfiguration` rule on the bucket that keeps
+    /// expiring objects indefinitely — and, after the hourly sweep was
+    /// scoped down to only actively-scheduled sources, there is no other
+    /// path that would ever clear it.
+    #[tokio::test]
+    async fn disable_and_enable_schedule_reconcile_s3_lifecycle_rules() {
+        let docker = match bollard::Docker::connect_with_local_defaults() {
+            Ok(docker) => docker,
+            Err(error) => {
+                println!("Docker not available, skipping test: {}", error);
+                return;
+            }
+        };
+        if let Err(error) = docker.ping().await {
+            println!("Docker daemon not reachable, skipping test: {}", error);
+            return;
+        }
+
+        use temps_database::test_utils::TestDatabase;
+        use testcontainers::{runners::AsyncRunner, GenericImage, ImageExt};
+
+        let minio_container = GenericImage::new("minio/minio", "latest")
+            .with_env_var("MINIO_ROOT_USER", "minioadmin")
+            .with_env_var("MINIO_ROOT_PASSWORD", "minioadmin")
+            .with_cmd(vec!["server", "/data", "--console-address", ":9001"])
+            .start()
+            .await
+            .expect("Failed to start MinIO container");
+        let minio_port = minio_container
+            .get_host_port_ipv4(9000)
+            .await
+            .expect("Failed to get MinIO port");
+        let minio_endpoint = format!("http://localhost:{}", minio_port);
+        tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+
+        let test_db = TestDatabase::with_migrations()
+            .await
+            .expect("Failed to create test database");
+
+        let s3_config = aws_sdk_s3::config::Builder::new()
+            .behavior_version(aws_sdk_s3::config::BehaviorVersion::latest())
+            .region(aws_sdk_s3::config::Region::new("us-east-1"))
+            .credentials_provider(aws_sdk_s3::config::Credentials::new(
+                "minioadmin",
+                "minioadmin",
+                None,
+                None,
+                "test",
+            ))
+            .endpoint_url(&minio_endpoint)
+            .force_path_style(true)
+            .http_client(crate::engines::v2_common::bundled_roots_http_client())
+            .build();
+        let s3_client = aws_sdk_s3::Client::from_conf(s3_config);
+
+        let bucket_name = "test-lifecycle-toggle";
+        s3_client
+            .create_bucket()
+            .bucket(bucket_name)
+            .send()
+            .await
+            .expect("Failed to create bucket");
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
+        let external_service_manager = create_mock_external_service_manager(test_db.db.clone());
+        let alarm_service = create_mock_alarm_service();
+        let server_config = temps_config::ServerConfig::new(
+            "127.0.0.1:3000".to_string(),
+            test_db.database_url.clone(),
+            None,
+            None,
+        )
+        .unwrap();
+        let config_service = Arc::new(temps_config::ConfigService::new(
+            Arc::new(server_config),
+            test_db.db.clone(),
+        ));
+        let encryption_service =
+            Arc::new(EncryptionService::new("test_encryption_key_1234567890ab").unwrap());
+        let backup_service = BackupService::new(
+            test_db.db.clone(),
+            external_service_manager,
+            alarm_service,
+            config_service,
+            encryption_service,
+        );
+
+        let s3_source = backup_service
+            .create_s3_source(CreateS3SourceRequest {
+                name: "test-minio-toggle".to_string(),
+                bucket_name: bucket_name.to_string(),
+                bucket_path: "/backups".to_string(),
+                access_key_id: "minioadmin".to_string(),
+                secret_key: "minioadmin".to_string(),
+                region: "us-east-1".to_string(),
+                endpoint: Some(minio_endpoint.clone()),
+                force_path_style: Some(true),
+                is_default: None,
+            })
+            .await
+            .expect("Failed to create S3 source");
+
+        let schedule = backup_service
+            .create_backup_schedule(CreateBackupScheduleRequest {
+                name: "toggle-schedule".to_string(),
+                backup_type: "full".to_string(),
+                retention_period: 7,
+                s3_source_id: Some(s3_source.id),
+                schedule_expression: "0 0 2 * * *".to_string(),
+                enabled: true,
+                description: None,
+                tags: vec![],
+                max_runtime_secs: None,
+                target_all_services: None,
+                include_control_plane: None,
+            })
+            .await
+            .expect("Failed to create backup schedule");
+
+        // Poll until the schedule creation's own reconcile has pushed the
+        // retention-7d rule (proves the create-path reconcile ran, so the
+        // baseline before disabling is "rule present").
+        let rules_after_create = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            poll_lifecycle_rule_count(&s3_client, bucket_name),
+        )
+        .await
+        .expect("lifecycle rule must appear after schedule creation");
+        assert_eq!(
+            rules_after_create, 1,
+            "expected exactly one rule (temps-retention-7d) after create"
+        );
+
+        backup_service
+            .disable_backup_schedule(schedule.id)
+            .await
+            .expect("Failed to disable backup schedule");
+
+        // The disable must clear the now-orphaned rule, not leave it
+        // dangling on the bucket.
+        let rules_after_disable = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            poll_lifecycle_rule_count_becomes(&s3_client, bucket_name, 0),
+        )
+        .await
+        .expect("lifecycle rule must be cleared after disabling the schedule");
+        assert_eq!(
+            rules_after_disable, 0,
+            "disabling the sole schedule must clear the S3 lifecycle rule"
+        );
+
+        backup_service
+            .enable_backup_schedule(schedule.id)
+            .await
+            .expect("Failed to enable backup schedule");
+
+        // Re-enabling must push the rule back.
+        let rules_after_enable = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            poll_lifecycle_rule_count_becomes(&s3_client, bucket_name, 1),
+        )
+        .await
+        .expect("lifecycle rule must reappear after re-enabling the schedule");
+        assert_eq!(
+            rules_after_enable, 1,
+            "re-enabling the schedule must restore the S3 lifecycle rule"
+        );
+    }
+
+    /// Number of lifecycle rules currently on the bucket, treating "no
+    /// lifecycle configuration at all" (`NoSuchLifecycleConfiguration`) as
+    /// zero rather than an error — that's the expected state before the
+    /// first reconcile, and after a reconcile clears the last rule.
+    async fn current_lifecycle_rule_count(client: &aws_sdk_s3::Client, bucket: &str) -> usize {
+        match client
+            .get_bucket_lifecycle_configuration()
+            .bucket(bucket)
+            .send()
+            .await
+        {
+            Ok(resp) => resp.rules().len(),
+            Err(err) => {
+                let msg = format!("{err:?}");
+                if msg.contains("NoSuchLifecycleConfiguration") {
+                    0
+                } else {
+                    panic!("unexpected error reading bucket lifecycle config: {msg}");
+                }
+            }
+        }
+    }
+
+    /// Polls until the bucket has at least one lifecycle rule, returning
+    /// the count once non-zero.
+    async fn poll_lifecycle_rule_count(client: &aws_sdk_s3::Client, bucket: &str) -> usize {
+        loop {
+            let count = current_lifecycle_rule_count(client, bucket).await;
+            if count > 0 {
+                return count;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    }
+
+    /// Polls until the bucket's lifecycle rule count equals `expected`.
+    async fn poll_lifecycle_rule_count_becomes(
+        client: &aws_sdk_s3::Client,
+        bucket: &str,
+        expected: usize,
+    ) -> usize {
+        loop {
+            let count = current_lifecycle_rule_count(client, bucket).await;
+            if count == expected {
+                return count;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
     }
 
     #[tokio::test]

--- a/crates/temps-backup/src/services/backup.rs
+++ b/crates/temps-backup/src/services/backup.rs
@@ -10003,6 +10003,7 @@ mod tests {
             is_default: false,
             managed_by_cloud: false,
             lifecycle_reconcile_failed_at: None,
+            lifecycle_reconcile_generation: 0,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -10070,6 +10071,7 @@ mod tests {
             is_default: false,
             managed_by_cloud: false,
             lifecycle_reconcile_failed_at: None,
+            lifecycle_reconcile_generation: 0,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -10124,6 +10126,7 @@ mod tests {
             is_default: false,
             managed_by_cloud: true,
             lifecycle_reconcile_failed_at: None,
+            lifecycle_reconcile_generation: 0,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -10171,6 +10174,7 @@ mod tests {
             is_default: false,
             managed_by_cloud: true,
             lifecycle_reconcile_failed_at: None,
+            lifecycle_reconcile_generation: 0,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -10313,6 +10317,7 @@ mod tests {
             is_default: false,
             managed_by_cloud: false,
             lifecycle_reconcile_failed_at: None,
+            lifecycle_reconcile_generation: 0,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -10583,6 +10588,7 @@ mod tests {
             is_default: false,
             managed_by_cloud: false,
             lifecycle_reconcile_failed_at: None,
+            lifecycle_reconcile_generation: 0,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -10716,6 +10722,7 @@ mod tests {
             is_default: false,
             managed_by_cloud: false,
             lifecycle_reconcile_failed_at: None,
+            lifecycle_reconcile_generation: 0,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -12008,6 +12015,7 @@ mod tests {
             is_default: false,
             managed_by_cloud: false,
             lifecycle_reconcile_failed_at: None,
+            lifecycle_reconcile_generation: 0,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -13214,6 +13222,7 @@ mod tests {
             is_default: Set(true),
             managed_by_cloud: Set(false),
             lifecycle_reconcile_failed_at: Set(None),
+            lifecycle_reconcile_generation: Set(0),
             created_at: Set(chrono::Utc::now()),
             updated_at: Set(chrono::Utc::now()),
         }
@@ -13400,6 +13409,7 @@ mod tests {
             is_default: Set(true),
             managed_by_cloud: Set(false),
             lifecycle_reconcile_failed_at: Set(None),
+            lifecycle_reconcile_generation: Set(0),
             created_at: Set(chrono::Utc::now()),
             updated_at: Set(chrono::Utc::now()),
         }
@@ -13565,6 +13575,7 @@ mod tests {
                     is_default: true,
                     managed_by_cloud: false,
                     lifecycle_reconcile_failed_at: None,
+                    lifecycle_reconcile_generation: 0,
                     created_at: Utc::now(),
                     updated_at: Utc::now(),
                 }]])
@@ -13702,6 +13713,7 @@ mod tests {
             is_default: Set(true),
             managed_by_cloud: Set(false),
             lifecycle_reconcile_failed_at: Set(None),
+            lifecycle_reconcile_generation: Set(0),
             created_at: Set(chrono::Utc::now()),
             updated_at: Set(chrono::Utc::now()),
         }
@@ -13848,6 +13860,7 @@ mod tests {
             is_default: Set(true),
             managed_by_cloud: Set(false),
             lifecycle_reconcile_failed_at: Set(None),
+            lifecycle_reconcile_generation: Set(0),
             created_at: Set(chrono::Utc::now()),
             updated_at: Set(chrono::Utc::now()),
         }

--- a/crates/temps-backup/src/services/backup.rs
+++ b/crates/temps-backup/src/services/backup.rs
@@ -1230,7 +1230,11 @@ impl BackupService {
     ///
     /// The reconcile rebuilds the bucket's lifecycle rules from current
     /// schedule state, so even concurrent schedule changes converge to a
-    /// consistent rule set eventually.
+    /// consistent rule set eventually. A failure here isn't a dead end: it's
+    /// recorded on the source via `lifecycle_reconcile_failed_at` (see
+    /// `S3LifecycleService::reconcile_bucket`), which keeps the source in
+    /// the hourly sweep's scope — even with no enabled schedule left — until
+    /// a later attempt actually succeeds.
     fn fire_lifecycle_reconcile(&self, s3_source_id: i32) {
         let db = self.db.clone();
         let enc = self.encryption_service.clone();
@@ -9998,6 +10002,7 @@ mod tests {
             force_path_style: Some(true),
             is_default: false,
             managed_by_cloud: false,
+            lifecycle_reconcile_failed_at: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -10064,6 +10069,7 @@ mod tests {
             force_path_style: Some(true),
             is_default: false,
             managed_by_cloud: false,
+            lifecycle_reconcile_failed_at: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -10117,6 +10123,7 @@ mod tests {
             force_path_style: Some(false),
             is_default: false,
             managed_by_cloud: true,
+            lifecycle_reconcile_failed_at: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -10163,6 +10170,7 @@ mod tests {
             force_path_style: Some(false),
             is_default: false,
             managed_by_cloud: true,
+            lifecycle_reconcile_failed_at: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -10304,6 +10312,7 @@ mod tests {
             force_path_style: Some(true),
             is_default: false,
             managed_by_cloud: false,
+            lifecycle_reconcile_failed_at: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -10573,6 +10582,7 @@ mod tests {
             force_path_style: Some(true),
             is_default: false,
             managed_by_cloud: false,
+            lifecycle_reconcile_failed_at: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -10705,6 +10715,7 @@ mod tests {
             force_path_style: Some(true),
             is_default: false,
             managed_by_cloud: false,
+            lifecycle_reconcile_failed_at: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -11996,6 +12007,7 @@ mod tests {
             force_path_style: Some(true),
             is_default: false,
             managed_by_cloud: false,
+            lifecycle_reconcile_failed_at: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -13201,6 +13213,7 @@ mod tests {
             force_path_style: Set(Some(true)),
             is_default: Set(true),
             managed_by_cloud: Set(false),
+            lifecycle_reconcile_failed_at: Set(None),
             created_at: Set(chrono::Utc::now()),
             updated_at: Set(chrono::Utc::now()),
         }
@@ -13386,6 +13399,7 @@ mod tests {
             force_path_style: Set(Some(true)),
             is_default: Set(true),
             managed_by_cloud: Set(false),
+            lifecycle_reconcile_failed_at: Set(None),
             created_at: Set(chrono::Utc::now()),
             updated_at: Set(chrono::Utc::now()),
         }
@@ -13550,6 +13564,7 @@ mod tests {
                     force_path_style: Some(true),
                     is_default: true,
                     managed_by_cloud: false,
+                    lifecycle_reconcile_failed_at: None,
                     created_at: Utc::now(),
                     updated_at: Utc::now(),
                 }]])
@@ -13686,6 +13701,7 @@ mod tests {
             force_path_style: Set(Some(true)),
             is_default: Set(true),
             managed_by_cloud: Set(false),
+            lifecycle_reconcile_failed_at: Set(None),
             created_at: Set(chrono::Utc::now()),
             updated_at: Set(chrono::Utc::now()),
         }
@@ -13831,6 +13847,7 @@ mod tests {
             force_path_style: Set(Some(true)),
             is_default: Set(true),
             managed_by_cloud: Set(false),
+            lifecycle_reconcile_failed_at: Set(None),
             created_at: Set(chrono::Utc::now()),
             updated_at: Set(chrono::Utc::now()),
         }

--- a/crates/temps-backup/src/services/restore.rs
+++ b/crates/temps-backup/src/services/restore.rs
@@ -3534,6 +3534,7 @@ mod tests {
             force_path_style: Some(true),
             is_default: true,
             managed_by_cloud: false,
+            lifecycle_reconcile_failed_at: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }

--- a/crates/temps-backup/src/services/restore.rs
+++ b/crates/temps-backup/src/services/restore.rs
@@ -3535,6 +3535,7 @@ mod tests {
             is_default: true,
             managed_by_cloud: false,
             lifecycle_reconcile_failed_at: None,
+            lifecycle_reconcile_generation: 0,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }

--- a/crates/temps-backup/src/services/s3_lifecycle.rs
+++ b/crates/temps-backup/src/services/s3_lifecycle.rs
@@ -87,6 +87,28 @@ pub enum ReconcileOutcome {
     Unsupported { reason: String },
 }
 
+/// Process-level locks keyed by `s3_source_id`, serializing
+/// `reconcile_bucket` calls for the same source. The lifecycle sweep and
+/// every event-driven trigger (`BackupService::fire_lifecycle_reconcile`)
+/// only ever run on the control-plane process, so an in-process lock is
+/// sufficient — no cross-process coordination is needed. This mirrors
+/// `ENVIRONMENT_LOCKS` in `temps-deployments/src/jobs/mark_deployment_complete.rs`,
+/// which rejected PostgreSQL advisory locks for the same reason: Sea-ORM's
+/// `DatabaseConnection` is pooled, so an advisory lock/unlock pair can hit
+/// different pooled connections and leave the lock permanently held.
+static SOURCE_LOCKS: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<i32, Arc<tokio::sync::Mutex<()>>>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+fn get_source_lock(s3_source_id: i32) -> Arc<tokio::sync::Mutex<()>> {
+    SOURCE_LOCKS
+        .lock()
+        .expect("source locks poisoned")
+        .entry(s3_source_id)
+        .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+        .clone()
+}
+
 /// Reconciles S3 bucket lifecycle policies with the retention values
 /// configured on `backup_schedules`. Stateless — every call recomputes
 /// the desired state from the database.
@@ -106,10 +128,71 @@ impl S3LifecycleService {
     /// Reconcile lifecycle rules for one S3 source. Loads all enabled
     /// schedules pointing at this source, collects the distinct
     /// retention values, and pushes one rule per value to the bucket.
+    ///
+    /// Two reconciles for the same source can overlap — an event-driven
+    /// trigger and the hourly sweep, or two schedule mutations in quick
+    /// succession — and this call is not itself ordered relative to them.
+    /// Without serialization, an older attempt (reading stale schedule
+    /// state) could push its `PutBucketLifecycleConfiguration` /
+    /// `DeleteBucketLifecycle` call to S3 *after* a newer attempt's,
+    /// silently overwriting the correct state with stale rules even though
+    /// the generation guard on `record_reconcile_attempt` correctly
+    /// prevents the stale attempt's DB write from clobbering the newer
+    /// one's retry marker. Acquiring `get_source_lock` first makes the two
+    /// attempts run strictly one after the other, so the second always
+    /// recomputes from fresh schedule state and its S3 call is the one
+    /// that actually lands last.
     pub async fn reconcile_bucket(
         &self,
         s3_source_id: i32,
     ) -> Result<ReconcileOutcome, BackupError> {
+        let source_lock = get_source_lock(s3_source_id);
+        let _guard = source_lock.lock().await;
+
+        // Claim this attempt's generation first — before schedule lookup,
+        // S3 client construction, or the S3 call itself, i.e. before
+        // anything else in this function that can fail. `begin_reconcile_attempt`
+        // itself confirms the source exists (its `UPDATE ... RETURNING`
+        // reports `NotFound` if no row matched), so no separate existence
+        // check is needed here. Every failure past this point (a
+        // schedule-fetch DB error, a credential-decrypt error building the
+        // client, a rejected S3 call) is captured by `do_reconcile` and
+        // reported through `record_reconcile_attempt` under this same
+        // generation. Claiming it any later would let those earlier
+        // failure modes slip through with no retry marker ever recorded —
+        // the source would then silently vanish from `sources_in_scope`
+        // the moment its last schedule is disabled, with nothing left to
+        // retry it.
+        let generation = self.begin_reconcile_attempt(s3_source_id).await?;
+
+        let result = self.do_reconcile(s3_source_id).await;
+
+        // Record the outcome so a transient failure keeps this source in
+        // `sources_in_scope` — and therefore in the hourly sweep's retry
+        // path — even if it has no enabled schedule at the moment (e.g. the
+        // schedule that triggered this reconcile was the one just
+        // disabled). Cleared on the next success so a source that's
+        // genuinely out of scope stops being swept once it converges.
+        if let Err(e) = self
+            .record_reconcile_attempt(s3_source_id, generation, result.is_err())
+            .await
+        {
+            warn!(
+                s3_source_id,
+                error = %e,
+                "failed to persist S3 lifecycle reconcile retry state"
+            );
+        }
+
+        result
+    }
+
+    /// The actual reconcile work — schedule lookup through the S3 call.
+    /// Split out from `reconcile_bucket` so every error path here (schedule
+    /// fetch, S3 client construction, the S3 call itself) runs *after* a
+    /// generation has already been claimed, letting the caller record the
+    /// failure under that generation regardless of which step raised it.
+    async fn do_reconcile(&self, s3_source_id: i32) -> Result<ReconcileOutcome, BackupError> {
         let source = temps_entities::s3_sources::Entity::find_by_id(s3_source_id)
             .one(self.db.as_ref())
             .await
@@ -136,38 +219,12 @@ impl S3LifecycleService {
                 ),
             })?;
 
-        // Claim this attempt's generation *before* talking to S3, so any
-        // concurrent reconcile for the same source that starts later (an
-        // overlapping event-driven trigger, or the hourly sweep) is
-        // guaranteed to claim a higher one — see `record_reconcile_attempt`
-        // for why that ordering is what makes the retry marker race-safe.
-        let generation = self.begin_reconcile_attempt(s3_source_id).await?;
-
-        let result = if retentions.is_empty() {
+        if retentions.is_empty() {
             clear_temps_rules(&client, &source.bucket_name, s3_source_id).await
         } else {
             let rules = build_lifecycle_rules(&retentions);
             apply_lifecycle(&client, &source.bucket_name, rules, s3_source_id).await
-        };
-
-        // Record the outcome so a transient failure keeps this source in
-        // `sources_in_scope` — and therefore in the hourly sweep's retry
-        // path — even if it has no enabled schedule at the moment (e.g. the
-        // schedule that triggered this reconcile was the one just
-        // disabled). Cleared on the next success so a source that's
-        // genuinely out of scope stops being swept once it converges.
-        if let Err(e) = self
-            .record_reconcile_attempt(s3_source_id, generation, result.is_err())
-            .await
-        {
-            warn!(
-                s3_source_id,
-                error = %e,
-                "failed to persist S3 lifecycle reconcile retry state"
-            );
         }
-
-        result
     }
 
     /// Atomically claim the next reconcile "generation" for `s3_source_id`
@@ -433,6 +490,64 @@ pub fn is_unsupported_error(msg: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression: without `get_source_lock`, two overlapping
+    /// `reconcile_bucket` calls for the same source can each push a
+    /// different desired lifecycle state to S3 independently, and whichever
+    /// HTTP call lands last on S3 wins regardless of which attempt started
+    /// with fresher schedule state — the generation guard on
+    /// `record_reconcile_attempt` only protects the DB bookkeeping, not the
+    /// actual S3 mutation order. This proves the lock actually serializes
+    /// same-source access: while the first guard is held, a second
+    /// acquisition attempt for the same id must block until it's released.
+    #[tokio::test]
+    async fn source_lock_serializes_calls_for_the_same_source() {
+        let order: Arc<tokio::sync::Mutex<Vec<&'static str>>> =
+            Arc::new(tokio::sync::Mutex::new(Vec::new()));
+
+        let first_lock = get_source_lock(90_001);
+        let first_guard = first_lock.lock().await;
+
+        let order_clone = order.clone();
+        let waiter = tokio::spawn(async move {
+            let second_lock = get_source_lock(90_001);
+            let _second_guard = second_lock.lock().await;
+            order_clone.lock().await.push("second acquired");
+        });
+
+        // Give the spawned task a chance to actually attempt (and block
+        // on) the same-source lock before we record that the first guard
+        // is still held.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        order.lock().await.push("first still holding");
+        drop(first_guard);
+
+        waiter.await.expect("waiter task completes");
+
+        assert_eq!(
+            *order.lock().await,
+            vec!["first still holding", "second acquired"],
+            "a second reconcile for the same source must block until the first releases the lock"
+        );
+    }
+
+    /// Complement to the test above: two different source ids must not
+    /// contend on the same lock, so the sweep isn't accidentally serialized
+    /// across unrelated sources.
+    #[tokio::test]
+    async fn source_lock_does_not_serialize_different_sources() {
+        let held_lock = get_source_lock(90_101);
+        let _held_guard = held_lock.lock().await;
+
+        let other_lock = get_source_lock(90_102);
+        let other_acquired =
+            tokio::time::timeout(std::time::Duration::from_millis(500), other_lock.lock()).await;
+
+        assert!(
+            other_acquired.is_ok(),
+            "a different source id's lock must be acquirable while an unrelated source's lock is held"
+        );
+    }
 
     fn schedule_with_retention(
         id: i32,

--- a/crates/temps-backup/src/services/s3_lifecycle.rs
+++ b/crates/temps-backup/src/services/s3_lifecycle.rs
@@ -109,6 +109,19 @@ fn get_source_lock(s3_source_id: i32) -> Arc<tokio::sync::Mutex<()>> {
         .clone()
 }
 
+/// Retry policy for the two small bookkeeping writes
+/// (`begin_reconcile_attempt`, `record_reconcile_attempt`) that guard the
+/// retry marker: a handful of fast retries, since these are single-row
+/// local DB round-trips, not calls to an external API. Enough to ride out a
+/// dropped pool connection or a momentary Postgres restart without
+/// meaningfully delaying the reconcile, but bounded so a genuine outage
+/// still surfaces as an error rather than hanging.
+fn reconcile_bookkeeping_retry() -> temps_core::retry::RetryConfig {
+    temps_core::retry::RetryConfig::new(3)
+        .with_base_delay(std::time::Duration::from_millis(100))
+        .with_max_delay(std::time::Duration::from_secs(1))
+}
+
 /// Reconciles S3 bucket lifecycle policies with the retention values
 /// configured on `backup_schedules`. Stateless — every call recomputes
 /// the desired state from the database.
@@ -230,23 +243,34 @@ impl S3LifecycleService {
     /// Atomically claim the next reconcile "generation" for `s3_source_id`
     /// and return it. Pairs with `record_reconcile_attempt`, which only
     /// applies its write while this is still the newest claimed generation.
+    ///
+    /// Retried with backoff: a bare transient DB error here (a dropped pool
+    /// connection, a momentary Postgres restart) would otherwise abort the
+    /// whole reconcile before it even reaches the S3 call, leaving no
+    /// retry marker recorded — indistinguishable from the source having
+    /// converged, and (once its last schedule is disabled) permanently
+    /// excluded from the sweep with a stale lifecycle rule still in S3.
     async fn begin_reconcile_attempt(&self, s3_source_id: i32) -> Result<i32, BackupError> {
-        let row = self
-            .db
-            .query_one(sea_orm::Statement::from_sql_and_values(
-                sea_orm::DatabaseBackend::Postgres,
-                "UPDATE s3_sources SET lifecycle_reconcile_generation = lifecycle_reconcile_generation + 1 \
-                 WHERE id = $1 RETURNING lifecycle_reconcile_generation",
-                [s3_source_id.into()],
-            ))
+        reconcile_bookkeeping_retry()
+            .retry(|| async {
+                let row = self
+                    .db
+                    .query_one(sea_orm::Statement::from_sql_and_values(
+                        sea_orm::DatabaseBackend::Postgres,
+                        "UPDATE s3_sources SET lifecycle_reconcile_generation = lifecycle_reconcile_generation + 1 \
+                         WHERE id = $1 RETURNING lifecycle_reconcile_generation",
+                        [s3_source_id.into()],
+                    ))
+                    .await
+                    .map_err(BackupError::Database)?
+                    .ok_or_else(|| BackupError::NotFound {
+                        resource: "s3_source".to_string(),
+                        detail: format!("id {}", s3_source_id),
+                    })?;
+                row.try_get("", "lifecycle_reconcile_generation")
+                    .map_err(BackupError::Database)
+            })
             .await
-            .map_err(BackupError::Database)?
-            .ok_or_else(|| BackupError::NotFound {
-                resource: "s3_source".to_string(),
-                detail: format!("id {}", s3_source_id),
-            })?;
-        row.try_get("", "lifecycle_reconcile_generation")
-            .map_err(BackupError::Database)
     }
 
     /// Persist whether the reconcile attempt for `s3_source_id` failed, so
@@ -270,23 +294,36 @@ impl S3LifecycleService {
     /// a stale write is simply dropped (`exec` reports 0 rows affected,
     /// which isn't an error — the newer attempt already recorded, or will
     /// record, the outcome that matters).
+    ///
+    /// Also retried with backoff, for the same reason as
+    /// `begin_reconcile_attempt`: a bare transient DB error on this write
+    /// alone (distinct from the S3 call succeeding or failing) must not be
+    /// the difference between "retry marker recorded" and "source silently
+    /// drops out of the sweep."
     async fn record_reconcile_attempt(
         &self,
         s3_source_id: i32,
         generation: i32,
         failed: bool,
     ) -> Result<(), BackupError> {
-        temps_entities::s3_sources::Entity::update_many()
-            .col_expr(
-                temps_entities::s3_sources::Column::LifecycleReconcileFailedAt,
-                sea_orm::sea_query::Expr::value(failed.then(chrono::Utc::now)),
-            )
-            .filter(temps_entities::s3_sources::Column::Id.eq(s3_source_id))
-            .filter(temps_entities::s3_sources::Column::LifecycleReconcileGeneration.eq(generation))
-            .exec(self.db.as_ref())
+        reconcile_bookkeeping_retry()
+            .retry(|| async {
+                temps_entities::s3_sources::Entity::update_many()
+                    .col_expr(
+                        temps_entities::s3_sources::Column::LifecycleReconcileFailedAt,
+                        sea_orm::sea_query::Expr::value(failed.then(chrono::Utc::now)),
+                    )
+                    .filter(temps_entities::s3_sources::Column::Id.eq(s3_source_id))
+                    .filter(
+                        temps_entities::s3_sources::Column::LifecycleReconcileGeneration
+                            .eq(generation),
+                    )
+                    .exec(self.db.as_ref())
+                    .await
+                    .map(|_| ())
+                    .map_err(BackupError::Database)
+            })
             .await
-            .map(|_| ())
-            .map_err(BackupError::Database)
     }
 
     /// S3 sources actually in scope for Temps-managed lifecycle rules:

--- a/crates/temps-backup/src/services/s3_lifecycle.rs
+++ b/crates/temps-backup/src/services/s3_lifecycle.rs
@@ -49,8 +49,8 @@ use aws_sdk_s3::types::{
     LifecycleRuleFilter, Tag,
 };
 use sea_orm::{
-    ActiveModelTrait, ActiveValue::Set, ColumnTrait, Condition, DatabaseConnection, EntityTrait,
-    QueryFilter, QuerySelect, QueryTrait,
+    ColumnTrait, Condition, ConnectionTrait, DatabaseConnection, EntityTrait, QueryFilter,
+    QuerySelect, QueryTrait,
 };
 use tracing::{debug, info, warn};
 
@@ -136,6 +136,13 @@ impl S3LifecycleService {
                 ),
             })?;
 
+        // Claim this attempt's generation *before* talking to S3, so any
+        // concurrent reconcile for the same source that starts later (an
+        // overlapping event-driven trigger, or the hourly sweep) is
+        // guaranteed to claim a higher one — see `record_reconcile_attempt`
+        // for why that ordering is what makes the retry marker race-safe.
+        let generation = self.begin_reconcile_attempt(s3_source_id).await?;
+
         let result = if retentions.is_empty() {
             clear_temps_rules(&client, &source.bucket_name, s3_source_id).await
         } else {
@@ -150,7 +157,7 @@ impl S3LifecycleService {
         // disabled). Cleared on the next success so a source that's
         // genuinely out of scope stops being swept once it converges.
         if let Err(e) = self
-            .record_reconcile_attempt(s3_source_id, result.is_err())
+            .record_reconcile_attempt(s3_source_id, generation, result.is_err())
             .await
         {
             warn!(
@@ -163,25 +170,66 @@ impl S3LifecycleService {
         result
     }
 
+    /// Atomically claim the next reconcile "generation" for `s3_source_id`
+    /// and return it. Pairs with `record_reconcile_attempt`, which only
+    /// applies its write while this is still the newest claimed generation.
+    async fn begin_reconcile_attempt(&self, s3_source_id: i32) -> Result<i32, BackupError> {
+        let row = self
+            .db
+            .query_one(sea_orm::Statement::from_sql_and_values(
+                sea_orm::DatabaseBackend::Postgres,
+                "UPDATE s3_sources SET lifecycle_reconcile_generation = lifecycle_reconcile_generation + 1 \
+                 WHERE id = $1 RETURNING lifecycle_reconcile_generation",
+                [s3_source_id.into()],
+            ))
+            .await
+            .map_err(BackupError::Database)?
+            .ok_or_else(|| BackupError::NotFound {
+                resource: "s3_source".to_string(),
+                detail: format!("id {}", s3_source_id),
+            })?;
+        row.try_get("", "lifecycle_reconcile_generation")
+            .map_err(BackupError::Database)
+    }
+
     /// Persist whether the reconcile attempt for `s3_source_id` failed, so
     /// `sources_in_scope` can keep retrying it independent of schedule
     /// state. Best-effort: a failure here doesn't change `reconcile_bucket`'s
     /// return value, since the S3 call itself already succeeded or failed on
     /// its own terms — this is only bookkeeping for the next sweep.
+    ///
+    /// Guarded by `generation` (claimed via `begin_reconcile_attempt` before
+    /// the S3 call): the write only applies `WHERE
+    /// lifecycle_reconcile_generation = generation`, i.e. only if no other
+    /// attempt has *started* for this source since this one did. Two
+    /// reconciles for the same source can overlap — an event-driven
+    /// reconcile and the hourly sweep, or two schedule mutations in quick
+    /// succession — and finish in either order. Without this guard, an
+    /// older attempt that started first but finishes last could overwrite a
+    /// newer attempt's failure marker with its own (stale) success,
+    /// silently dropping the source from every future retry even though the
+    /// newer, more-informed attempt actually failed. The generation check
+    /// makes only the most-recently-*started* attempt's outcome authoritative;
+    /// a stale write is simply dropped (`exec` reports 0 rows affected,
+    /// which isn't an error — the newer attempt already recorded, or will
+    /// record, the outcome that matters).
     async fn record_reconcile_attempt(
         &self,
         s3_source_id: i32,
+        generation: i32,
         failed: bool,
     ) -> Result<(), BackupError> {
-        temps_entities::s3_sources::ActiveModel {
-            id: Set(s3_source_id),
-            lifecycle_reconcile_failed_at: Set(failed.then(chrono::Utc::now)),
-            ..Default::default()
-        }
-        .update(self.db.as_ref())
-        .await
-        .map(|_| ())
-        .map_err(BackupError::Database)
+        temps_entities::s3_sources::Entity::update_many()
+            .col_expr(
+                temps_entities::s3_sources::Column::LifecycleReconcileFailedAt,
+                sea_orm::sea_query::Expr::value(failed.then(chrono::Utc::now)),
+            )
+            .filter(temps_entities::s3_sources::Column::Id.eq(s3_source_id))
+            .filter(temps_entities::s3_sources::Column::LifecycleReconcileGeneration.eq(generation))
+            .exec(self.db.as_ref())
+            .await
+            .map(|_| ())
+            .map_err(BackupError::Database)
     }
 
     /// S3 sources actually in scope for Temps-managed lifecycle rules:
@@ -691,6 +739,7 @@ mod tests {
                 is_default: Set(false),
                 managed_by_cloud: Set(managed_by_cloud),
                 lifecycle_reconcile_failed_at: Set(None),
+                lifecycle_reconcile_generation: Set(0),
                 created_at: Set(now),
                 updated_at: Set(now),
             }
@@ -812,6 +861,7 @@ mod tests {
             is_default: Set(false),
             managed_by_cloud: Set(false),
             lifecycle_reconcile_failed_at: Set(None),
+            lifecycle_reconcile_generation: Set(0),
             created_at: Set(now),
             updated_at: Set(now),
         }
@@ -846,6 +896,7 @@ mod tests {
         temps_entities::s3_sources::ActiveModel {
             id: Set(source.id),
             lifecycle_reconcile_failed_at: Set(Some(now)),
+            lifecycle_reconcile_generation: Set(0),
             ..Default::default()
         }
         .update(db.as_ref())
@@ -869,6 +920,96 @@ mod tests {
             in_scope_ids.contains(&source.id),
             "a source with a pending reconcile retry must stay in scope even with no enabled \
              schedule, so the hourly sweep keeps retrying until it converges"
+        );
+    }
+
+    /// Regression (Greptile P1 on the fix above): two reconciles for the
+    /// same source can overlap and finish out of start order — an
+    /// event-driven reconcile and the hourly sweep, or two schedule
+    /// mutations in quick succession. Without a generation guard, an older
+    /// attempt that starts first but finishes *last* could write its own
+    /// (stale) success over a newer attempt's failure, silently clearing
+    /// `lifecycle_reconcile_failed_at` and dropping the source out of every
+    /// future retry even though the more recent, more-informed attempt
+    /// actually failed. `record_reconcile_attempt` must refuse a write once
+    /// a newer attempt has already claimed the generation.
+    #[tokio::test]
+    async fn a_stale_reconcile_attempt_cannot_clobber_a_newer_attempts_failure() {
+        use sea_orm::{ActiveModelTrait, ActiveValue::Set};
+
+        let test_db = match temps_database::test_utils::TestDatabase::with_migrations().await {
+            Ok(d) => d,
+            Err(e) => {
+                println!("TestDatabase unavailable, skipping: {e}");
+                return;
+            }
+        };
+        let db = test_db.db.clone();
+        let now = chrono::Utc::now();
+
+        let source = temps_entities::s3_sources::ActiveModel {
+            id: sea_orm::ActiveValue::NotSet,
+            name: Set("overlapping-reconciles".to_string()),
+            bucket_name: Set("overlapping-reconciles-bucket".to_string()),
+            bucket_path: Set("/".to_string()),
+            access_key_id: Set(String::new()),
+            secret_key: Set(String::new()),
+            session_token: Set(None),
+            credentials_expire_at: Set(None),
+            region: Set("us-east-1".to_string()),
+            endpoint: Set(None),
+            force_path_style: Set(Some(true)),
+            is_default: Set(false),
+            managed_by_cloud: Set(true),
+            lifecycle_reconcile_failed_at: Set(None),
+            lifecycle_reconcile_generation: Set(0),
+            created_at: Set(now),
+            updated_at: Set(now),
+        }
+        .insert(db.as_ref())
+        .await
+        .expect("insert source");
+
+        let encryption = Arc::new(temps_core::EncryptionService::new_from_password(
+            "test_encryption_key_1234567890ab",
+        ));
+        let svc = S3LifecycleService::new(db.clone(), encryption);
+
+        // Two attempts start, in order: an older one (e.g. an event-driven
+        // reconcile from an earlier schedule mutation), then a newer one
+        // (e.g. the immediate reconcile fired by disabling the last
+        // schedule).
+        let older_generation = svc
+            .begin_reconcile_attempt(source.id)
+            .await
+            .expect("begin older attempt");
+        let newer_generation = svc
+            .begin_reconcile_attempt(source.id)
+            .await
+            .expect("begin newer attempt");
+        assert!(newer_generation > older_generation);
+
+        // The newer attempt finishes first and fails.
+        svc.record_reconcile_attempt(source.id, newer_generation, true)
+            .await
+            .expect("record newer failure");
+
+        // The older attempt, despite having started first, finishes last
+        // and succeeds. Its write must be dropped rather than clearing the
+        // newer attempt's failure marker.
+        svc.record_reconcile_attempt(source.id, older_generation, false)
+            .await
+            .expect("record older success (must be a no-op)");
+
+        let refreshed = temps_entities::s3_sources::Entity::find_by_id(source.id)
+            .one(db.as_ref())
+            .await
+            .expect("refetch source")
+            .expect("source still exists");
+
+        assert!(
+            refreshed.lifecycle_reconcile_failed_at.is_some(),
+            "a stale (older) attempt's success must not clear a newer attempt's failure marker"
         );
     }
 }

--- a/crates/temps-backup/src/services/s3_lifecycle.rs
+++ b/crates/temps-backup/src/services/s3_lifecycle.rs
@@ -48,7 +48,9 @@ use aws_sdk_s3::types::{
     BucketLifecycleConfiguration, ExpirationStatus, LifecycleExpiration, LifecycleRule,
     LifecycleRuleFilter, Tag,
 };
-use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
+use sea_orm::{
+    ColumnTrait, Condition, DatabaseConnection, EntityTrait, QueryFilter, QuerySelect, QueryTrait,
+};
 use tracing::{debug, info, warn};
 
 use temps_core::EncryptionService;
@@ -139,6 +141,38 @@ impl S3LifecycleService {
 
         let rules = build_lifecycle_rules(&retentions);
         apply_lifecycle(&client, &source.bucket_name, rules, s3_source_id).await
+    }
+
+    /// S3 sources actually in scope for Temps-managed lifecycle rules:
+    /// those with at least one enabled backup schedule, plus any bucket
+    /// Temps Cloud provisioned itself (`managed_by_cloud`).
+    ///
+    /// Deliberately excludes sources with no enabled schedule and
+    /// `managed_by_cloud = false` — buckets the operator configured with
+    /// their own credentials but never attached to a backup schedule
+    /// (e.g. an unrelated production bucket). `reconcile_bucket` has never
+    /// had anything to apply for those, so calling
+    /// `PutBucketLifecycleConfiguration` / `DeleteBucketLifecycle` against
+    /// them is a paid API call against infrastructure Temps doesn't
+    /// manage, for no behavioral benefit.
+    pub async fn sources_in_scope(
+        &self,
+    ) -> Result<Vec<temps_entities::s3_sources::Model>, BackupError> {
+        let scheduled_source_ids = temps_entities::backup_schedules::Entity::find()
+            .filter(temps_entities::backup_schedules::Column::Enabled.eq(true))
+            .select_only()
+            .column(temps_entities::backup_schedules::Column::S3SourceId)
+            .into_query();
+
+        temps_entities::s3_sources::Entity::find()
+            .filter(
+                Condition::any()
+                    .add(temps_entities::s3_sources::Column::ManagedByCloud.eq(true))
+                    .add(temps_entities::s3_sources::Column::Id.in_subquery(scheduled_source_ids)),
+            )
+            .all(self.db.as_ref())
+            .await
+            .map_err(BackupError::Database)
     }
 }
 
@@ -560,5 +594,128 @@ mod tests {
         }
 
         assert_lifecycle_roundtrip(&client, bucket, &[14, 60]).await;
+    }
+
+    /// Regression: the hourly lifecycle sweep must not touch S3 sources
+    /// the operator configured with their own credentials but never
+    /// attached to a backup schedule — those API calls cost money against
+    /// infrastructure Temps doesn't manage. Seeds four sources against a
+    /// real Postgres: one with an enabled schedule (in scope), one with
+    /// only a disabled schedule (out of scope), one `managed_by_cloud`
+    /// with no schedule at all (in scope), and one plain unattached
+    /// source (out of scope) — then asserts `sources_in_scope` returns
+    /// exactly the two that should be reconciled.
+    #[tokio::test]
+    async fn sources_in_scope_excludes_unscheduled_operator_buckets() {
+        use sea_orm::{ActiveModelTrait, ActiveValue::Set};
+
+        let test_db = match temps_database::test_utils::TestDatabase::with_migrations().await {
+            Ok(d) => d,
+            Err(e) => {
+                println!("TestDatabase unavailable, skipping: {e}");
+                return;
+            }
+        };
+        let db = test_db.db.clone();
+
+        let insert_source = |name: &str, managed_by_cloud: bool| {
+            let now = chrono::Utc::now();
+            temps_entities::s3_sources::ActiveModel {
+                id: sea_orm::ActiveValue::NotSet,
+                name: Set(name.to_string()),
+                bucket_name: Set(format!("{name}-bucket")),
+                bucket_path: Set("/".to_string()),
+                access_key_id: Set(String::new()),
+                secret_key: Set(String::new()),
+                session_token: Set(None),
+                credentials_expire_at: Set(None),
+                region: Set("us-east-1".to_string()),
+                endpoint: Set(None),
+                force_path_style: Set(Some(true)),
+                is_default: Set(false),
+                managed_by_cloud: Set(managed_by_cloud),
+                created_at: Set(now),
+                updated_at: Set(now),
+            }
+        };
+
+        let scheduled = insert_source("scheduled", false)
+            .insert(db.as_ref())
+            .await
+            .expect("insert scheduled source");
+        let disabled_only = insert_source("disabled-only", false)
+            .insert(db.as_ref())
+            .await
+            .expect("insert disabled-only source");
+        let cloud_managed = insert_source("cloud-managed", true)
+            .insert(db.as_ref())
+            .await
+            .expect("insert cloud-managed source");
+        let unattached = insert_source("unattached", false)
+            .insert(db.as_ref())
+            .await
+            .expect("insert unattached source");
+
+        let insert_schedule = |name: &str, s3_source_id: i32, enabled: bool| {
+            let now = chrono::Utc::now();
+            temps_entities::backup_schedules::ActiveModel {
+                id: sea_orm::ActiveValue::NotSet,
+                name: Set(name.to_string()),
+                backup_type: Set("full".to_string()),
+                retention_period: Set(7),
+                s3_source_id: Set(s3_source_id),
+                schedule_expression: Set("0 0 2 * * *".to_string()),
+                enabled: Set(enabled),
+                last_run: Set(None),
+                next_run: Set(None),
+                created_at: Set(now),
+                updated_at: Set(now),
+                description: Set(None),
+                tags: Set("[]".to_string()),
+                max_runtime_secs: Set(None),
+                target_all_services: Set(false),
+                include_control_plane: Set(true),
+            }
+        };
+
+        insert_schedule("enabled-sched", scheduled.id, true)
+            .insert(db.as_ref())
+            .await
+            .expect("insert enabled schedule");
+        insert_schedule("disabled-sched", disabled_only.id, false)
+            .insert(db.as_ref())
+            .await
+            .expect("insert disabled schedule");
+        // `unattached` and `cloud_managed` intentionally have no schedule.
+
+        let encryption = Arc::new(temps_core::EncryptionService::new_from_password(
+            "test_encryption_key_1234567890ab",
+        ));
+        let svc = S3LifecycleService::new(db.clone(), encryption);
+
+        let in_scope_ids: std::collections::HashSet<i32> = svc
+            .sources_in_scope()
+            .await
+            .expect("sources_in_scope should succeed")
+            .into_iter()
+            .map(|s| s.id)
+            .collect();
+
+        assert!(
+            in_scope_ids.contains(&scheduled.id),
+            "source with an enabled schedule must be in scope"
+        );
+        assert!(
+            in_scope_ids.contains(&cloud_managed.id),
+            "managed_by_cloud source must be in scope even with no schedule"
+        );
+        assert!(
+            !in_scope_ids.contains(&disabled_only.id),
+            "source with only a disabled schedule must NOT be in scope"
+        );
+        assert!(
+            !in_scope_ids.contains(&unattached.id),
+            "unattached operator bucket must NOT be in scope — reconciling it wastes a paid S3 API call"
+        );
     }
 }

--- a/crates/temps-backup/src/services/s3_lifecycle.rs
+++ b/crates/temps-backup/src/services/s3_lifecycle.rs
@@ -49,7 +49,8 @@ use aws_sdk_s3::types::{
     LifecycleRuleFilter, Tag,
 };
 use sea_orm::{
-    ColumnTrait, Condition, DatabaseConnection, EntityTrait, QueryFilter, QuerySelect, QueryTrait,
+    ActiveModelTrait, ActiveValue::Set, ColumnTrait, Condition, DatabaseConnection, EntityTrait,
+    QueryFilter, QuerySelect, QueryTrait,
 };
 use tracing::{debug, info, warn};
 
@@ -135,26 +136,77 @@ impl S3LifecycleService {
                 ),
             })?;
 
-        if retentions.is_empty() {
-            return clear_temps_rules(&client, &source.bucket_name, s3_source_id).await;
+        let result = if retentions.is_empty() {
+            clear_temps_rules(&client, &source.bucket_name, s3_source_id).await
+        } else {
+            let rules = build_lifecycle_rules(&retentions);
+            apply_lifecycle(&client, &source.bucket_name, rules, s3_source_id).await
+        };
+
+        // Record the outcome so a transient failure keeps this source in
+        // `sources_in_scope` — and therefore in the hourly sweep's retry
+        // path — even if it has no enabled schedule at the moment (e.g. the
+        // schedule that triggered this reconcile was the one just
+        // disabled). Cleared on the next success so a source that's
+        // genuinely out of scope stops being swept once it converges.
+        if let Err(e) = self
+            .record_reconcile_attempt(s3_source_id, result.is_err())
+            .await
+        {
+            warn!(
+                s3_source_id,
+                error = %e,
+                "failed to persist S3 lifecycle reconcile retry state"
+            );
         }
 
-        let rules = build_lifecycle_rules(&retentions);
-        apply_lifecycle(&client, &source.bucket_name, rules, s3_source_id).await
+        result
+    }
+
+    /// Persist whether the reconcile attempt for `s3_source_id` failed, so
+    /// `sources_in_scope` can keep retrying it independent of schedule
+    /// state. Best-effort: a failure here doesn't change `reconcile_bucket`'s
+    /// return value, since the S3 call itself already succeeded or failed on
+    /// its own terms — this is only bookkeeping for the next sweep.
+    async fn record_reconcile_attempt(
+        &self,
+        s3_source_id: i32,
+        failed: bool,
+    ) -> Result<(), BackupError> {
+        temps_entities::s3_sources::ActiveModel {
+            id: Set(s3_source_id),
+            lifecycle_reconcile_failed_at: Set(failed.then(chrono::Utc::now)),
+            ..Default::default()
+        }
+        .update(self.db.as_ref())
+        .await
+        .map(|_| ())
+        .map_err(BackupError::Database)
     }
 
     /// S3 sources actually in scope for Temps-managed lifecycle rules:
-    /// those with at least one enabled backup schedule, plus any bucket
-    /// Temps Cloud provisioned itself (`managed_by_cloud`).
+    /// those with at least one enabled backup schedule, any bucket Temps
+    /// Cloud provisioned itself (`managed_by_cloud`), or any source with a
+    /// reconcile attempt still pending retry (`lifecycle_reconcile_failed_at`
+    /// set).
     ///
-    /// Deliberately excludes sources with no enabled schedule and
-    /// `managed_by_cloud = false` — buckets the operator configured with
-    /// their own credentials but never attached to a backup schedule
-    /// (e.g. an unrelated production bucket). `reconcile_bucket` has never
-    /// had anything to apply for those, so calling
-    /// `PutBucketLifecycleConfiguration` / `DeleteBucketLifecycle` against
-    /// them is a paid API call against infrastructure Temps doesn't
+    /// Deliberately excludes sources with no enabled schedule,
+    /// `managed_by_cloud = false`, and no pending retry — buckets the
+    /// operator configured with their own credentials but never attached to
+    /// a backup schedule (e.g. an unrelated production bucket).
+    /// `reconcile_bucket` has never had anything to apply for those, so
+    /// calling `PutBucketLifecycleConfiguration` / `DeleteBucketLifecycle`
+    /// against them is a paid API call against infrastructure Temps doesn't
     /// manage, for no behavioral benefit.
+    ///
+    /// The pending-retry clause exists because disabling a source's last
+    /// enabled schedule fires an immediate reconcile to clear its rules; if
+    /// that attempt hits a transient S3 error, the source would otherwise
+    /// drop out of scope in the same moment it needed a retry, stranding a
+    /// stale lifecycle rule in S3 with nothing left to clear it. Keeping it
+    /// in scope until reconcile actually succeeds (which clears the flag —
+    /// see `record_reconcile_attempt`) bounds staleness to the sweep
+    /// interval instead of leaving it indefinite.
     pub async fn sources_in_scope(
         &self,
     ) -> Result<Vec<temps_entities::s3_sources::Model>, BackupError> {
@@ -168,7 +220,11 @@ impl S3LifecycleService {
             .filter(
                 Condition::any()
                     .add(temps_entities::s3_sources::Column::ManagedByCloud.eq(true))
-                    .add(temps_entities::s3_sources::Column::Id.in_subquery(scheduled_source_ids)),
+                    .add(temps_entities::s3_sources::Column::Id.in_subquery(scheduled_source_ids))
+                    .add(
+                        temps_entities::s3_sources::Column::LifecycleReconcileFailedAt
+                            .is_not_null(),
+                    ),
             )
             .all(self.db.as_ref())
             .await
@@ -634,6 +690,7 @@ mod tests {
                 force_path_style: Set(Some(true)),
                 is_default: Set(false),
                 managed_by_cloud: Set(managed_by_cloud),
+                lifecycle_reconcile_failed_at: Set(None),
                 created_at: Set(now),
                 updated_at: Set(now),
             }
@@ -716,6 +773,102 @@ mod tests {
         assert!(
             !in_scope_ids.contains(&unattached.id),
             "unattached operator bucket must NOT be in scope — reconciling it wastes a paid S3 API call"
+        );
+    }
+
+    /// Regression: disabling a source's last enabled schedule fires an
+    /// immediate reconcile (`BackupService::fire_lifecycle_reconcile`). If
+    /// that attempt hits a transient S3 error, the source must not simply
+    /// fall out of scope — `lifecycle_reconcile_failed_at` (set by
+    /// `record_reconcile_attempt`) has to keep it in the hourly sweep until
+    /// a retry actually succeeds, or its stale lifecycle rule would persist
+    /// in S3 indefinitely with nothing left to clear it.
+    #[tokio::test]
+    async fn sources_in_scope_includes_source_with_a_pending_reconcile_retry() {
+        use sea_orm::{ActiveModelTrait, ActiveValue::Set};
+
+        let test_db = match temps_database::test_utils::TestDatabase::with_migrations().await {
+            Ok(d) => d,
+            Err(e) => {
+                println!("TestDatabase unavailable, skipping: {e}");
+                return;
+            }
+        };
+        let db = test_db.db.clone();
+        let now = chrono::Utc::now();
+
+        let source = temps_entities::s3_sources::ActiveModel {
+            id: sea_orm::ActiveValue::NotSet,
+            name: Set("disabled-with-pending-retry".to_string()),
+            bucket_name: Set("disabled-with-pending-retry-bucket".to_string()),
+            bucket_path: Set("/".to_string()),
+            access_key_id: Set(String::new()),
+            secret_key: Set(String::new()),
+            session_token: Set(None),
+            credentials_expire_at: Set(None),
+            region: Set("us-east-1".to_string()),
+            endpoint: Set(None),
+            force_path_style: Set(Some(true)),
+            is_default: Set(false),
+            managed_by_cloud: Set(false),
+            lifecycle_reconcile_failed_at: Set(None),
+            created_at: Set(now),
+            updated_at: Set(now),
+        }
+        .insert(db.as_ref())
+        .await
+        .expect("insert source");
+
+        temps_entities::backup_schedules::ActiveModel {
+            id: sea_orm::ActiveValue::NotSet,
+            name: Set("disabled-sched".to_string()),
+            backup_type: Set("full".to_string()),
+            retention_period: Set(7),
+            s3_source_id: Set(source.id),
+            schedule_expression: Set("0 0 2 * * *".to_string()),
+            enabled: Set(false),
+            last_run: Set(None),
+            next_run: Set(None),
+            created_at: Set(now),
+            updated_at: Set(now),
+            description: Set(None),
+            tags: Set("[]".to_string()),
+            max_runtime_secs: Set(None),
+            target_all_services: Set(false),
+            include_control_plane: Set(true),
+        }
+        .insert(db.as_ref())
+        .await
+        .expect("insert disabled schedule");
+
+        // Simulate the bookkeeping `record_reconcile_attempt` performs when
+        // the disable-time fire-and-forget reconcile errors.
+        temps_entities::s3_sources::ActiveModel {
+            id: Set(source.id),
+            lifecycle_reconcile_failed_at: Set(Some(now)),
+            ..Default::default()
+        }
+        .update(db.as_ref())
+        .await
+        .expect("mark reconcile attempt as failed");
+
+        let encryption = Arc::new(temps_core::EncryptionService::new_from_password(
+            "test_encryption_key_1234567890ab",
+        ));
+        let svc = S3LifecycleService::new(db.clone(), encryption);
+
+        let in_scope_ids: std::collections::HashSet<i32> = svc
+            .sources_in_scope()
+            .await
+            .expect("sources_in_scope should succeed")
+            .into_iter()
+            .map(|s| s.id)
+            .collect();
+
+        assert!(
+            in_scope_ids.contains(&source.id),
+            "a source with a pending reconcile retry must stay in scope even with no enabled \
+             schedule, so the hourly sweep keeps retrying until it converges"
         );
     }
 }

--- a/crates/temps-cli/src/commands/backup.rs
+++ b/crates/temps-cli/src/commands/backup.rs
@@ -1788,6 +1788,7 @@ impl BackupCommand {
             force_path_style: Some(s3_credentials.force_path_style),
             is_default: false,
             managed_by_cloud: false,
+            lifecycle_reconcile_failed_at: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };

--- a/crates/temps-cli/src/commands/backup.rs
+++ b/crates/temps-cli/src/commands/backup.rs
@@ -1789,6 +1789,7 @@ impl BackupCommand {
             is_default: false,
             managed_by_cloud: false,
             lifecycle_reconcile_failed_at: None,
+            lifecycle_reconcile_generation: 0,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };

--- a/crates/temps-cloud-client/src/lib.rs
+++ b/crates/temps-cloud-client/src/lib.rs
@@ -1145,14 +1145,23 @@ async fn describe_failed_response(response: reqwest::Response) -> String {
     }
 }
 
+/// The subset of an RFC 7807 Problem Details body this client reads. Cloud's
+/// error responses may carry `type`/`title`/`instance`/extension fields too,
+/// but `detail` is the only one `managed_detail` surfaces — declaring just
+/// it (rather than parsing into `serde_json::Value`) checks the response
+/// actually has the expected shape instead of silently accepting anything.
+#[derive(serde::Deserialize)]
+struct ManagedProblemDetail {
+    detail: Option<String>,
+}
+
 /// Extract the RFC 7807 `detail` from a managed response body, if it has one.
 async fn managed_detail(response: reqwest::Response) -> Option<String> {
     let detail = response
-        .json::<serde_json::Value>()
+        .json::<ManagedProblemDetail>()
         .await
         .ok()?
-        .get("detail")?
-        .as_str()?
+        .detail?
         .trim()
         .to_string();
     (!detail.is_empty()).then_some(detail)

--- a/crates/temps-cloud-client/src/lib.rs
+++ b/crates/temps-cloud-client/src/lib.rs
@@ -446,7 +446,7 @@ impl CloudClient {
                     return decode_managed_response(response).await;
                 }
                 Ok(response) => {
-                    last_failure = Some(format!("managed backend returned {}", response.status()));
+                    last_failure = Some(describe_failed_response(response).await);
                 }
                 Err(error) => last_failure = Some(error.without_url().to_string()),
             }
@@ -757,7 +757,7 @@ impl CloudClient {
                     return decode_managed_response(response).await;
                 }
                 Ok(response) => {
-                    last_failure = Some(format!("managed backend returned {}", response.status()));
+                    last_failure = Some(describe_failed_response(response).await);
                 }
                 Err(error) => last_failure = Some(error.without_url().to_string()),
             }
@@ -1130,6 +1130,34 @@ async fn inspect_local_backup(path: &Path) -> Result<(u64, String), CloudError> 
     Ok((bytes, checksum_sha256))
 }
 
+/// Render a non-success response as an operator-readable reason, keeping the
+/// Problem Details `detail` Cloud sent with it.
+///
+/// A retryable status is not automatically an opaque one: Cloud answers a 503
+/// with a specific reason (which object storage call failed, for which key),
+/// and dropping it left a self-hosted operator with nothing but
+/// "returned 503 Service Unavailable" to debug a permanently stuck mirror.
+async fn describe_failed_response(response: reqwest::Response) -> String {
+    let status = response.status();
+    match managed_detail(response).await {
+        Some(detail) => format!("managed backend returned {status}: {detail}"),
+        None => format!("managed backend returned {status}"),
+    }
+}
+
+/// Extract the RFC 7807 `detail` from a managed response body, if it has one.
+async fn managed_detail(response: reqwest::Response) -> Option<String> {
+    let detail = response
+        .json::<serde_json::Value>()
+        .await
+        .ok()?
+        .get("detail")?
+        .as_str()?
+        .trim()
+        .to_string();
+    (!detail.is_empty()).then_some(detail)
+}
+
 async fn decode_managed_response<T: serde::de::DeserializeOwned>(
     response: reqwest::Response,
 ) -> Result<T, CloudError> {
@@ -1147,15 +1175,12 @@ async fn decode_managed_response<T: serde::de::DeserializeOwned>(
     }
     if matches!(status.as_u16(), 429 | 500..=599) {
         return Err(CloudError::Unreachable {
-            reason: format!("managed backend returned {status}"),
+            reason: describe_failed_response(response).await,
             spooled_bytes: 0,
         });
     }
-    let detail = response
-        .json::<serde_json::Value>()
+    let detail = managed_detail(response)
         .await
-        .ok()
-        .and_then(|value| value["detail"].as_str().map(str::to_string))
         .unwrap_or_else(|| format!("managed backend returned {status}"));
     Err(CloudError::Rejected { detail })
 }
@@ -1431,6 +1456,116 @@ mod tests {
                 .expect("notification source ids lock")
                 .as_slice(),
             [source_id, "stable-private-source-id".to_string()]
+        );
+    }
+
+    /// A retryable status is where Cloud puts its most operationally useful
+    /// reasons (which object-storage call failed, for which key). Dropping the
+    /// body left an operator staring at a bare "returned 503 Service
+    /// Unavailable" while a backup mirror retried for an hour.
+    #[tokio::test]
+    async fn an_exhausted_backup_retry_reports_the_reason_cloud_sent() {
+        let listener = match tokio::net::TcpListener::bind("127.0.0.1:0").await {
+            Ok(listener) => listener,
+            Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
+                eprintln!("skipping backup detail test: sandbox denied TCP bind");
+                return;
+            }
+            Err(error) => panic!("bind backup detail stub: {error}"),
+        };
+        let address = listener.local_addr().expect("backup detail stub address");
+        let app = Router::new().route(
+            "/v1/backups/walg/objects/complete",
+            post(|| async {
+                (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Json(json!({
+                        "title": "Backups Unavailable",
+                        "detail": "Backups are not configured: Object storage failed while \
+                                   inspect uploaded object for repository/base/00: provider \
+                                   returned HTTP 404 Not Found"
+                    })),
+                )
+            }),
+        );
+        tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("serve backup detail stub");
+        });
+        let client = CloudClient::new(
+            BackendUrl::loopback_development(&format!("http://{address}"))
+                .expect("loopback backup backend"),
+        )
+        .expect("cloud client");
+
+        let error = client
+            .complete_walg_object(
+                "instance-token",
+                &WalGObjectCompleted {
+                    backup_id: Uuid::new_v4(),
+                    relative_key: "repository/base/00".into(),
+                    bytes: 1,
+                    checksum_sha256: "0".repeat(64),
+                },
+            )
+            .await
+            .expect_err("a 503 on every attempt is a failure");
+
+        assert!(error.is_retryable(), "a 503 stays retryable: {error}");
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("provider returned HTTP 404 Not Found"),
+            "the operator must see Cloud's own reason, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("503"),
+            "the status still belongs in the message, got: {rendered}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_retryable_failure_without_a_body_still_names_the_status() {
+        let listener = match tokio::net::TcpListener::bind("127.0.0.1:0").await {
+            Ok(listener) => listener,
+            Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
+                eprintln!("skipping bodyless retry test: sandbox denied TCP bind");
+                return;
+            }
+            Err(error) => panic!("bind bodyless stub: {error}"),
+        };
+        let address = listener.local_addr().expect("bodyless stub address");
+        let app = Router::new().route(
+            "/v1/backups/walg/objects/complete",
+            post(|| async { StatusCode::BAD_GATEWAY }),
+        );
+        tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("serve bodyless stub");
+        });
+        let client = CloudClient::new(
+            BackendUrl::loopback_development(&format!("http://{address}"))
+                .expect("loopback bodyless backend"),
+        )
+        .expect("cloud client");
+
+        let error = client
+            .complete_walg_object(
+                "instance-token",
+                &WalGObjectCompleted {
+                    backup_id: Uuid::new_v4(),
+                    relative_key: "repository/base/00".into(),
+                    bytes: 1,
+                    checksum_sha256: "0".repeat(64),
+                },
+            )
+            .await
+            .expect_err("a 502 on every attempt is a failure");
+
+        assert!(
+            error.to_string().contains("502"),
+            "a body-less failure still names its status, got: {error}"
         );
     }
 

--- a/crates/temps-cloud/src/backup_mirror.rs
+++ b/crates/temps-cloud/src/backup_mirror.rs
@@ -2081,6 +2081,7 @@ mod tests {
             // Only Cloud-managed sources are mirror candidates.
             managed_by_cloud: Set(true),
             lifecycle_reconcile_failed_at: Set(None),
+            lifecycle_reconcile_generation: Set(0),
             created_at: Set(now),
             updated_at: Set(now),
         }
@@ -2231,6 +2232,7 @@ mod tests {
                 is_default: Set(false),
                 managed_by_cloud: Set(managed_by_cloud),
                 lifecycle_reconcile_failed_at: Set(None),
+                lifecycle_reconcile_generation: Set(0),
                 created_at: Set(now),
                 updated_at: Set(now),
             };
@@ -2641,6 +2643,7 @@ mod tests {
             is_default: false,
             managed_by_cloud: false,
             lifecycle_reconcile_failed_at: None,
+            lifecycle_reconcile_generation: 0,
             created_at: now,
             updated_at: now,
         };
@@ -2815,6 +2818,7 @@ mod tests {
             is_default: Set(true),
             managed_by_cloud: Set(true),
             lifecycle_reconcile_failed_at: Set(None),
+            lifecycle_reconcile_generation: Set(0),
             created_at: Set(now),
             updated_at: Set(now),
         }

--- a/crates/temps-cloud/src/backup_mirror.rs
+++ b/crates/temps-cloud/src/backup_mirror.rs
@@ -2080,6 +2080,7 @@ mod tests {
             is_default: Set(false),
             // Only Cloud-managed sources are mirror candidates.
             managed_by_cloud: Set(true),
+            lifecycle_reconcile_failed_at: Set(None),
             created_at: Set(now),
             updated_at: Set(now),
         }
@@ -2229,6 +2230,7 @@ mod tests {
                 force_path_style: Set(Some(true)),
                 is_default: Set(false),
                 managed_by_cloud: Set(managed_by_cloud),
+                lifecycle_reconcile_failed_at: Set(None),
                 created_at: Set(now),
                 updated_at: Set(now),
             };
@@ -2638,6 +2640,7 @@ mod tests {
             force_path_style: Some(true),
             is_default: false,
             managed_by_cloud: false,
+            lifecycle_reconcile_failed_at: None,
             created_at: now,
             updated_at: now,
         };
@@ -2811,6 +2814,7 @@ mod tests {
             // Cloud's bucket without the operator choosing a destination.
             is_default: Set(true),
             managed_by_cloud: Set(true),
+            lifecycle_reconcile_failed_at: Set(None),
             created_at: Set(now),
             updated_at: Set(now),
         }

--- a/crates/temps-cloud/src/service.rs
+++ b/crates/temps-cloud/src/service.rs
@@ -1246,6 +1246,7 @@ mod tests {
             is_default: true,
             managed_by_cloud: true,
             lifecycle_reconcile_failed_at: None,
+            lifecycle_reconcile_generation: 0,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         }

--- a/crates/temps-cloud/src/service.rs
+++ b/crates/temps-cloud/src/service.rs
@@ -1245,6 +1245,7 @@ mod tests {
             force_path_style: Some(false),
             is_default: true,
             managed_by_cloud: true,
+            lifecycle_reconcile_failed_at: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         }

--- a/crates/temps-entities/src/s3_sources.rs
+++ b/crates/temps-entities/src/s3_sources.rs
@@ -48,6 +48,14 @@ pub struct Model {
     /// disconnect cleanup path may remove one.
     #[sea_orm(default_value = false)]
     pub managed_by_cloud: bool,
+    /// When the last S3 lifecycle reconcile attempt for this source failed.
+    /// `None` means the most recent attempt succeeded (or none has run yet).
+    /// Set by [`crate` consumers, see `temps-backup`'s `S3LifecycleService`],
+    /// and consulted by `sources_in_scope` so a source stays in the hourly
+    /// sweep until a retry actually converges — even if its last backup
+    /// schedule was disabled in the same moment the failure happened, which
+    /// would otherwise strand a stale lifecycle rule in S3 forever.
+    pub lifecycle_reconcile_failed_at: Option<DBDateTime>,
     pub created_at: DBDateTime,
     pub updated_at: DBDateTime,
 }
@@ -277,6 +285,7 @@ pub async fn insert_encrypted<C: ConnectionTrait>(
         force_path_style: Set(credentials.force_path_style),
         is_default: Set(is_default),
         managed_by_cloud: Set(managed_by_cloud),
+        lifecycle_reconcile_failed_at: Set(None),
         created_at: Set(now),
         updated_at: Set(now),
     }
@@ -367,6 +376,7 @@ mod tests {
             force_path_style: Some(true),
             is_default: false,
             managed_by_cloud: false,
+            lifecycle_reconcile_failed_at: None,
             created_at: now,
             updated_at: now,
         }

--- a/crates/temps-entities/src/s3_sources.rs
+++ b/crates/temps-entities/src/s3_sources.rs
@@ -56,6 +56,13 @@ pub struct Model {
     /// schedule was disabled in the same moment the failure happened, which
     /// would otherwise strand a stale lifecycle rule in S3 forever.
     pub lifecycle_reconcile_failed_at: Option<DBDateTime>,
+    /// Monotonic counter bumped at the start of every reconcile attempt for
+    /// this source. Lets `S3LifecycleService::record_reconcile_attempt`
+    /// detect a stale write — an attempt that started before a newer one but
+    /// finishes after it — and drop it instead of clobbering the newer
+    /// attempt's outcome in `lifecycle_reconcile_failed_at`.
+    #[sea_orm(default_value = 0)]
+    pub lifecycle_reconcile_generation: i32,
     pub created_at: DBDateTime,
     pub updated_at: DBDateTime,
 }
@@ -286,6 +293,7 @@ pub async fn insert_encrypted<C: ConnectionTrait>(
         is_default: Set(is_default),
         managed_by_cloud: Set(managed_by_cloud),
         lifecycle_reconcile_failed_at: Set(None),
+        lifecycle_reconcile_generation: Set(0),
         created_at: Set(now),
         updated_at: Set(now),
     }
@@ -377,6 +385,7 @@ mod tests {
             is_default: false,
             managed_by_cloud: false,
             lifecycle_reconcile_failed_at: None,
+            lifecycle_reconcile_generation: 0,
             created_at: now,
             updated_at: now,
         }

--- a/crates/temps-migrations/src/migration/m20260904_000001_add_lifecycle_reconcile_failed_at_to_s3_sources.rs
+++ b/crates/temps-migrations/src/migration/m20260904_000001_add_lifecycle_reconcile_failed_at_to_s3_sources.rs
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Track a failed S3 lifecycle reconcile attempt so a source stays in the
+//! hourly sweep's scope until it converges.
+//!
+//! `S3LifecycleService::sources_in_scope` narrows the hourly sweep to
+//! sources with an enabled backup schedule (plus Cloud-managed ones), so
+//! that reconciling a bucket the operator never attached to Temps doesn't
+//! burn a paid S3 API call. But that scoping created a gap: if disabling a
+//! source's last schedule triggers an immediate reconcile and that reconcile
+//! hits a transient S3 error, the source drops out of the sweep's scope in
+//! the same moment its retry would have been needed, stranding a stale
+//! lifecycle rule in S3 with no other mechanism to clear it.
+//!
+//! `lifecycle_reconcile_failed_at` closes that gap: it's set whenever a
+//! reconcile attempt errors and cleared on the next success, and
+//! `sources_in_scope` includes any source where it's non-null regardless of
+//! schedule state — so a failed attempt keeps retrying hourly until it
+//! actually converges.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+        db.execute_unprepared(
+            "ALTER TABLE s3_sources \
+             ADD COLUMN IF NOT EXISTS lifecycle_reconcile_failed_at TIMESTAMPTZ",
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+        db.execute_unprepared(
+            "ALTER TABLE s3_sources DROP COLUMN IF EXISTS lifecycle_reconcile_failed_at",
+        )
+        .await?;
+        Ok(())
+    }
+}

--- a/crates/temps-migrations/src/migration/m20260904_000002_add_lifecycle_reconcile_generation_to_s3_sources.rs
+++ b/crates/temps-migrations/src/migration/m20260904_000002_add_lifecycle_reconcile_generation_to_s3_sources.rs
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Guard `lifecycle_reconcile_failed_at` against out-of-order concurrent
+//! writes.
+//!
+//! Two S3 lifecycle reconciles for the same source can overlap — an
+//! event-driven reconcile from an earlier schedule mutation and the hourly
+//! sweep, or two schedule mutations in quick succession — and finish out of
+//! start order. Without a way to detect that, whichever `UPDATE` lands last
+//! in wall-clock time wins even if it started first and saw stale state: an
+//! older attempt's success could clear a newer attempt's failure marker,
+//! silently dropping the source from every future retry.
+//!
+//! `lifecycle_reconcile_generation` is a monotonic counter bumped
+//! atomically at the start of every reconcile attempt
+//! (`S3LifecycleService::begin_reconcile_attempt`). The attempt's outcome is
+//! only written if the counter still matches what it read at the start
+//! (`record_reconcile_attempt`), so only the most-recently-*started*
+//! attempt's result can ever be persisted — an older attempt that finishes
+//! late has its write silently dropped instead of clobbering a newer one.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+        db.execute_unprepared(
+            "ALTER TABLE s3_sources \
+             ADD COLUMN IF NOT EXISTS lifecycle_reconcile_generation INTEGER NOT NULL DEFAULT 0",
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+        db.execute_unprepared(
+            "ALTER TABLE s3_sources DROP COLUMN IF EXISTS lifecycle_reconcile_generation",
+        )
+        .await?;
+        Ok(())
+    }
+}

--- a/crates/temps-migrations/src/migration/mod.rs
+++ b/crates/temps-migrations/src/migration/mod.rs
@@ -232,6 +232,7 @@ mod m20260903_000002_add_signal_group_to_write_intervals;
 mod m20260903_000003_add_cloud_analytics_write_mode;
 mod m20260903_000004_add_target_table_and_payload_row_to_outbox;
 mod m20260904_000001_add_lifecycle_reconcile_failed_at_to_s3_sources;
+mod m20260904_000002_add_lifecycle_reconcile_generation_to_s3_sources;
 
 pub struct Migrator;
 
@@ -512,6 +513,9 @@ impl MigratorTrait for Migrator {
             ),
             Box::new(
                 m20260904_000001_add_lifecycle_reconcile_failed_at_to_s3_sources::Migration,
+            ),
+            Box::new(
+                m20260904_000002_add_lifecycle_reconcile_generation_to_s3_sources::Migration,
             ),
         ]
     }

--- a/crates/temps-migrations/src/migration/mod.rs
+++ b/crates/temps-migrations/src/migration/mod.rs
@@ -231,6 +231,7 @@ mod m20260903_000001_generalize_cloud_telemetry_outbox;
 mod m20260903_000002_add_signal_group_to_write_intervals;
 mod m20260903_000003_add_cloud_analytics_write_mode;
 mod m20260903_000004_add_target_table_and_payload_row_to_outbox;
+mod m20260904_000001_add_lifecycle_reconcile_failed_at_to_s3_sources;
 
 pub struct Migrator;
 
@@ -508,6 +509,9 @@ impl MigratorTrait for Migrator {
             Box::new(m20260903_000003_add_cloud_analytics_write_mode::Migration),
             Box::new(
                 m20260903_000004_add_target_table_and_payload_row_to_outbox::Migration,
+            ),
+            Box::new(
+                m20260904_000001_add_lifecycle_reconcile_failed_at_to_s3_sources::Migration,
             ),
         ]
     }

--- a/crates/temps-providers/src/externalsvc/postgres.rs
+++ b/crates/temps-providers/src/externalsvc/postgres.rs
@@ -6377,6 +6377,7 @@ mod tests {
             is_default: false,
             managed_by_cloud: false,
             lifecycle_reconcile_failed_at: None,
+            lifecycle_reconcile_generation: 0,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };

--- a/crates/temps-providers/src/externalsvc/postgres.rs
+++ b/crates/temps-providers/src/externalsvc/postgres.rs
@@ -6376,6 +6376,7 @@ mod tests {
             force_path_style: Some(true),
             is_default: false,
             managed_by_cloud: false,
+            lifecycle_reconcile_failed_at: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };

--- a/crates/temps-providers/src/externalsvc/postgres_upgrade.rs
+++ b/crates/temps-providers/src/externalsvc/postgres_upgrade.rs
@@ -3783,6 +3783,7 @@ mod tests {
                     is_default: Set(true),
                     managed_by_cloud: Set(false),
                     lifecycle_reconcile_failed_at: Set(None),
+                    lifecycle_reconcile_generation: Set(0),
                     created_at: Set(now),
                     updated_at: Set(now),
                 }

--- a/crates/temps-providers/src/externalsvc/postgres_upgrade.rs
+++ b/crates/temps-providers/src/externalsvc/postgres_upgrade.rs
@@ -3782,6 +3782,7 @@ mod tests {
                     force_path_style: Set(Some(true)),
                     is_default: Set(true),
                     managed_by_cloud: Set(false),
+                    lifecycle_reconcile_failed_at: Set(None),
                     created_at: Set(now),
                     updated_at: Set(now),
                 }

--- a/crates/temps-providers/src/externalsvc/s3.rs
+++ b/crates/temps-providers/src/externalsvc/s3.rs
@@ -3430,6 +3430,7 @@ mod tests {
             is_default: false,
             managed_by_cloud: false,
             lifecycle_reconcile_failed_at: None,
+            lifecycle_reconcile_generation: 0,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };

--- a/crates/temps-providers/src/externalsvc/s3.rs
+++ b/crates/temps-providers/src/externalsvc/s3.rs
@@ -3429,6 +3429,7 @@ mod tests {
             force_path_style: Some(true),
             is_default: false,
             managed_by_cloud: false,
+            lifecycle_reconcile_failed_at: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };

--- a/crates/temps-providers/src/externalsvc/test_utils.rs
+++ b/crates/temps-providers/src/externalsvc/test_utils.rs
@@ -197,6 +197,7 @@ mod docker_utils {
                 force_path_style: Some(true),
                 is_default: false,
                 managed_by_cloud: false,
+                lifecycle_reconcile_failed_at: None,
                 created_at: chrono::Utc::now(),
                 updated_at: chrono::Utc::now(),
             };

--- a/crates/temps-providers/src/externalsvc/test_utils.rs
+++ b/crates/temps-providers/src/externalsvc/test_utils.rs
@@ -198,6 +198,7 @@ mod docker_utils {
                 is_default: false,
                 managed_by_cloud: false,
                 lifecycle_reconcile_failed_at: None,
+                lifecycle_reconcile_generation: 0,
                 created_at: chrono::Utc::now(),
                 updated_at: chrono::Utc::now(),
             };


### PR DESCRIPTION
## Summary
- The hourly S3 lifecycle drift reconciler walked every row in `s3_sources` and called `reconcile_bucket` on each, including buckets an operator configured with their own credentials but never attached to a Temps backup schedule — every tick made a paid `PutBucketLifecycleConfiguration`/`DeleteBucketLifecycle` call against infrastructure Temps was never asked to manage.
- Adds `S3LifecycleService::sources_in_scope()`, which scopes the sweep to sources with at least one enabled `backup_schedules` row or `managed_by_cloud = true`, and switches `plugin.rs`'s hourly sweep to use it.
- The existing event-driven reconciles on schedule create/update/delete already keep in-scope sources in sync. `disable_backup_schedule` and `enable_backup_schedule` were relying on the old unscoped hourly sweep as their only safety net for clearing/reapplying lifecycle rules — now that the sweep is scoped, they fire the same reconcile the other schedule mutations already do.

## Test plan
- [x] `cargo check --lib --tests -p temps-backup` — clean
- [x] `cargo clippy --lib --tests -p temps-backup -- -D warnings` — clean
- [x] `cargo fmt -p temps-backup -- --check` on touched files — clean
- [x] New unit test `sources_in_scope_excludes_unscheduled_operator_buckets` (real Postgres testcontainer) — passes
- [x] New end-to-end test `disable_and_enable_schedule_reconcile_s3_lifecycle_rules` (real MinIO + Postgres testcontainers) — passes, and was verified to actually fail when the fix is reverted
- [x] `python3 scripts/source_attribution.py check` — passes
- [x] security-auditor review — signed off