### PR TITLE
fix(cloud): route pg_dump-fallback Postgres backups to native mirror, not WAL-G

### DIFF
--- a/crates/temps-cloud-client/src/lib.rs
+++ b/crates/temps-cloud-client/src/lib.rs
@@ -446,7 +446,7 @@ impl CloudClient {
                     return decode_managed_response(response).await;
                 }
                 Ok(response) => {
-                    last_failure = Some(format!("managed backend returned {}", response.status()));
+                    last_failure = Some(describe_failed_response(response).await);
                 }
                 Err(error) => last_failure = Some(error.without_url().to_string()),
             }
@@ -757,7 +757,7 @@ impl CloudClient {
                     return decode_managed_response(response).await;
                 }
                 Ok(response) => {
-                    last_failure = Some(format!("managed backend returned {}", response.status()));
+                    last_failure = Some(describe_failed_response(response).await);
                 }
                 Err(error) => last_failure = Some(error.without_url().to_string()),
             }
@@ -1130,6 +1130,34 @@ async fn inspect_local_backup(path: &Path) -> Result<(u64, String), CloudError> 
     Ok((bytes, checksum_sha256))
 }
 
+/// Render a non-success response as an operator-readable reason, keeping the
+/// Problem Details `detail` Cloud sent with it.
+///
+/// A retryable status is not automatically an opaque one: Cloud answers a 503
+/// with a specific reason (which object storage call failed, for which key),
+/// and dropping it left a self-hosted operator with nothing but
+/// "returned 503 Service Unavailable" to debug a permanently stuck mirror.
+async fn describe_failed_response(response: reqwest::Response) -> String {
+    let status = response.status();
+    match managed_detail(response).await {
+        Some(detail) => format!("managed backend returned {status}: {detail}"),
+        None => format!("managed backend returned {status}"),
+    }
+}
+
+/// Extract the RFC 7807 `detail` from a managed response body, if it has one.
+async fn managed_detail(response: reqwest::Response) -> Option<String> {
+    let detail = response
+        .json::<serde_json::Value>()
+        .await
+        .ok()?
+        .get("detail")?
+        .as_str()?
+        .trim()
+        .to_string();
+    (!detail.is_empty()).then_some(detail)
+}
+
 async fn decode_managed_response<T: serde::de::DeserializeOwned>(
     response: reqwest::Response,
 ) -> Result<T, CloudError> {
@@ -1147,15 +1175,12 @@ async fn decode_managed_response<T: serde::de::DeserializeOwned>(
     }
     if matches!(status.as_u16(), 429 | 500..=599) {
         return Err(CloudError::Unreachable {
-            reason: format!("managed backend returned {status}"),
+            reason: describe_failed_response(response).await,
             spooled_bytes: 0,
         });
     }
-    let detail = response
-        .json::<serde_json::Value>()
+    let detail = managed_detail(response)
         .await
-        .ok()
-        .and_then(|value| value["detail"].as_str().map(str::to_string))
         .unwrap_or_else(|| format!("managed backend returned {status}"));
     Err(CloudError::Rejected { detail })
 }
@@ -1431,6 +1456,116 @@ mod tests {
                 .expect("notification source ids lock")
                 .as_slice(),
             [source_id, "stable-private-source-id".to_string()]
+        );
+    }
+
+    /// A retryable status is where Cloud puts its most operationally useful
+    /// reasons (which object-storage call failed, for which key). Dropping the
+    /// body left an operator staring at a bare "returned 503 Service
+    /// Unavailable" while a backup mirror retried for an hour.
+    #[tokio::test]
+    async fn an_exhausted_backup_retry_reports_the_reason_cloud_sent() {
+        let listener = match tokio::net::TcpListener::bind("127.0.0.1:0").await {
+            Ok(listener) => listener,
+            Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
+                eprintln!("skipping backup detail test: sandbox denied TCP bind");
+                return;
+            }
+            Err(error) => panic!("bind backup detail stub: {error}"),
+        };
+        let address = listener.local_addr().expect("backup detail stub address");
+        let app = Router::new().route(
+            "/v1/backups/walg/objects/complete",
+            post(|| async {
+                (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Json(json!({
+                        "title": "Backups Unavailable",
+                        "detail": "Backups are not configured: Object storage failed while \
+                                   inspect uploaded object for repository/base/00: provider \
+                                   returned HTTP 404 Not Found"
+                    })),
+                )
+            }),
+        );
+        tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("serve backup detail stub");
+        });
+        let client = CloudClient::new(
+            BackendUrl::loopback_development(&format!("http://{address}"))
+                .expect("loopback backup backend"),
+        )
+        .expect("cloud client");
+
+        let error = client
+            .complete_walg_object(
+                "instance-token",
+                &WalGObjectCompleted {
+                    backup_id: Uuid::new_v4(),
+                    relative_key: "repository/base/00".into(),
+                    bytes: 1,
+                    checksum_sha256: "0".repeat(64),
+                },
+            )
+            .await
+            .expect_err("a 503 on every attempt is a failure");
+
+        assert!(error.is_retryable(), "a 503 stays retryable: {error}");
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("provider returned HTTP 404 Not Found"),
+            "the operator must see Cloud's own reason, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("503"),
+            "the status still belongs in the message, got: {rendered}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_retryable_failure_without_a_body_still_names_the_status() {
+        let listener = match tokio::net::TcpListener::bind("127.0.0.1:0").await {
+            Ok(listener) => listener,
+            Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
+                eprintln!("skipping bodyless retry test: sandbox denied TCP bind");
+                return;
+            }
+            Err(error) => panic!("bind bodyless stub: {error}"),
+        };
+        let address = listener.local_addr().expect("bodyless stub address");
+        let app = Router::new().route(
+            "/v1/backups/walg/objects/complete",
+            post(|| async { StatusCode::BAD_GATEWAY }),
+        );
+        tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("serve bodyless stub");
+        });
+        let client = CloudClient::new(
+            BackendUrl::loopback_development(&format!("http://{address}"))
+                .expect("loopback bodyless backend"),
+        )
+        .expect("cloud client");
+
+        let error = client
+            .complete_walg_object(
+                "instance-token",
+                &WalGObjectCompleted {
+                    backup_id: Uuid::new_v4(),
+                    relative_key: "repository/base/00".into(),
+                    bytes: 1,
+                    checksum_sha256: "0".repeat(64),
+                },
+            )
+            .await
+            .expect_err("a 502 on every attempt is a failure");
+
+        assert!(
+            error.to_string().contains("502"),
+            "a body-less failure still names its status, got: {error}"
         );
     }
 

--- a/crates/temps-cloud/src/backup_mirror.rs
+++ b/crates/temps-cloud/src/backup_mirror.rs
@@ -593,6 +593,21 @@ async fn mirror_backup(
     };
     let service = resources.service(external.service_id)?;
     match service.service_type.to_ascii_lowercase().as_str() {
+        // Postgres/Timescale falls back from `postgres_walg` to `postgres_pgdump`
+        // whenever the container doesn't have wal-g in it (`container_has_walg`
+        // in temps-backup's engine dispatch, e.g. a custom image supplied via
+        // `TEMPS_ALLOWED_POSTGRES_DOCKER_IMAGES`). A pg_dump-produced backup has
+        // no WAL-G sentinel and never will, so routing it into
+        // `mirror_walg_backup` doesn't just fail once — it retries forever
+        // against a gate it can structurally never satisfy. `backups.metadata`
+        // records which engine actually ran (set at row-creation time in
+        // temps-backup's `services/backup.rs`), so check that before committing
+        // to a mirror path.
+        "postgres" | "postgresql" | "timescale" | "timescaledb"
+            if backup_engine_key(&backup.metadata).as_deref() == Some("postgres_pgdump") =>
+        {
+            mirror_native_backup(link, resources, backup, &external, &service, instance_id).await
+        }
         "postgres" | "postgresql" | "timescale" | "timescaledb" => {
             mirror_walg_backup(link, resources, backup, Some(external), instance_id).await
         }
@@ -603,6 +618,19 @@ async fn mirror_backup(
             "Cloud backup mirroring does not support engine {engine}"
         ))),
     }
+}
+
+/// The engine key `temps-backup` recorded on `backups.metadata` when it
+/// created this row (`{"engine": "postgres_walg" | "postgres_pgdump" | ...}`).
+/// Malformed or pre-dispatch-key legacy metadata yields `None`, which callers
+/// treat as "assume WAL-G" — the only engine that existed before Postgres
+/// backups could fall back to pg_dump.
+fn backup_engine_key(metadata: &str) -> Option<String> {
+    serde_json::from_str::<serde_json::Value>(metadata)
+        .ok()?
+        .get("engine")?
+        .as_str()
+        .map(str::to_owned)
 }
 
 fn supports_native_mirror(service_type: &str) -> bool {
@@ -767,6 +795,54 @@ async fn mirror_native_backup(
                     backup_name,
                     binlog_file,
                     binlog_position,
+                },
+            )
+        }
+        "postgres" | "postgresql" | "timescale" | "timescaledb" => {
+            // pg_dump writes exactly two objects, siblings under one date/uuid
+            // directory: the dump itself (`location_key`, already the exact
+            // object key `postgres_pgdump.rs` uploaded via
+            // `build_external_service_s3_key`) and a `metadata.json` sidecar
+            // next to it (`v2_common::derive_metadata_key`: same parent,
+            // filename replaced). Unlike the RustFS arm below, the sidecar is
+            // included and declared with `Metadata` kind (auto-detected by the
+            // `.../metadata.json` suffix check further down) — pg_dump's
+            // restore needs it, the same way MariaDB's physical snapshot needs
+            // its own metadata sidecar for binlog position.
+            let root = location_key
+                .rsplit_once('/')
+                .map(|(parent, _)| parent.to_string())
+                .ok_or_else(|| {
+                    StageError::Unsupported(format!(
+                        "pg_dump snapshot location {location_key} has no parent directory"
+                    ))
+                })?;
+            let metadata_key = format!("{root}/metadata.json");
+            let all = resources
+                .list_repository(backup.s3_source_id, &source_config.bucket_name, &root)
+                .await?;
+            let selected = all
+                .iter()
+                .filter(|object| object.key == location_key || object.key == metadata_key)
+                .cloned()
+                .collect::<Vec<_>>();
+            if selected.len() < 2 || !selected.iter().any(|object| object.key == metadata_key) {
+                return Err(StageError::Retry(format!(
+                    "pg_dump snapshot {location_key} is incomplete or lacks {metadata_key}"
+                )));
+            }
+            let engine = match service_type.as_str() {
+                "postgres" | "postgresql" => BackupEngine::Postgres,
+                _ => BackupEngine::TimescaleDb,
+            };
+            (
+                root,
+                selected,
+                engine,
+                BackupFormat::PgDumpPlain,
+                BackupCompression::Gzip,
+                NativeSnapshotIdentity::ObjectSet {
+                    snapshot_name: backup.backup_id.clone(),
                 },
             )
         }
@@ -1964,13 +2040,13 @@ fn deferred_legacy_state(metadata: &str, tenant_id: Uuid) -> Option<LegacyMirror
 #[cfg(test)]
 mod tests {
     use super::{
-        append_source_object, contains_backup_identity, deferred_legacy_state,
+        append_source_object, backup_engine_key, contains_backup_identity, deferred_legacy_state,
         ensure_json_object_size, image_tag_version, manifest_digest, merge_mirror_state,
-        next_sweep_interval, parse_postgres_major, run, s3_key, select_due_backups, sentinel_lsn,
-        supports_native_mirror, sweep, timeline_from_backup_name, upload_native_object,
-        wal_segment_name, wal_segment_of, walg_root_key, SourceObject, StageError, SweepOutcome,
-        BASE_SWEEP_INTERVAL, DISCOVER_BACKUPS_SQL, DUE_BACKUPS_SQL, MAX_SWEEP_INTERVAL,
-        MIRROR_STATE_VERSION,
+        mirror_backup, next_sweep_interval, parse_postgres_major, run, s3_key, select_due_backups,
+        sentinel_lsn, supports_native_mirror, sweep, timeline_from_backup_name,
+        upload_native_object, wal_segment_name, wal_segment_of, walg_root_key, SourceObject,
+        StageError, SweepOutcome, BASE_SWEEP_INTERVAL, DISCOVER_BACKUPS_SQL, DUE_BACKUPS_SQL,
+        MAX_SWEEP_INTERVAL, MIRROR_STATE_VERSION,
     };
     use std::{
         collections::HashMap,
@@ -2954,6 +3030,200 @@ mod tests {
             .await
             .expect("mirror loop stops promptly on cancellation, not at the next tick")
             .expect("mirror loop does not panic");
+    }
+
+    #[test]
+    fn backup_engine_key_reads_the_dispatch_resolved_engine() {
+        assert_eq!(
+            backup_engine_key(r#"{"engine":"postgres_pgdump","other":1}"#).as_deref(),
+            Some("postgres_pgdump")
+        );
+        assert_eq!(
+            backup_engine_key(r#"{"engine":"postgres_walg"}"#).as_deref(),
+            Some("postgres_walg")
+        );
+        assert_eq!(backup_engine_key("{}"), None, "no engine key recorded");
+        assert_eq!(backup_engine_key("not json"), None, "malformed metadata");
+        assert_eq!(
+            backup_engine_key(r#"{"engine":42}"#),
+            None,
+            "non-string engine value"
+        );
+    }
+
+    /// A Postgres backup whose `backups.metadata.engine` reads
+    /// `"postgres_pgdump"` — the container had no wal-g in it, so
+    /// `temps-backup`'s dispatch fell back from `postgres_walg` at backup
+    /// time (`crates/temps-backup/src/engines/dispatch.rs`). Its S3 location
+    /// is therefore never a WAL-G repository and it never carries a
+    /// `_backup_stop_sentinel.json`.
+    ///
+    /// `mirror_backup` must recognize the recorded engine and route into
+    /// `mirror_native_backup` instead of `mirror_walg_backup`. Routed
+    /// correctly, dispatch reaches `mirror_native_backup`'s own S3 listing
+    /// call, which fails against the closed loopback source with a
+    /// *transient* `StageError::Retry` (connection refused). Routed
+    /// incorrectly — the bug this regression test guards against —
+    /// `mirror_walg_backup` rejects the location synchronously, with no I/O
+    /// at all, as a *permanent* `StageError::Unsupported("... is not a WAL-G
+    /// repository ...")`. The two failure shapes are distinguishable without
+    /// a working S3 backend, so this test needs no stub server.
+    #[tokio::test]
+    async fn postgres_backups_recorded_as_pgdump_route_to_native_mirror_not_walg() {
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("in-memory SQLite connects");
+        let backend = db.get_database_backend();
+        let schema = Schema::new(backend);
+        for statement in [
+            schema.create_table_from_entity(temps_entities::backups::Entity),
+            schema.create_table_from_entity(temps_entities::s3_sources::Entity),
+            schema.create_table_from_entity(temps_entities::external_service_backups::Entity),
+            schema.create_table_from_entity(temps_entities::external_services::Entity),
+        ] {
+            db.execute(backend.build(&statement))
+                .await
+                .expect("SQLite fixture table creates");
+        }
+        db.execute_unprepared("PRAGMA foreign_keys = OFF")
+            .await
+            .expect("SQLite fixture disables unrelated foreign keys");
+
+        let encryption = temps_core::EncryptionService::new_from_password("pgdump-dispatch-test");
+        let now = chrono::Utc::now();
+        temps_entities::s3_sources::ActiveModel {
+            id: Set(1),
+            name: Set("Temps Cloud managed backups".to_owned()),
+            bucket_name: Set("managed-bucket".to_owned()),
+            region: Set("test-1".to_owned()),
+            // A closed loopback port: any S3 call this test reaches fails
+            // fast with connection-refused instead of hanging or reaching
+            // real AWS, per the convention documented on `linked_link_fixture`.
+            endpoint: Set(Some("http://127.0.0.1:1".to_owned())),
+            bucket_path: Set(String::new()),
+            access_key_id: Set(encryption
+                .encrypt_string("test-access-key")
+                .expect("encrypt fixture access key")),
+            secret_key: Set(encryption
+                .encrypt_string("test-secret-key")
+                .expect("encrypt fixture secret key")),
+            session_token: Set(None),
+            credentials_expire_at: Set(None),
+            force_path_style: Set(Some(true)),
+            is_default: Set(true),
+            managed_by_cloud: Set(true),
+            created_at: Set(now),
+            updated_at: Set(now),
+        }
+        .insert(&db)
+        .await
+        .expect("S3 source inserts");
+        temps_entities::external_services::Model {
+            id: 1,
+            name: "postgres".to_owned(),
+            service_type: "postgres".to_owned(),
+            version: Some("17".to_owned()),
+            status: "running".to_owned(),
+            created_at: now,
+            updated_at: now,
+            slug: None,
+            config: None,
+            node_id: None,
+            topology: "standalone".to_owned(),
+            error_message: None,
+            health_status: None,
+            last_health_check_at: None,
+            last_health_error: None,
+            consecutive_health_failures: 0,
+            health_metadata: None,
+            metrics_enabled: false,
+            default_backup_provisioned: false,
+            container_name: None,
+            ai_data_access: false,
+            created_by_user_id: None,
+        }
+        .into_active_model()
+        .insert(&db)
+        .await
+        .expect("external service inserts");
+        let backup_uuid = Uuid::new_v4().to_string();
+        let s3_location = format!(
+            "s3://managed-bucket/external_services/postgres/postgres/2026/09/04/{backup_uuid}/dump.sql.gz"
+        );
+        temps_entities::external_service_backups::Model {
+            id: 1,
+            service_id: 1,
+            backup_id: 1,
+            backup_type: "full".to_owned(),
+            state: "completed".to_owned(),
+            started_at: now,
+            finished_at: Some(now),
+            size_bytes: Some(1),
+            s3_location: s3_location.clone(),
+            error_message: None,
+            metadata: serde_json::json!({}),
+            checksum: None,
+            compression_type: "gzip".to_owned(),
+            created_by: 1,
+            expires_at: None,
+        }
+        .into_active_model()
+        .insert(&db)
+        .await
+        .expect("external service backup inserts");
+        let backup = temps_entities::backups::ActiveModel {
+            id: Set(1),
+            name: Set("pgdump-fallback-backup".to_owned()),
+            backup_id: Set(backup_uuid),
+            schedule_id: Set(None),
+            backup_type: Set("full".to_owned()),
+            state: Set("completed".to_owned()),
+            started_at: Set(now),
+            finished_at: Set(Some(now)),
+            size_bytes: Set(Some(1)),
+            file_count: Set(Some(1)),
+            s3_source_id: Set(1),
+            s3_location: Set(s3_location),
+            error_message: Set(None),
+            metadata: Set(serde_json::json!({"engine": "postgres_pgdump"}).to_string()),
+            checksum: Set(None),
+            compression_type: Set("gzip".to_owned()),
+            created_by: Set(1),
+            expires_at: Set(None),
+            tags: Set("[]".to_owned()),
+            schedule_run_id: Set(None),
+        }
+        .insert(&db)
+        .await
+        .expect("pg_dump-fallback backup inserts");
+
+        let temp = tempfile::tempdir().expect("cloud-link state dir");
+        let link = linked_link_fixture(&temp);
+        let instance_id = link.instance_id().expect("linked instance id");
+        let mut resources =
+            super::SweepResources::load(&db, &encryption, std::slice::from_ref(&backup))
+                .await
+                .expect("resources load");
+
+        let error = mirror_backup(&link, &mut resources, &backup, instance_id)
+            .await
+            .expect_err("closed loopback source can never actually mirror in this test");
+        match error {
+            // `mirror_native_backup` reached its own repository-listing S3
+            // call and failed there (connection refused). The shared listing
+            // helper's error text says "WAL-G repository" regardless of which
+            // engine called it (RustFS and MariaDB hit the same string) — it
+            // is not evidence of taking the WAL-G *path*, only of the
+            // listing helper's generic naming, so this is exactly the
+            // "correctly routed, failed on unreachable S3" outcome under test.
+            StageError::Retry(_) => {}
+            StageError::Unsupported(reason) => panic!(
+                "pg_dump-tagged backup was rejected instead of routed to native mirroring \
+                 (this is the exact bug under test — dispatch fell through to WAL-G's synchronous \
+                 \"not a WAL-G repository\" check, which runs before any I/O and can only produce \
+                 Unsupported, never Retry): {reason}"
+            ),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `mirror_backup` routed every Postgres/Timescale backup into the WAL-G-only mirror path (`mirror_walg_backup`) regardless of which engine actually produced it. Postgres backups fall back from `postgres_walg` to `postgres_pgdump` whenever the container has no wal-g in it — those backups have no WAL-G sentinel and never will, so they retried forever against a gate that could never be satisfied and silently never appeared in Cloud's backup catalog.
- `mirror_backup` now reads the engine `temps-backup` already recorded on `backups.metadata` at backup-creation time, and routes `postgres_pgdump`-tagged backups into `mirror_native_backup` instead, reusing the exact same declare/upload/complete protocol already used by the MariaDB/RustFS arms in that function.
- Security-auditor reviewed the diff (metadata-trust boundary, path/bucket-confusion risk of the new listing arm, test hygiene) — no findings.

## Test plan
- [x] `cargo test --lib -p temps-cloud backup_mirror` — 30/30 pass, including two new tests: a pure unit test for the new `backup_engine_key` discriminator, and a regression test proving a `postgres_pgdump`-tagged backup reaches `mirror_native_backup` (not `mirror_walg_backup`) by distinguishing the two mirror paths' failure shapes against a closed loopback S3 endpoint.
- [x] `cargo check --lib --tests -p temps-cloud`
- [x] `cargo clippy --lib --tests -p temps-cloud -- -D warnings` (via the resolved `cargo` binary directly, not rtk)
- [x] `python3 scripts/source_attribution.py check`