### PR TITLE
fix(services): preserve template and monitor ownership

### DIFF
--- a/crates/temps-migrations/src/migration/m20260831_000002_add_managed_status_monitors.rs
+++ b/crates/temps-migrations/src/migration/m20260831_000002_add_managed_status_monitors.rs
@@ -23,25 +23,10 @@ impl MigrationTrait for Migration {
             )
             .await?;
 
-        // Before provenance existed, automatic monitors were created with this
-        // deterministic name. Backfill only that exact convention; all other
-        // monitors remain user-managed and will never be rewritten by deploys.
-        manager
-            .get_connection()
-            .execute_unprepared(
-                "UPDATE status_monitors AS monitor \
-                 SET is_managed = TRUE \
-                 FROM environments AS environment \
-                 WHERE monitor.environment_id = environment.id \
-                   AND monitor.name = environment.name || ' Monitor' \
-                   AND monitor.id = ( \
-                       SELECT MIN(candidate.id) \
-                       FROM status_monitors AS candidate \
-                       WHERE candidate.environment_id = environment.id \
-                         AND candidate.name = environment.name || ' Monitor' \
-                   )",
-            )
-            .await?;
+        // Existing rows have no durable provenance. Their names and runtime
+        // settings were always user-editable, so none can safely be claimed as
+        // platform-managed during migration. The next deployment creates a
+        // separate managed monitor while preserving every existing monitor.
         manager
             .get_connection()
             .execute_unprepared(

--- a/crates/temps-migrations/src/migration/m20260904_000001_reset_ambiguous_managed_status_monitors.rs
+++ b/crates/temps-migrations/src/migration/m20260904_000001_reset_ambiguous_managed_status_monitors.rs
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // The first shipped version of the managed-monitor migration inferred
+        // ownership from an editable monitor name. There is no durable field
+        // that can distinguish those user monitors from monitors created by
+        // Temps during the affected window. Resetting ownership is the only
+        // non-destructive correction: a later deployment creates a new,
+        // explicitly managed monitor while every existing monitor is preserved.
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "CREATE TABLE _temps_m20260904_managed_monitor_ownership_backup (\
+                     monitor_id INTEGER PRIMARY KEY \
+                         REFERENCES status_monitors(id) ON DELETE CASCADE\
+                 ); \
+                 INSERT INTO _temps_m20260904_managed_monitor_ownership_backup (monitor_id) \
+                 SELECT id FROM status_monitors WHERE is_managed = TRUE; \
+                 UPDATE status_monitors SET is_managed = FALSE WHERE is_managed = TRUE",
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Restore exactly the ownership state captured by up(). If the
+        // application created a replacement managed monitor in the meantime,
+        // demote it first within only the affected environment so the partial
+        // unique index remains valid.
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "UPDATE status_monitors AS current \
+                 SET is_managed = FALSE \
+                 WHERE current.is_managed = TRUE \
+                   AND EXISTS ( \
+                       SELECT 1 \
+                       FROM _temps_m20260904_managed_monitor_ownership_backup AS backup \
+                       JOIN status_monitors AS original ON original.id = backup.monitor_id \
+                       WHERE original.environment_id = current.environment_id \
+                   ); \
+                 UPDATE status_monitors AS monitor \
+                 SET is_managed = TRUE \
+                 FROM _temps_m20260904_managed_monitor_ownership_backup AS backup \
+                 WHERE monitor.id = backup.monitor_id; \
+                 DROP TABLE _temps_m20260904_managed_monitor_ownership_backup",
+            )
+            .await?;
+
+        Ok(())
+    }
+}

--- a/crates/temps-migrations/src/migration/mod.rs
+++ b/crates/temps-migrations/src/migration/mod.rs
@@ -219,6 +219,7 @@ mod m20260831_000002_backfill_acme_verification_method;
 mod m20260902_000001_backup_safety_and_provenance;
 mod m20260903_000001_add_service_project_identity;
 mod m20260903_000001_add_vulnerability_scanning_enabled_to_projects;
+mod m20260904_000001_reset_ambiguous_managed_status_monitors;
 
 pub struct Migrator;
 
@@ -481,6 +482,7 @@ impl MigratorTrait for Migrator {
             ),
             Box::new(m20260831_000002_add_managed_status_monitors::Migration),
             Box::new(m20260903_000001_add_service_project_identity::Migration),
+            Box::new(m20260904_000001_reset_ambiguous_managed_status_monitors::Migration),
         ]
     }
 }
@@ -523,6 +525,10 @@ mod registry_tests {
             (
                 "m20260831_000002_add_managed_status_monitors",
                 "m20260903_000001_add_service_project_identity",
+            ),
+            (
+                "m20260903_000001_add_service_project_identity",
+                "m20260904_000001_reset_ambiguous_managed_status_monitors",
             ),
         ] {
             let shipped_position = names

--- a/crates/temps-migrations/tests/migration_tests.rs
+++ b/crates/temps-migrations/tests/migration_tests.rs
@@ -295,7 +295,8 @@ async fn test_service_project_identity_migration_defaults_down_and_reup() -> any
 }
 
 #[tokio::test]
-async fn test_managed_monitor_migration_backfill_uniqueness_down_and_reup() -> anyhow::Result<()> {
+async fn test_managed_monitor_migration_preserves_ownership_uniqueness_down_and_reup(
+) -> anyhow::Result<()> {
     if external_db_configured() {
         println!("Skipping managed-monitor migration test: external database configured");
         return Ok(());
@@ -374,7 +375,18 @@ async fn test_managed_monitor_migration_backfill_uniqueness_down_and_reup() -> a
     assert_eq!(rows[0].try_get::<String>("", "name")?, "Custom readiness");
     assert!(!rows[0].try_get::<bool>("", "is_managed")?);
     assert_eq!(rows[1].try_get::<String>("", "name")?, "production Monitor");
-    assert!(rows[1].try_get::<bool>("", "is_managed")?);
+    assert!(
+        !rows[1].try_get::<bool>("", "is_managed")?,
+        "an ordinary user-editable name is not durable ownership provenance"
+    );
+
+    db.execute_unprepared(
+        "INSERT INTO status_monitors \
+         (project_id, environment_id, name, monitor_type, check_interval_seconds, is_active, is_managed, created_at, updated_at) \
+         SELECT project_id, id, 'Temps managed', 'web', 60, true, true, now(), now() FROM environments \
+         WHERE subdomain = 'monitor-test-production'",
+    )
+    .await?;
 
     let duplicate = db
         .execute_unprepared(

--- a/crates/temps-migrations/tests/migration_tests.rs
+++ b/crates/temps-migrations/tests/migration_tests.rs
@@ -295,8 +295,7 @@ async fn test_service_project_identity_migration_defaults_down_and_reup() -> any
 }
 
 #[tokio::test]
-async fn test_managed_monitor_migration_preserves_ownership_uniqueness_down_and_reup(
-) -> anyhow::Result<()> {
+async fn test_managed_monitor_migrations_preserve_and_repair_ownership() -> anyhow::Result<()> {
     if external_db_configured() {
         println!("Skipping managed-monitor migration test: external database configured");
         return Ok(());
@@ -380,6 +379,11 @@ async fn test_managed_monitor_migration_preserves_ownership_uniqueness_down_and_
         "an ordinary user-editable name is not durable ownership provenance"
     );
 
+    Migrator::down(&db, Some(1)).await?;
+    assert_eq!(managed_monitor_schema_state(&db).await?, (false, false));
+    Migrator::up(&db, Some(1)).await?;
+    assert_eq!(managed_monitor_schema_state(&db).await?, (true, true));
+
     db.execute_unprepared(
         "INSERT INTO status_monitors \
          (project_id, environment_id, name, monitor_type, check_interval_seconds, is_active, is_managed, created_at, updated_at) \
@@ -401,10 +405,60 @@ async fn test_managed_monitor_migration_preserves_ownership_uniqueness_down_and_
         "only one managed monitor is allowed per environment"
     );
 
-    Migrator::down(&db, Some(1)).await?;
-    assert_eq!(managed_monitor_schema_state(&db).await?, (false, false));
-    Migrator::up(&db, Some(1)).await?;
+    db.execute_unprepared("DELETE FROM status_monitors WHERE name = 'Temps managed'")
+        .await?;
+    db.execute_unprepared(
+        "UPDATE status_monitors SET is_managed = TRUE WHERE name = 'production Monitor'",
+    )
+    .await?;
+    assert_eq!(
+        db.query_one(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Postgres,
+            "SELECT COUNT(*) AS count FROM status_monitors WHERE is_managed = TRUE".to_string(),
+        ))
+        .await?
+        .expect("managed monitor count row")
+        .try_get::<i64>("", "count")?,
+        1,
+        "simulate the ownership inferred by the previously shipped migration"
+    );
+
+    Migrator::up(&db, None).await?;
     assert_eq!(managed_monitor_schema_state(&db).await?, (true, true));
+    let corrected = db
+        .query_one(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Postgres,
+            "SELECT is_managed FROM status_monitors WHERE name = 'production Monitor'".to_string(),
+        ))
+        .await?
+        .expect("default-named user monitor remains present");
+    assert!(
+        !corrected.try_get::<bool>("", "is_managed")?,
+        "the forward corrective migration must demote ownership inferred by the shipped migration"
+    );
+
+    Migrator::down(&db, Some(1)).await?;
+    let restored = db
+        .query_one(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Postgres,
+            "SELECT is_managed FROM status_monitors WHERE name = 'production Monitor'".to_string(),
+        ))
+        .await?
+        .expect("default-named user monitor remains present after rollback");
+    assert!(
+        restored.try_get::<bool>("", "is_managed")?,
+        "rolling back the corrective migration must restore the captured ownership state"
+    );
+
+    Migrator::up(&db, Some(1)).await?;
+    let corrected_again = db
+        .query_one(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Postgres,
+            "SELECT is_managed FROM status_monitors WHERE name = 'production Monitor'".to_string(),
+        ))
+        .await?
+        .expect("default-named user monitor remains present after reapplying correction");
+    assert!(!corrected_again.try_get::<bool>("", "is_managed")?);
     Ok(())
 }
 

--- a/crates/temps-status-page/src/services/monitor_service.rs
+++ b/crates/temps-status-page/src/services/monitor_service.rs
@@ -1253,6 +1253,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn managed_monitor_does_not_claim_a_user_monitor_with_the_default_name() {
+        let Ok(test_db) = TestDatabase::with_migrations().await else {
+            println!("Docker not available, skipping");
+            return;
+        };
+        let db = test_db.connection_arc();
+        let service = MonitorService::new(db.clone(), create_mock_config_service(&db));
+        let project = create_test_project(&db).await;
+        let environment = create_test_environment(&db, project.id).await;
+        let user_monitor = service
+            .create_monitor(
+                project.id,
+                CreateMonitorRequest {
+                    name: format!("{} Monitor", environment.name),
+                    monitor_type: "web".to_string(),
+                    environment_id: environment.id,
+                    check_interval_seconds: Some(60),
+                    check_path: Some("/user-health".to_string()),
+                },
+            )
+            .await
+            .unwrap();
+
+        let managed_monitor = service
+            .ensure_monitor_for_environment(project.id, environment.id, &environment.name)
+            .await
+            .unwrap();
+
+        assert_ne!(managed_monitor.id, user_monitor.id);
+        service
+            .update_managed_check_path_for_environment(
+                project.id,
+                environment.id,
+                Some("/deployed-health"),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            service
+                .get_monitor(user_monitor.id)
+                .await
+                .unwrap()
+                .check_path
+                .as_deref(),
+            Some("/user-health")
+        );
+        assert_eq!(
+            service
+                .get_monitor(managed_monitor.id)
+                .await
+                .unwrap()
+                .check_path
+                .as_deref(),
+            Some("/deployed-health")
+        );
+    }
+
+    #[tokio::test]
     async fn concurrent_environment_events_create_one_managed_monitor() {
         let Ok(test_db) = TestDatabase::with_migrations().await else {
             println!("Docker not available, skipping");

--- a/web/src/components/project/GitImportClone.tsx
+++ b/web/src/components/project/GitImportClone.tsx
@@ -51,6 +51,10 @@ import { toast } from 'sonner'
 import { Badge } from '@/components/ui/badge'
 import { parsePublicRepositoryUrl } from '@/lib/public-repository'
 import { getPublicRepository } from '@/api/client/sdk.gen'
+import {
+  templateBelongsToSource,
+  templateSource,
+} from '@/lib/template-source-selection'
 
 const SOURCE_VALUES: ProjectSource[] = [
   'templates',
@@ -161,9 +165,8 @@ export function GitImportClone({
     if (mode !== 'navigation') return
     queueMicrotask(() => {
       if (
-        selectedSource !== 'templates' &&
-        selectedSource !== 'services' &&
-        selectedTemplate
+        selectedTemplate &&
+        !templateBelongsToSource(selectedTemplate, selectedSource)
       ) {
         setSelectedTemplate(null)
       }
@@ -516,16 +519,25 @@ export function GitImportClone({
     }
   }
 
+  const handleTemplateSourceSelection = (source: ProjectSource) => {
+    if (
+      selectedTemplate &&
+      !templateBelongsToSource(selectedTemplate, source)
+    ) {
+      setSelectedTemplate(null)
+    }
+    setSelectedSource(source)
+  }
+
   // Show TemplateConfigurator when a template is selected — inside the same
   // shell (header + pills) as the picker, so configuring never swaps the
   // page frame.
   if (selectedTemplate) {
-    const selectedTemplateSource =
-      selectedTemplate.kind === 'service' ? 'services' : 'templates'
+    const selectedTemplateSource = templateSource(selectedTemplate)
     return (
       <NewProjectShell
         activeSource={selectedTemplateSource}
-        onSelectSource={setSelectedSource}
+        onSelectSource={handleTemplateSourceSelection}
       >
         <div className="space-y-6">
           <div className="flex items-center gap-4">

--- a/web/src/components/project/settings/ServiceTemplateRuntimeCard.tsx
+++ b/web/src/components/project/settings/ServiceTemplateRuntimeCard.tsx
@@ -98,6 +98,7 @@ export function ServiceTemplateRuntimeCard({
   )
   const runtimeDefaultsKey = JSON.stringify(runtimeDefaults)
   const appliedDefaultsKey = useRef<string | null>(null)
+  const appliedProjectId = useRef<number | null>(null)
   const isDirty = form.formState.isDirty
 
   useEffect(() => {
@@ -105,14 +106,17 @@ export function ServiceTemplateRuntimeCard({
       !shouldSynchronizeServiceTemplateRuntimeForm(
         isDirty,
         appliedDefaultsKey.current,
-        runtimeDefaultsKey
+        runtimeDefaultsKey,
+        appliedProjectId.current,
+        project.id
       )
     ) {
       return
     }
     form.reset(runtimeDefaults)
     appliedDefaultsKey.current = runtimeDefaultsKey
-  }, [form, isDirty, runtimeDefaults, runtimeDefaultsKey])
+    appliedProjectId.current = project.id
+  }, [form, isDirty, project.id, runtimeDefaults, runtimeDefaultsKey])
 
   const template = instanceQuery.data?.applied.template
   const appliedVersion = instanceQuery.data?.applied.version

--- a/web/src/components/project/settings/ServiceTemplateRuntimeCard.tsx
+++ b/web/src/components/project/settings/ServiceTemplateRuntimeCard.tsx
@@ -37,6 +37,7 @@ import { templateEnvironmentVariableDefaultsToSecret } from '@/lib/project-envir
 import { legacyDatabasesRedirectPath } from '@/lib/project-detail-routes'
 import {
   serviceTemplateRuntimeDefaults,
+  shouldSynchronizeServiceTemplateRuntimeForm,
   templateRuntimeDefaults,
   templateRuntimeDefaultsSchema,
   templateRuntimeOverrides,
@@ -54,7 +55,7 @@ import {
   RotateCcw,
   Save,
 } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { Link } from 'react-router'
 import { toast } from 'sonner'
@@ -90,14 +91,28 @@ export function ServiceTemplateRuntimeCard({
     },
   })
 
+  const appliedTemplate = instanceQuery.data?.applied.template
+  const runtimeDefaults = useMemo(
+    () => serviceTemplateRuntimeDefaults(project, appliedTemplate ?? {}),
+    [project, appliedTemplate]
+  )
+  const runtimeDefaultsKey = JSON.stringify(runtimeDefaults)
+  const appliedDefaultsKey = useRef<string | null>(null)
+  const isDirty = form.formState.isDirty
+
   useEffect(() => {
-    form.reset(
-      serviceTemplateRuntimeDefaults(
-        project,
-        instanceQuery.data?.applied.template ?? {}
+    if (
+      !shouldSynchronizeServiceTemplateRuntimeForm(
+        isDirty,
+        appliedDefaultsKey.current,
+        runtimeDefaultsKey
       )
-    )
-  }, [form, project, instanceQuery.data?.applied.template])
+    ) {
+      return
+    }
+    form.reset(runtimeDefaults)
+    appliedDefaultsKey.current = runtimeDefaultsKey
+  }, [form, isDirty, runtimeDefaults, runtimeDefaultsKey])
 
   const template = instanceQuery.data?.applied.template
   const appliedVersion = instanceQuery.data?.applied.version
@@ -131,6 +146,7 @@ export function ServiceTemplateRuntimeCard({
           },
         })
         await refetch()
+        form.reset(values)
       })(),
       {
         loading: 'Saving service runtime…',

--- a/web/src/lib/template-runtime-defaults.test.ts
+++ b/web/src/lib/template-runtime-defaults.test.ts
@@ -7,10 +7,40 @@ import {
   historicalImageRuntime,
   serviceTemplateDeployOverrides,
   serviceTemplateRuntimeDefaults,
+  shouldSynchronizeServiceTemplateRuntimeForm,
   templateRuntimeDefaults,
   templateRuntimeDefaultsSchema,
   templateRuntimeOverrides,
 } from './template-runtime-defaults'
+
+describe('service template runtime form synchronization', () => {
+  test('does not replace dirty edits when project data refetches', () => {
+    expect(
+      shouldSynchronizeServiceTemplateRuntimeForm(
+        true,
+        'persisted-runtime-v1',
+        'persisted-runtime-v2'
+      )
+    ).toBe(false)
+  })
+
+  test('synchronizes a clean form only when persisted defaults change', () => {
+    expect(
+      shouldSynchronizeServiceTemplateRuntimeForm(
+        false,
+        'persisted-runtime-v1',
+        'persisted-runtime-v2'
+      )
+    ).toBe(true)
+    expect(
+      shouldSynchronizeServiceTemplateRuntimeForm(
+        false,
+        'persisted-runtime-v2',
+        'persisted-runtime-v2'
+      )
+    ).toBe(false)
+  })
+})
 
 const template = {
   image: 'registry.example.test/identity:26.7.2',

--- a/web/src/lib/template-runtime-defaults.test.ts
+++ b/web/src/lib/template-runtime-defaults.test.ts
@@ -19,7 +19,9 @@ describe('service template runtime form synchronization', () => {
       shouldSynchronizeServiceTemplateRuntimeForm(
         true,
         'persisted-runtime-v1',
-        'persisted-runtime-v2'
+        'persisted-runtime-v2',
+        41,
+        41
       )
     ).toBe(false)
   })
@@ -29,16 +31,32 @@ describe('service template runtime form synchronization', () => {
       shouldSynchronizeServiceTemplateRuntimeForm(
         false,
         'persisted-runtime-v1',
-        'persisted-runtime-v2'
+        'persisted-runtime-v2',
+        41,
+        41
       )
     ).toBe(true)
     expect(
       shouldSynchronizeServiceTemplateRuntimeForm(
         false,
         'persisted-runtime-v2',
-        'persisted-runtime-v2'
+        'persisted-runtime-v2',
+        41,
+        41
       )
     ).toBe(false)
+  })
+
+  test('always synchronizes when the form is reused for another project', () => {
+    expect(
+      shouldSynchronizeServiceTemplateRuntimeForm(
+        true,
+        'project-a-runtime',
+        'project-b-runtime',
+        41,
+        42
+      )
+    ).toBe(true)
   })
 })
 

--- a/web/src/lib/template-runtime-defaults.ts
+++ b/web/src/lib/template-runtime-defaults.ts
@@ -260,9 +260,13 @@ export function serviceTemplateRuntimeDefaults(
 export function shouldSynchronizeServiceTemplateRuntimeForm(
   isDirty: boolean,
   appliedDefaultsKey: string | null,
-  nextDefaultsKey: string
+  nextDefaultsKey: string,
+  appliedProjectId: number | null,
+  nextProjectId: number
 ): boolean {
-  return !isDirty && appliedDefaultsKey !== nextDefaultsKey
+  const projectChanged =
+    appliedProjectId !== null && appliedProjectId !== nextProjectId
+  return projectChanged || (!isDirty && appliedDefaultsKey !== nextDefaultsKey)
 }
 
 export function serviceTemplateDeployOverrides(

--- a/web/src/lib/template-runtime-defaults.ts
+++ b/web/src/lib/template-runtime-defaults.ts
@@ -257,6 +257,14 @@ export function serviceTemplateRuntimeDefaults(
   }
 }
 
+export function shouldSynchronizeServiceTemplateRuntimeForm(
+  isDirty: boolean,
+  appliedDefaultsKey: string | null,
+  nextDefaultsKey: string
+): boolean {
+  return !isDirty && appliedDefaultsKey !== nextDefaultsKey
+}
+
 export function serviceTemplateDeployOverrides(
   project: ServiceTemplateProjectSource
 ): {

--- a/web/src/lib/template-source-selection.test.ts
+++ b/web/src/lib/template-source-selection.test.ts
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+import { describe, expect, test } from 'bun:test'
+import {
+  templateBelongsToSource,
+  templateSource,
+} from './template-source-selection'
+
+describe('template source selection', () => {
+  test('service selections belong only to the Services source', () => {
+    const template = { kind: 'service' as const }
+
+    expect(templateSource(template)).toBe('services')
+    expect(templateBelongsToSource(template, 'services')).toBe(true)
+    expect(templateBelongsToSource(template, 'templates')).toBe(false)
+  })
+
+  test('starter selections belong only to the Template source', () => {
+    const template = { kind: 'starter' as const }
+
+    expect(templateSource(template)).toBe('templates')
+    expect(templateBelongsToSource(template, 'templates')).toBe(true)
+    expect(templateBelongsToSource(template, 'services')).toBe(false)
+  })
+})

--- a/web/src/lib/template-source-selection.ts
+++ b/web/src/lib/template-source-selection.ts
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+import type { TemplateResponse } from '@/api/client/types.gen'
+import type { ProjectSource } from '@/components/project/NewProjectShell'
+
+export function templateSource(
+  template: Pick<TemplateResponse, 'kind'>
+): Extract<ProjectSource, 'services' | 'templates'> {
+  return template.kind === 'service' ? 'services' : 'templates'
+}
+
+export function templateBelongsToSource(
+  template: Pick<TemplateResponse, 'kind'>,
+  source: ProjectSource | null
+): boolean {
+  return templateSource(template) === source
+}


### PR DESCRIPTION
## Summary

Follow-up to #855 that fixes the blocking and major findings from the post-merge review and Greptile's P1 follow-up findings:

- preserve every pre-existing status monitor as user-owned instead of inferring platform ownership from an editable name
- repair databases that already applied the original name-based ownership migration
- clear stale service/starter configurators when switching between Services and Template
- preserve dirty service runtime edits across same-project refetches while resetting them on project identity changes

## Evidence

**Cross-project runtime state**: a dirty image value from Keycloak does not cross into Browserless during an in-app route transition.

```text
PASS: project A contains an unsaved dirty image value
PASS: project B replaces project A's dirty value with its own persisted runtime
```

Screenshot captured from the fixed local UI: `/tmp/pr903-cross-project-runtime-reset.png`.

**Template source switching**:

```text
PASS: selecting Keycloak opens the service configurator
PASS: switching Services -> Template removes the stale service configurator
PASS: switching Template -> Services removes the stale starter configurator
```

**Corrective migration against real PostgreSQL**:

```bash
SKIP_WEB_BUILD=1 cargo test -p temps-migrations test_managed_monitor_migrations_preserve_and_repair_ownership -- --nocapture
```

```text
cargo test: 1 passed, 38 filtered out (4 suites, 3.30s)
```

The test simulates the ownership state written by the previously shipped migration, verifies the new migration demotes the ambiguous row, verifies `down()` restores the captured state, and verifies reapplying the migration corrects it again.

**Managed-monitor service behavior**:

```text
test managed_monitor_does_not_claim_a_user_monitor_with_the_default_name ... ok
```

## Verification

- targeted frontend tests — 15 passed
- `bunx tsc --noEmit` — passed
- scoped ESLint and Prettier checks — passed
- `cargo fmt --all -- --check` — passed
- `SKIP_WEB_BUILD=1 cargo check --lib` — passed
- `SKIP_WEB_BUILD=1 cargo clippy -p temps-migrations --lib --tests -- -D warnings` — passed
- migration registry test — passed
- `python3 scripts/source_attribution.py check` — passed for 3,412 source files
- repository pre-commit hooks — passed

## Review gates

- migration review: approved
- frontend regression review: approved
- security review: approved, no findings
