### PR TITLE
feat(web): make delete-confirmation name chip copyable

### DIFF
--- a/web/src/components/project/settings/GeneralSettings.tsx
+++ b/web/src/components/project/settings/GeneralSettings.tsx
@@ -18,6 +18,7 @@ import {
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
+import { ConfirmNameBadge } from '@/components/ui/confirm-name-badge'
 import {
   Card,
   CardContent,
@@ -358,11 +359,7 @@ export function GeneralSettings({ project, refetch }: GeneralSettingsProps) {
             </AlertDialogHeader>
             <div className="space-y-2">
               <Label htmlFor="confirm-delete-project-name">
-                Type{' '}
-                <span className="font-mono font-semibold text-foreground">
-                  {project?.name}
-                </span>{' '}
-                to confirm
+                Type <ConfirmNameBadge value={project?.name ?? ''} /> to confirm
               </Label>
               <Input
                 id="confirm-delete-project-name"

--- a/web/src/components/storage/DeleteServiceButton.tsx
+++ b/web/src/components/storage/DeleteServiceButton.tsx
@@ -14,6 +14,7 @@ import {
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
+import { ConfirmNameBadge } from '@/components/ui/confirm-name-badge'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
@@ -98,11 +99,7 @@ export function DeleteServiceButton({
         </AlertDialogHeader>
         <div className="space-y-2">
           <Label htmlFor="confirm-service-name">
-            Type{' '}
-            <span className="font-mono font-semibold text-foreground">
-              {serviceName}
-            </span>{' '}
-            to confirm
+            Type <ConfirmNameBadge value={serviceName} /> to confirm
           </Label>
           <Input
             id="confirm-service-name"

--- a/web/src/components/ui/confirm-name-badge.tsx
+++ b/web/src/components/ui/confirm-name-badge.tsx
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+import { CopyButton } from '@/components/ui/copy-button'
+
+interface ConfirmNameBadgeProps {
+  value: string
+}
+
+/**
+ * Renders a resource name as a clickable chip for "type X to confirm"
+ * destructive-action prompts, so the user can copy it instead of retyping
+ * it by hand. Rectangular rather than the pill-shaped `Badge`, and dashed,
+ * so it reads as a copy affordance rather than a status tag.
+ */
+export function ConfirmNameBadge({ value }: ConfirmNameBadgeProps) {
+  return (
+    <CopyButton
+      value={value}
+      label={`Copy "${value}"`}
+      className="mx-1 inline-flex items-center gap-1.5 rounded-md border border-dashed border-input bg-muted/40 px-2 py-0.5 align-middle font-mono font-semibold text-foreground hover:border-solid"
+    >
+      {value}
+    </CopyButton>
+  )
+}

--- a/web/src/pages/ServiceDetail.tsx
+++ b/web/src/pages/ServiceDetail.tsx
@@ -63,6 +63,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover'
+import { ConfirmNameBadge } from '@/components/ui/confirm-name-badge'
 import { CopyButton } from '@/components/ui/copy-button'
 import { EnvVariablesDisplay } from '@/components/ui/env-variables-display'
 import { Input } from '@/components/ui/input'
@@ -1819,11 +1820,7 @@ export function ServiceDetail() {
           </DialogHeader>
           <div className="space-y-2">
             <Label htmlFor="confirm-delete-service-name">
-              Type{' '}
-              <span className="font-mono font-semibold text-foreground">
-                {service.service.name}
-              </span>{' '}
-              to confirm
+              Type <ConfirmNameBadge value={service.service.name} /> to confirm
             </Label>
             <Input
               id="confirm-delete-service-name"


### PR DESCRIPTION
## Summary
- Renders the resource name in "type X to confirm" delete dialogs (project delete, service delete, storage service delete) as a rectangular, dashed-border chip with a copy icon instead of plain styled text.
- Uses the existing `CopyButton` primitive (no new clipboard handling) so the user can click the chip to copy the exact name instead of retyping it.
- Adds a small shared `ConfirmNameBadge` component since the same markup was duplicated identically across the three dialogs.

## Test plan
- [x] `tsc --noEmit` passes on the touched files
- [x] `eslint` clean on the touched files (pre-existing unrelated warnings left untouched)
- [x] `python3 scripts/source_attribution.py check` passes
- [x] Visually verified the chip renders as a rectangular dashed badge with the copy icon, matching the intended UX