### PR TITLE
fix(cli): repair management commands and issue 899 regressions

### DIFF
--- a/apps/temps-cli/src/commands/custom-domains/index.test.ts
+++ b/apps/temps-cli/src/commands/custom-domains/index.test.ts
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 import { test, expect, describe } from 'bun:test'
-import { buildCustomDomainUpdateBody } from './index.js'
+import { buildCustomDomainUpdateBody, customDomainTimestamp } from './index.js'
+
+test('custom domain timestamps are interpreted as epoch milliseconds', () => {
+  expect(customDomainTimestamp(1_796_278_035_000).toISOString()).toBe('2026-12-03T06:07:15.000Z')
+})
 
 describe('buildCustomDomainUpdateBody', () => {
   test('produces an empty body when no options are provided', () => {

--- a/apps/temps-cli/src/commands/custom-domains/index.ts
+++ b/apps/temps-cli/src/commands/custom-domains/index.ts
@@ -62,6 +62,11 @@ interface LinkCertOptions {
   certificateId: string
 }
 
+/** Custom-domain API timestamps are epoch milliseconds. */
+export function customDomainTimestamp(timestampMillis: number): Date {
+  return new Date(timestampMillis)
+}
+
 export function registerCustomDomainsCommands(program: Command): void {
   const customDomains = program
     .command('custom-domains')
@@ -171,7 +176,7 @@ async function listCustomDomains(options: ListOptions): Promise<void> {
     { header: 'Environment', accessor: (d) => d.environment?.name ?? '-' },
     { header: 'Branch', accessor: (d) => d.branch ?? '-' },
     { header: 'Redirect', accessor: (d) => d.redirect_to ?? '-', color: (v) => colors.muted(v) },
-    { header: 'Created', accessor: (d) => new Date(d.created_at * 1000).toLocaleDateString(), color: (v) => colors.muted(v) },
+    { header: 'Created', accessor: (d) => customDomainTimestamp(d.created_at).toLocaleDateString(), color: (v) => colors.muted(v) },
   ]
 
   printTable(domainsData, columns, { style: 'minimal' })
@@ -295,16 +300,16 @@ async function showCustomDomain(options: ShowOptions): Promise<void> {
     keyValue('Linked Domain ID', domain.domain_id)
   }
   if (domain.expiration_time) {
-    keyValue('Certificate Expires', new Date(domain.expiration_time * 1000).toLocaleString())
+    keyValue('Certificate Expires', customDomainTimestamp(domain.expiration_time).toLocaleString())
   }
   if (domain.last_renewed) {
-    keyValue('Last Renewed', new Date(domain.last_renewed * 1000).toLocaleString())
+    keyValue('Last Renewed', customDomainTimestamp(domain.last_renewed).toLocaleString())
   }
   if (domain.message) {
     keyValue('Message', domain.message)
   }
-  keyValue('Created', new Date(domain.created_at * 1000).toLocaleString())
-  keyValue('Updated', new Date(domain.updated_at * 1000).toLocaleString())
+  keyValue('Created', customDomainTimestamp(domain.created_at).toLocaleString())
+  keyValue('Updated', customDomainTimestamp(domain.updated_at).toLocaleString())
   newline()
 }
 

--- a/apps/temps-cli/src/commands/domains/index.test.ts
+++ b/apps/temps-cli/src/commands/domains/index.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 import { test, expect, describe } from 'bun:test'
-import { findDomainByName, wildcardBaseDomain, isProvisionedStatus } from './index.js'
+import { domainTimestamp, findDomainByName, wildcardBaseDomain, isProvisionedStatus } from './index.js'
 import type { DomainResponse } from '../../api/types.gen.js'
 
 function domain(overrides: Partial<DomainResponse>): DomainResponse {
@@ -67,5 +67,11 @@ describe('isProvisionedStatus', () => {
 
   test('is case-sensitive', () => {
     expect(isProvisionedStatus('Active')).toBe(false)
+  })
+})
+
+describe('domainTimestamp', () => {
+  test('treats API timestamps as epoch milliseconds', () => {
+    expect(domainTimestamp(1_796_278_035_000).toISOString()).toBe('2026-12-03T06:07:15.000Z')
   })
 })

--- a/apps/temps-cli/src/commands/domains/index.ts
+++ b/apps/temps-cli/src/commands/domains/index.ts
@@ -58,6 +58,11 @@ export function isProvisionedStatus(status: string): boolean {
   return status === 'active' || status === 'provisioned'
 }
 
+/** Domain API timestamps are epoch milliseconds, matching JavaScript Date. */
+export function domainTimestamp(timestampMillis: number): Date {
+  return new Date(timestampMillis)
+}
+
 interface AddOptions {
   domain: string
   challenge?: string
@@ -258,7 +263,7 @@ async function listDomains(options: { json?: boolean }): Promise<void> {
     { header: 'Method', accessor: (d) => d.verification_method },
     {
       header: 'Expires',
-      accessor: (d) => d.expiration_time ? formatDate(new Date(d.expiration_time * 1000).toISOString()) : '-',
+      accessor: (d) => d.expiration_time ? formatDate(domainTimestamp(d.expiration_time).toISOString()) : '-',
       color: (v) => colors.muted(v)
     },
   ]
@@ -422,9 +427,9 @@ async function manageSsl(options: SslOptions): Promise<void> {
   keyValue('Status', statusBadge(sslInfo?.status ?? 'unknown'))
   keyValue('Wildcard', sslInfo?.is_wildcard ? 'Yes' : 'No')
   keyValue('Method', sslInfo?.verification_method ?? '-')
-  keyValue('Expires', sslInfo?.expiration_time ? formatDate(new Date(sslInfo.expiration_time * 1000).toISOString()) : '-')
+  keyValue('Expires', sslInfo?.expiration_time ? formatDate(domainTimestamp(sslInfo.expiration_time).toISOString()) : '-')
   if (sslInfo?.last_renewed) {
-    keyValue('Last Renewed', formatDate(new Date(sslInfo.last_renewed * 1000).toISOString()))
+    keyValue('Last Renewed', formatDate(domainTimestamp(sslInfo.last_renewed).toISOString()))
   }
   if (sslInfo?.last_error) {
     keyValue('Last Error', colors.error(sslInfo.last_error))
@@ -467,7 +472,7 @@ async function domainStatus(options: StatusOptions): Promise<void> {
     keyValue('DNS Challenge Value', status.dns_challenge_value)
   }
 
-  keyValue('Certificate Expires', status?.expiration_time ? formatDate(new Date(status.expiration_time * 1000).toISOString()) : '-')
+  keyValue('Certificate Expires', status?.expiration_time ? formatDate(domainTimestamp(status.expiration_time).toISOString()) : '-')
 
   if (status?.last_error) {
     newline()
@@ -570,12 +575,12 @@ async function listOrders(options: { json?: boolean }): Promise<void> {
     { header: 'Email', key: 'email' },
     {
       header: 'Created',
-      accessor: (o) => formatDate(new Date(o.created_at * 1000).toISOString()),
+      accessor: (o) => formatDate(domainTimestamp(o.created_at).toISOString()),
       color: (v) => colors.muted(v),
     },
     {
       header: 'Expires',
-      accessor: (o) => o.expires_at ? formatDate(new Date(o.expires_at * 1000).toISOString()) : '-',
+      accessor: (o) => o.expires_at ? formatDate(domainTimestamp(o.expires_at).toISOString()) : '-',
       color: (v) => colors.muted(v),
     },
   ]
@@ -625,10 +630,10 @@ async function showOrder(options: OrderShowOptions): Promise<void> {
   if (order.certificate_url) {
     keyValue('Certificate URL', order.certificate_url)
   }
-  keyValue('Created', formatDate(new Date(order.created_at * 1000).toISOString()))
-  keyValue('Updated', formatDate(new Date(order.updated_at * 1000).toISOString()))
+  keyValue('Created', formatDate(domainTimestamp(order.created_at).toISOString()))
+  keyValue('Updated', formatDate(domainTimestamp(order.updated_at).toISOString()))
   if (order.expires_at) {
-    keyValue('Expires', formatDate(new Date(order.expires_at * 1000).toISOString()))
+    keyValue('Expires', formatDate(domainTimestamp(order.expires_at).toISOString()))
   }
 
   if (order.challenge_validation) {
@@ -736,7 +741,7 @@ async function finalizeOrder(options: OrderFinalizeOptions): Promise<void> {
     success(`ACME order finalized for ${result.domain}`)
     keyValue('Status', statusBadge(result.status))
     if (result.expiration_time) {
-      keyValue('Certificate Expires', formatDate(new Date(result.expiration_time * 1000).toISOString()))
+      keyValue('Certificate Expires', formatDate(domainTimestamp(result.expiration_time).toISOString()))
     }
   } else {
     warning(`Order finalization returned status: ${result.status}`)

--- a/crates/temps-cli/src/commands/api_url.rs
+++ b/crates/temps-cli/src/commands/api_url.rs
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! URL construction shared by Rust CLI commands that call the management API.
+
+/// Build a management API URL from an instance URL.
+///
+/// Operators configure `TEMPS_API_URL` as the address of their Temps instance,
+/// while the HTTP server mounts management routes below `/api`. Accept both the
+/// documented instance form (`https://temps.example.com`) and the historically
+/// used explicit API form (`https://temps.example.com/api`) without producing a
+/// missing or duplicated `/api` segment.
+pub(crate) fn management_api_url(base: &str, path: &str) -> String {
+    let base = base.trim_end_matches('/');
+    let base = base.strip_suffix("/api").unwrap_or(base);
+    format!("{base}/api/{}", path.trim_start_matches('/'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::management_api_url;
+
+    #[test]
+    fn builds_management_url_from_instance_root() {
+        assert_eq!(
+            management_api_url("http://127.0.0.1", "/domains"),
+            "http://127.0.0.1/api/domains"
+        );
+    }
+
+    #[test]
+    fn accepts_existing_api_suffix_and_trailing_slashes() {
+        assert_eq!(
+            management_api_url("https://temps.example.com/api/", "domains/7"),
+            "https://temps.example.com/api/domains/7"
+        );
+    }
+
+    #[test]
+    fn preserves_reverse_proxy_path_prefix() {
+        assert_eq!(
+            management_api_url("https://example.com/temps", "/domains"),
+            "https://example.com/temps/api/domains"
+        );
+    }
+
+    #[test]
+    fn api_text_inside_hostname_is_not_treated_as_path_suffix() {
+        assert_eq!(
+            management_api_url("https://my-api.example.com", "/domains"),
+            "https://my-api.example.com/api/domains"
+        );
+    }
+}

--- a/crates/temps-cli/src/commands/deploy.rs
+++ b/crates/temps-cli/src/commands/deploy.rs
@@ -12,6 +12,8 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use tracing::info;
 
+use super::api_url::management_api_url;
+
 #[derive(Args)]
 pub struct DeployCommand {
     #[command(subcommand)]
@@ -270,11 +272,12 @@ impl DeployCommand {
 
             // Trigger deployment
             println!("{}", "Starting deployment...".bright_white());
-            let deploy_url = format!(
-                "{}/projects/{}/environments/{}/deploy/image",
-                args.api_url.trim_end_matches('/'),
-                project.id,
-                environment.id
+            let deploy_url = management_api_url(
+                &args.api_url,
+                &format!(
+                    "/projects/{}/environments/{}/deploy/image",
+                    project.id, environment.id
+                ),
             );
 
             let request = DeployImageRequest {
@@ -325,11 +328,8 @@ impl DeployCommand {
                     .bright_white()
                 );
 
-                let deployment_url = format!(
-                    "{}/deployments/{}",
-                    args.api_url.trim_end_matches('/'),
-                    deployment.id
-                );
+                let deployment_url =
+                    management_api_url(&args.api_url, &format!("/deployments/{}", deployment.id));
 
                 let start = std::time::Instant::now();
                 let timeout = std::time::Duration::from_secs(args.timeout);
@@ -498,10 +498,9 @@ impl DeployCommand {
 
             // Upload static bundle
             println!("{}", "Uploading static bundle...".bright_white());
-            let upload_url = format!(
-                "{}/projects/{}/upload/static",
-                args.api_url.trim_end_matches('/'),
-                project.id
+            let upload_url = management_api_url(
+                &args.api_url,
+                &format!("/projects/{}/upload/static", project.id),
             );
 
             let form = reqwest::multipart::Form::new().part(
@@ -543,11 +542,12 @@ impl DeployCommand {
 
             // Trigger deployment
             println!("{}", "Starting deployment...".bright_white());
-            let deploy_url = format!(
-                "{}/projects/{}/environments/{}/deploy/static",
-                args.api_url.trim_end_matches('/'),
-                project.id,
-                environment.id
+            let deploy_url = management_api_url(
+                &args.api_url,
+                &format!(
+                    "/projects/{}/environments/{}/deploy/static",
+                    project.id, environment.id
+                ),
             );
 
             #[derive(Debug, Serialize)]
@@ -614,11 +614,8 @@ impl DeployCommand {
                     .bright_white()
                 );
 
-                let deployment_url = format!(
-                    "{}/deployments/{}",
-                    args.api_url.trim_end_matches('/'),
-                    deployment.id
-                );
+                let deployment_url =
+                    management_api_url(&args.api_url, &format!("/deployments/{}", deployment.id));
 
                 let start = std::time::Instant::now();
                 let timeout = std::time::Duration::from_secs(args.timeout);
@@ -775,10 +772,9 @@ impl DeployCommand {
 
             // Trigger pipeline
             println!("{}", "Triggering pipeline...".bright_white());
-            let trigger_url = format!(
-                "{}/projects/{}/trigger-pipeline",
-                args.api_url.trim_end_matches('/'),
-                project.id
+            let trigger_url = management_api_url(
+                &args.api_url,
+                &format!("/projects/{}/trigger-pipeline", project.id),
             );
 
             let request = TriggerPipelineRequest {
@@ -841,11 +837,12 @@ impl DeployCommand {
                 );
 
                 // Poll the last deployment for this project/environment
-                let deployments_url = format!(
-                    "{}/projects/{}/deployments?environment_id={}",
-                    args.api_url.trim_end_matches('/'),
-                    project.id,
-                    environment.id
+                let deployments_url = management_api_url(
+                    &args.api_url,
+                    &format!(
+                        "/projects/{}/deployments?environment_id={}",
+                        project.id, environment.id
+                    ),
                 );
 
                 let start = std::time::Instant::now();
@@ -940,11 +937,7 @@ impl DeployCommand {
         project_slug: &str,
     ) -> anyhow::Result<ProjectResponse> {
         // Try to get project by slug first
-        let url = format!(
-            "{}/projects/by-slug/{}",
-            api_url.trim_end_matches('/'),
-            project_slug
-        );
+        let url = management_api_url(api_url, &format!("/projects/by-slug/{project_slug}"));
 
         let response = client
             .get(&url)
@@ -962,7 +955,7 @@ impl DeployCommand {
 
         // Try as project ID if slug lookup failed
         if let Ok(project_id) = project_slug.parse::<i32>() {
-            let url = format!("{}/projects/{}", api_url.trim_end_matches('/'), project_id);
+            let url = management_api_url(api_url, &format!("/projects/{project_id}"));
 
             let response = client
                 .get(&url)
@@ -989,11 +982,7 @@ impl DeployCommand {
         project_id: i32,
         environment_name: &str,
     ) -> anyhow::Result<EnvironmentResponse> {
-        let url = format!(
-            "{}/projects/{}/environments",
-            api_url.trim_end_matches('/'),
-            project_id
-        );
+        let url = management_api_url(api_url, &format!("/projects/{project_id}/environments"));
 
         let response = client
             .get(&url)

--- a/crates/temps-cli/src/commands/doctor.rs
+++ b/crates/temps-cli/src/commands/doctor.rs
@@ -190,9 +190,8 @@ impl DoctorCommand {
         } else if let Ok(d) = std::env::var("TEMPS_DATA_DIR") {
             PathBuf::from(d)
         } else {
-            dirs::home_dir()
-                .unwrap_or_else(|| PathBuf::from("."))
-                .join(".temps")
+            let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+            default_data_dir(&home)
         }
     }
 
@@ -860,6 +859,24 @@ impl DoctorCommand {
     }
 }
 
+/// Resolve the default installation layout without overriding an explicit
+/// `--data-dir` or `TEMPS_DATA_DIR`. Current installs use `~/.temps`, while
+/// older deployment scripts placed runtime secrets in `~/.temps/data`.
+fn default_data_dir(home: &Path) -> PathBuf {
+    let root = home.join(".temps");
+    let nested = root.join("data");
+    let root_has_runtime_files =
+        root.join("auth_secret").is_file() || root.join("encryption_key").is_file();
+    let nested_has_runtime_files =
+        nested.join("auth_secret").is_file() || nested.join("encryption_key").is_file();
+
+    if !root_has_runtime_files && nested_has_runtime_files {
+        nested
+    } else {
+        root
+    }
+}
+
 /// Check if a URL is reachable via HTTPS.
 async fn check_url_reachable(label: &'static str, url: &str, report: &mut DiagnosticReport) {
     let client = reqwest::Client::builder()
@@ -1034,5 +1051,29 @@ mod tests {
         assert_eq!(report.pass_count, 2);
         assert_eq!(report.warn_count, 1);
         assert_eq!(report.fail_count, 1);
+    }
+
+    #[test]
+    fn default_data_dir_detects_legacy_nested_runtime_layout() {
+        let home = tempfile::tempdir().expect("create temporary home");
+        let nested = home.path().join(".temps/data");
+        std::fs::create_dir_all(&nested).expect("create nested data directory");
+        std::fs::write(nested.join("auth_secret"), "test-secret")
+            .expect("write nested auth secret");
+
+        assert_eq!(default_data_dir(home.path()), nested);
+    }
+
+    #[test]
+    fn default_data_dir_prefers_current_root_layout() {
+        let home = tempfile::tempdir().expect("create temporary home");
+        let root = home.path().join(".temps");
+        let nested = root.join("data");
+        std::fs::create_dir_all(&nested).expect("create nested data directory");
+        std::fs::write(root.join("auth_secret"), "current-secret").expect("write root auth secret");
+        std::fs::write(nested.join("auth_secret"), "legacy-secret")
+            .expect("write nested auth secret");
+
+        assert_eq!(default_data_dir(home.path()), root);
     }
 }

--- a/crates/temps-cli/src/commands/domain.rs
+++ b/crates/temps-cli/src/commands/domain.rs
@@ -9,9 +9,10 @@
 
 use anyhow::Context;
 use chrono::Utc;
-use clap::{Args, Subcommand, ValueEnum};
+use clap::{ArgGroup, Args, Subcommand, ValueEnum};
 use colored::Colorize;
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -19,6 +20,8 @@ use temps_core::EncryptionService;
 use temps_database::establish_connection;
 use temps_entities::domains;
 use x509_parser::prelude::*;
+
+use super::api_url::management_api_url;
 
 /// Domain and certificate management commands
 #[derive(Args)]
@@ -136,10 +139,20 @@ pub struct CertStatusCommand {
 
 /// Show details for a specific domain
 #[derive(Args)]
+#[command(group(
+    ArgGroup::new("domain_identifier")
+        .required(true)
+        .multiple(false)
+        .args(["id", "domain"])
+))]
 pub struct ShowDomainCommand {
-    /// Domain ID
+    /// Domain ID (use either --id or --domain)
     #[arg(long)]
-    pub id: i32,
+    pub id: Option<i32>,
+
+    /// Domain hostname (e.g. example.com)
+    #[arg(long, short = 'd')]
+    pub domain: Option<String>,
 
     /// Temps API URL
     #[arg(long, env = "TEMPS_API_URL")]
@@ -511,7 +524,7 @@ impl DomainCommand {
 // ========================================
 
 fn api_url(base: &str, path: &str) -> String {
-    format!("{}{}", base.trim_end_matches('/'), path)
+    management_api_url(base, path)
 }
 
 // ========================================
@@ -522,6 +535,69 @@ async fn handle_api_error(response: reqwest::Response) -> anyhow::Error {
     let status = response.status();
     let body = response.text().await.unwrap_or_default();
     anyhow::anyhow!("API request failed (HTTP {}): {}", status, body)
+}
+
+/// Decode a successful API response without hiding the endpoint and response
+/// metadata that operators need when the server returns an unexpected body.
+/// The body itself is deliberately omitted because domain responses can carry
+/// certificate material and live DNS challenge values.
+async fn parse_api_response<T: DeserializeOwned>(
+    response: reqwest::Response,
+    method: &str,
+    url: &str,
+) -> anyhow::Result<T> {
+    let diagnostic_url = diagnostic_api_url(url);
+    let status = response.status();
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("missing content-type")
+        .to_string();
+    let body = response.bytes().await.map_err(|error| {
+        anyhow::anyhow!(
+            "Failed to read {} {} response (HTTP {}, content-type {}): {}",
+            method,
+            diagnostic_url,
+            status,
+            content_type,
+            error
+        )
+    })?;
+
+    serde_json::from_slice(&body).map_err(|error| {
+        let hint = if content_type.contains("text/html") {
+            " The server returned HTML instead of JSON; verify that --api-url points to the Temps instance (the CLI adds /api automatically)."
+        } else {
+            ""
+        };
+        anyhow::anyhow!(
+            "Failed to decode {} {} response (HTTP {}, content-type {}): {}.{}",
+            method,
+            diagnostic_url,
+            status,
+            content_type,
+            error,
+            hint
+        )
+    })
+}
+
+/// Preserve the endpoint information needed to diagnose routing problems
+/// without echoing URL userinfo, query credentials, or fragments into logs.
+fn diagnostic_api_url(url: &str) -> String {
+    let Ok(mut parsed) = reqwest::Url::parse(url) else {
+        return "<invalid API URL>".to_string();
+    };
+    if parsed.set_username("").is_err() {
+        return "<redacted API URL>".to_string();
+    }
+    if parsed.set_password(None).is_err() {
+        return "<redacted API URL>".to_string();
+    }
+    parsed.set_query(None);
+    parsed.set_fragment(None);
+    parsed.to_string()
 }
 
 // ========================================
@@ -612,10 +688,7 @@ async fn execute_add(cmd: AddDomainCommand) -> anyhow::Result<()> {
         return Err(handle_api_error(response).await);
     }
 
-    let domain_resp: DomainResponse = response
-        .json()
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to parse response: {}", e))?;
+    let domain_resp: DomainResponse = parse_api_response(response, "POST", &url).await?;
 
     println!(
         "  {} Domain created (ID: {})",
@@ -844,10 +917,7 @@ async fn execute_list_api(cmd: ListDomainsApiCommand) -> anyhow::Result<()> {
         return Err(handle_api_error(response).await);
     }
 
-    let list_resp: ListDomainsResponse = response
-        .json()
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to parse response: {}", e))?;
+    let list_resp: ListDomainsResponse = parse_api_response(response, "GET", &url).await?;
 
     // Filter to on-demand-state hostnames when --on-demand is set.
     let domains: Vec<&DomainResponse> = if cmd.on_demand {
@@ -982,7 +1052,12 @@ async fn execute_list_api(cmd: ListDomainsApiCommand) -> anyhow::Result<()> {
 
 async fn execute_show(cmd: ShowDomainCommand) -> anyhow::Result<()> {
     let client = reqwest::Client::new();
-    let url = api_url(&cmd.api_url, &format!("/domains/{}", cmd.id));
+    let path = match (cmd.id, cmd.domain.as_deref()) {
+        (Some(id), None) => format!("/domains/{id}"),
+        (None, Some(domain)) => format!("/domains/by-host/{}", urlencoding::encode(domain)),
+        _ => anyhow::bail!("Specify exactly one of --id or --domain"),
+    };
+    let url = api_url(&cmd.api_url, &path);
 
     let response = client
         .get(&url)
@@ -995,10 +1070,7 @@ async fn execute_show(cmd: ShowDomainCommand) -> anyhow::Result<()> {
         return Err(handle_api_error(response).await);
     }
 
-    let domain_resp: DomainResponse = response
-        .json()
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to parse response: {}", e))?;
+    let domain_resp: DomainResponse = parse_api_response(response, "GET", &url).await?;
 
     if cmd.json {
         println!(
@@ -1131,10 +1203,7 @@ async fn execute_provision(cmd: ProvisionDomainCommand) -> anyhow::Result<()> {
         return Err(handle_api_error(response).await);
     }
 
-    let provision_resp: ProvisionApiResponse = response
-        .json()
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to parse response: {}", e))?;
+    let provision_resp: ProvisionApiResponse = parse_api_response(response, "POST", &url).await?;
 
     match provision_resp {
         ProvisionApiResponse::Complete(domain) => {
@@ -1199,10 +1268,7 @@ async fn execute_cert_status(cmd: CertStatusCommand) -> anyhow::Result<()> {
         return Err(handle_api_error(response).await);
     }
 
-    let status_resp: CertStatusResponse = response
-        .json()
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to parse response: {}", e))?;
+    let status_resp: CertStatusResponse = parse_api_response(response, "GET", &url).await?;
 
     if cmd.json {
         println!(
@@ -1375,10 +1441,8 @@ async fn execute_order_create(cmd: OrderCreateCommand) -> anyhow::Result<()> {
         return Err(handle_api_error(response).await);
     }
 
-    let challenge_resp: DomainChallengeResponse = response
-        .json()
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to parse response: {}", e))?;
+    let challenge_resp: DomainChallengeResponse =
+        parse_api_response(response, "POST", &url).await?;
 
     println!(
         "  {} ACME order created for {}",
@@ -1441,10 +1505,7 @@ async fn execute_order_show(cmd: OrderShowCommand) -> anyhow::Result<()> {
         return Err(handle_api_error(response).await);
     }
 
-    let order_resp: AcmeOrderResponse = response
-        .json()
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to parse response: {}", e))?;
+    let order_resp: AcmeOrderResponse = parse_api_response(response, "GET", &url).await?;
 
     if cmd.json {
         println!(
@@ -1599,10 +1660,7 @@ async fn execute_order_cancel(cmd: OrderCancelCommand) -> anyhow::Result<()> {
         return Err(handle_api_error(response).await);
     }
 
-    let domain_resp: DomainResponse = response
-        .json()
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to parse response: {}", e))?;
+    let domain_resp: DomainResponse = parse_api_response(response, "DELETE", &url).await?;
 
     println!(
         "  {} Order cancelled for domain '{}'",
@@ -1648,10 +1706,7 @@ async fn execute_order_finalize(cmd: OrderFinalizeCommand) -> anyhow::Result<()>
         return Err(handle_api_error(response).await);
     }
 
-    let domain_resp: DomainResponse = response
-        .json()
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to parse response: {}", e))?;
+    let domain_resp: DomainResponse = parse_api_response(response, "POST", &url).await?;
 
     match domain_resp.status.as_str() {
         "active" => {
@@ -1701,10 +1756,7 @@ async fn execute_order_list(cmd: OrderListCommand) -> anyhow::Result<()> {
         return Err(handle_api_error(response).await);
     }
 
-    let list_resp: ListOrdersResponse = response
-        .json()
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to parse response: {}", e))?;
+    let list_resp: ListOrdersResponse = parse_api_response(response, "GET", &url).await?;
 
     if cmd.json {
         println!(
@@ -2087,6 +2139,68 @@ fn validate_private_key(key_pem: &str) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::{
+        http::{header, HeaderMap, StatusCode},
+        response::{Html, IntoResponse},
+        routing::get,
+        Json, Router,
+    };
+    use clap::Parser;
+
+    #[test]
+    fn show_accepts_exactly_one_domain_identifier() {
+        let common = ["--api-url", "http://127.0.0.1", "--api-token", "test-token"];
+
+        let mut by_domain = vec!["temps", "domain", "show", "--domain", "example.com"];
+        by_domain.extend(common);
+        assert!(crate::Cli::try_parse_from(by_domain).is_ok());
+
+        let mut by_id = vec!["temps", "domain", "show", "--id", "7"];
+        by_id.extend(common);
+        assert!(crate::Cli::try_parse_from(by_id).is_ok());
+
+        let mut missing = vec!["temps", "domain", "show"];
+        missing.extend(common);
+        let missing_error = match crate::Cli::try_parse_from(missing) {
+            Ok(_) => panic!("show without an identifier must fail"),
+            Err(error) => error,
+        };
+        assert_eq!(
+            missing_error.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+
+        let mut conflicting = vec![
+            "temps",
+            "domain",
+            "show",
+            "--id",
+            "7",
+            "--domain",
+            "example.com",
+        ];
+        conflicting.extend(common);
+        let conflict_error = match crate::Cli::try_parse_from(conflicting) {
+            Ok(_) => panic!("show with both identifiers must fail"),
+            Err(error) => error,
+        };
+        assert_eq!(
+            conflict_error.kind(),
+            clap::error::ErrorKind::ArgumentConflict
+        );
+    }
+
+    #[test]
+    fn diagnostic_urls_redact_credentials_and_query_values() {
+        let diagnostic = diagnostic_api_url(
+            "https://operator:super-secret@example.com/api/domains?token=query-secret#fragment",
+        );
+
+        assert_eq!(diagnostic, "https://example.com/api/domains");
+        assert!(!diagnostic.contains("operator"));
+        assert!(!diagnostic.contains("super-secret"));
+        assert!(!diagnostic.contains("query-secret"));
+    }
 
     #[test]
     fn test_validate_private_key_rsa() {
@@ -2175,11 +2289,11 @@ MIIBkTCB+wIJAKHBfpeg...
     fn test_api_url() {
         assert_eq!(
             api_url("http://localhost:3000", "/domains"),
-            "http://localhost:3000/domains"
+            "http://localhost:3000/api/domains"
         );
         assert_eq!(
-            api_url("http://localhost:3000/", "/domains"),
-            "http://localhost:3000/domains"
+            api_url("http://localhost:3000/api/", "/domains"),
+            "http://localhost:3000/api/domains"
         );
     }
 
@@ -2290,5 +2404,140 @@ MIIBkTCB+wIJAKHBfpeg...
         }"#;
         let parsed: DomainResponse = serde_json::from_str(json).unwrap();
         assert!(parsed.on_demand_backoff_until.is_none());
+    }
+
+    #[tokio::test]
+    async fn domain_list_uses_api_prefix_and_decodes_millis_and_pem() {
+        async fn domains(headers: HeaderMap) -> impl IntoResponse {
+            if headers
+                .get(header::AUTHORIZATION)
+                .and_then(|v| v.to_str().ok())
+                != Some("Bearer test-token")
+            {
+                return StatusCode::UNAUTHORIZED.into_response();
+            }
+
+            Json(serde_json::json!({
+                "domains": [{
+                    "id": 7,
+                    "domain": "example.com",
+                    "status": "active",
+                    "expiration_time": 1796278035000_i64,
+                    "last_renewed": 1788505547092_i64,
+                    "created_at": 1788505084030_i64,
+                    "updated_at": 1788505547092_i64,
+                    "certificate": "-----BEGIN CERTIFICATE-----\nMIIB-test-chain\n-----END CERTIFICATE-----\n",
+                    "is_wildcard": false,
+                    "verification_method": "dns-01"
+                }],
+                "total": 1,
+                "page": 1,
+                "page_size": 20
+            }))
+            .into_response()
+        }
+
+        let app = Router::new()
+            .route("/api/domains", get(domains))
+            // Mirrors the console SPA fallback that previously returned HTTP
+            // 200 HTML for the CLI's incorrect `/domains` request.
+            .fallback(|| async { Html("<html>Temps console</html>") });
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test listener");
+        let address = listener.local_addr().expect("read test listener address");
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve test router");
+        });
+
+        let result = execute_list_api(ListDomainsApiCommand {
+            api_url: format!("http://{address}"),
+            api_token: "test-token".to_string(),
+            on_demand: false,
+            json: true,
+        })
+        .await;
+
+        server.abort();
+        assert!(result.is_ok(), "domain list failed: {result:?}");
+    }
+
+    #[tokio::test]
+    async fn domain_show_by_hostname_uses_encoded_api_route_and_decodes_response() {
+        async fn domain_by_host(
+            axum::extract::Path(hostname): axum::extract::Path<String>,
+        ) -> impl IntoResponse {
+            if hostname != "*.example.com" {
+                return StatusCode::NOT_FOUND.into_response();
+            }
+            Json(serde_json::json!({
+                "id": 7,
+                "domain": hostname,
+                "status": "active",
+                "expiration_time": 1796278035000_i64,
+                "created_at": 1788505084030_i64,
+                "updated_at": 1788505547092_i64,
+                "certificate": "-----BEGIN CERTIFICATE-----\nMIIB-test-chain\n-----END CERTIFICATE-----\n",
+                "is_wildcard": true,
+                "verification_method": "dns-01"
+            }))
+            .into_response()
+        }
+
+        let app = Router::new().route("/api/domains/by-host/{hostname}", get(domain_by_host));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test listener");
+        let address = listener.local_addr().expect("read test listener address");
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve test router");
+        });
+
+        let result = execute_show(ShowDomainCommand {
+            id: None,
+            domain: Some("*.example.com".to_string()),
+            api_url: format!("http://{address}"),
+            api_token: "test-token".to_string(),
+            json: true,
+        })
+        .await;
+
+        server.abort();
+        assert!(result.is_ok(), "domain show failed: {result:?}");
+    }
+
+    #[tokio::test]
+    async fn html_decode_error_identifies_endpoint_and_configuration_hint() {
+        let app = Router::new().route(
+            "/api/domains",
+            get(|| async { Html("<html>not JSON</html>") }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test listener");
+        let address = listener.local_addr().expect("read test listener address");
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve test router");
+        });
+
+        let error = execute_list_api(ListDomainsApiCommand {
+            api_url: format!("http://{address}"),
+            api_token: "test-token".to_string(),
+            on_demand: false,
+            json: true,
+        })
+        .await
+        .expect_err("HTML response must not decode as a domain list");
+
+        server.abort();
+        let message = error.to_string();
+        assert!(message.contains("GET http://"));
+        assert!(message.contains("/api/domains"));
+        assert!(message.contains("text/html"));
+        assert!(message.contains("CLI adds /api automatically"));
+        assert!(
+            !message.contains("not JSON"),
+            "response body leaked: {message}"
+        );
     }
 }

--- a/crates/temps-cli/src/commands/join.rs
+++ b/crates/temps-cli/src/commands/join.rs
@@ -12,6 +12,8 @@
 
 use clap::Args;
 
+use super::api_url::management_api_url;
+
 /// Join this machine to a Temps cluster as a worker node
 #[derive(Args)]
 pub struct JoinCommand {
@@ -283,7 +285,7 @@ impl JoinCommand {
         // opt-in does NOT apply to CLI binaries on purpose.
         let client = reqwest::Client::builder().build()?;
 
-        let register_url = format!("{}/api/internal/nodes/register", self.target);
+        let register_url = management_api_url(&self.target, "/internal/nodes/register");
 
         // Generate per-node mTLS material; send the CSR so the control plane
         // can sign a leaf for us (ADR-020 WS-2.1). The leaf must be valid for
@@ -440,9 +442,9 @@ impl JoinCommand {
         // hijack worker registration.
         let register_client = reqwest::Client::builder().build()?;
 
-        let register_url = format!(
-            "{}/api/internal/nodes/register",
-            relay_response.control_plane_url
+        let register_url = management_api_url(
+            &relay_response.control_plane_url,
+            "/internal/nodes/register",
         );
 
         let agent_port = self

--- a/crates/temps-cli/src/commands/mod.rs
+++ b/crates/temps-cli/src/commands/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod agent;
 pub mod api_key;
+mod api_url;
 pub mod backfill;
 pub mod backup;
 pub mod build;

--- a/crates/temps-cli/src/commands/network.rs
+++ b/crates/temps-cli/src/commands/network.rs
@@ -22,6 +22,8 @@ use clap::{Args, Subcommand};
 use colored::Colorize;
 use serde::Deserialize;
 
+use super::api_url::management_api_url;
+
 /// Inspect the multi-host overlay on this node and across the cluster.
 #[derive(Args)]
 pub struct NetworkCommand {
@@ -446,10 +448,9 @@ fn ping(host: &str, count: u32) -> bool {
 // ---------------------------------------------------------------------------
 
 async fn fetch_peers(auth: &ResolvedAuth) -> anyhow::Result<WirePeerListResponse> {
-    let url = format!(
-        "{}/api/internal/nodes/{}/network/peers",
-        auth.control_plane_url.trim_end_matches('/'),
-        auth.node_id
+    let url = management_api_url(
+        &auth.control_plane_url,
+        &format!("/internal/nodes/{}/network/peers", auth.node_id),
     );
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(15))

--- a/crates/temps-cli/src/commands/node.rs
+++ b/crates/temps-cli/src/commands/node.rs
@@ -10,6 +10,8 @@ use clap::{Args, Subcommand};
 use colored::Colorize;
 use serde::Deserialize;
 
+use super::api_url::management_api_url;
+
 /// Worker node management commands
 #[derive(Args)]
 pub struct NodeCommand {
@@ -164,8 +166,7 @@ struct ProblemDetail {
 // ── Helpers ──
 
 fn api_url(base: &str, path: &str) -> String {
-    let base = base.trim_end_matches('/');
-    format!("{}/api/internal{}", base, path)
+    management_api_url(base, &format!("/internal{}", path))
 }
 
 fn make_client() -> reqwest::Client {

--- a/crates/temps-cli/src/commands/upgrade.rs
+++ b/crates/temps-cli/src/commands/upgrade.rs
@@ -1012,12 +1012,14 @@ pub(crate) fn platform_target() -> anyhow::Result<String> {
 pub async fn fetch_latest_release_in_channel(
     channel: UpgradeChannel,
 ) -> anyhow::Result<GitHubRelease> {
-    fetch_latest_release_in_channel_from(channel, GITHUB_RELEASES_API).await
+    let target = platform_target()?;
+    fetch_latest_release_in_channel_from(channel, GITHUB_RELEASES_API, &target).await
 }
 
 async fn fetch_latest_release_in_channel_from(
     channel: UpgradeChannel,
     releases_api: &str,
+    target: &str,
 ) -> anyhow::Result<GitHubRelease> {
     let client = reqwest::Client::new();
     let mut releases = Vec::new();
@@ -1055,15 +1057,20 @@ async fn fetch_latest_release_in_channel_from(
         page += 1;
     }
 
-    pick_release_for_channel(releases, channel).ok_or_else(|| match channel {
+    pick_installable_release_for_channel(releases, channel, target).ok_or_else(|| match channel {
         UpgradeChannel::Stable => anyhow::anyhow!(
-            "No stable releases found. Try `--channel beta` to include prereleases."
+            "No stable releases with a temps-{}.tar.gz asset found. Try `--channel beta` to include prereleases.",
+            target
         ),
-        UpgradeChannel::Beta => anyhow::anyhow!("No releases found."),
+        UpgradeChannel::Beta => anyhow::anyhow!(
+            "No stable or beta releases with a temps-{}.tar.gz asset found.",
+            target
+        ),
         UpgradeChannel::Nightly => anyhow::anyhow!(
-            "No nightly releases found. The nightly build only cuts a new tag when \
+            "No nightly releases with a temps-{}.tar.gz asset found. The nightly build only cuts a new tag when \
              `main` has commits since the last one — check the 'Nightly Release' \
-             workflow run history, or try `--channel beta`."
+             workflow run history, or try `--channel beta`.",
+            target
         ),
     })
 }
@@ -1085,6 +1092,30 @@ fn pick_release_for_channel(
         })
         .max_by(|left, right| left.0.cmp(&right.0))
         .map(|(_, release)| release)
+}
+
+/// Select the newest release that this host can actually install. GitHub can
+/// contain semver-valid test releases without binary assets; selecting one of
+/// those makes `temps upgrade --check` fail even when an older, real release
+/// exists in the same channel.
+fn pick_installable_release_for_channel(
+    releases: Vec<GitHubRelease>,
+    channel: UpgradeChannel,
+    target: &str,
+) -> Option<GitHubRelease> {
+    let tarball_name = format!("temps-{}.tar.gz", target);
+    pick_release_for_channel(
+        releases
+            .into_iter()
+            .filter(|release| {
+                release
+                    .assets
+                    .iter()
+                    .any(|asset| asset.name == tarball_name)
+            })
+            .collect(),
+        channel,
+    )
 }
 
 /// Normalize a caller-supplied version into a release tag, rejecting anything
@@ -2803,6 +2834,21 @@ mod tests {
         }
     }
 
+    fn release_with_asset(
+        tag: &str,
+        prerelease: bool,
+        draft: bool,
+        asset_name: &str,
+    ) -> GitHubRelease {
+        let mut release = release(tag, prerelease, draft);
+        release.assets.push(GitHubAsset {
+            name: asset_name.to_string(),
+            browser_download_url: format!("https://example.test/{asset_name}"),
+            size: 1,
+        });
+        release
+    }
+
     #[test]
     fn channel_includes_only_non_prerelease_for_stable() {
         // Stable must reject any prerelease tag, even if it's newer.
@@ -2914,6 +2960,23 @@ mod tests {
     }
 
     #[test]
+    fn installable_picker_skips_newer_release_without_platform_asset() {
+        let releases = vec![
+            release("v1.3.0-test", true, false),
+            release_with_asset("v1.2.0-beta.4", true, false, "temps-darwin-arm64.tar.gz"),
+            release_with_asset("v1.1.0-beta.3", true, false, "temps-linux-amd64.tar.gz"),
+        ];
+
+        let picked =
+            pick_installable_release_for_channel(releases, UpgradeChannel::Beta, "darwin-arm64");
+
+        assert_eq!(
+            picked.expect("an installable beta should remain").tag_name,
+            "v1.2.0-beta.4"
+        );
+    }
+
+    #[test]
     fn release_lookup_continues_until_github_returns_a_short_page() {
         let nightlies: Vec<_> = (0..100)
             .map(|index| {
@@ -2947,7 +3010,11 @@ mod tests {
                             "tag_name": format!("v1.0.0-nightly.202609{:02}.abc1234", index),
                             "prerelease": true,
                             "draft": false,
-                            "assets": [],
+                            "assets": [{
+                                "name": "temps-test-target.tar.gz",
+                                "browser_download_url": "https://example.test/nightly.tar.gz",
+                                "size": 1
+                            }],
                             "html_url": "https://example.test/nightly"
                         })
                     })
@@ -2957,7 +3024,11 @@ mod tests {
                     "tag_name": "v0.0.8",
                     "prerelease": false,
                     "draft": false,
-                    "assets": [],
+                    "assets": [{
+                        "name": "temps-test-target.tar.gz",
+                        "browser_download_url": "https://example.test/stable.tar.gz",
+                        "size": 1
+                    }],
                     "html_url": "https://example.test/stable"
                 })]
             };
@@ -2979,6 +3050,7 @@ mod tests {
         let selected = fetch_latest_release_in_channel_from(
             UpgradeChannel::Stable,
             &format!("http://{address}/releases"),
+            "test-target",
         )
         .await
         .expect("stable release should be found on page two");

--- a/crates/temps-cli/src/commands/upgrade.rs
+++ b/crates/temps-cli/src/commands/upgrade.rs
@@ -299,6 +299,17 @@ impl UpgradeCommand {
             return Ok(());
         }
 
+        // Channel selection is not permission to go backwards. This matters
+        // when a beta installation runs plain `temps upgrade`: the newest
+        // stable release can be older than the installed beta. An explicit
+        // --version remains the deliberate escape hatch for rollback.
+        ensure_implicit_upgrade_is_not_downgrade(
+            self.version.as_deref(),
+            channel,
+            &current_version,
+            latest_version,
+        )?;
+
         // Find the matching asset
         let tarball_name = format!("temps-{}.tar.gz", target);
         let asset = release
@@ -839,6 +850,36 @@ pub(crate) fn is_newer_version(candidate: &str, current: &str) -> bool {
     }
 }
 
+/// Is `candidate` strictly older than `current`? Unparsable development or
+/// fork tags are not classified as downgrades so existing explicit workflows
+/// keep working; official release tags are always semver-shaped.
+fn is_older_version(candidate: &str, current: &str) -> bool {
+    match (version_sort_key(candidate), version_sort_key(current)) {
+        (Some(candidate_key), Some(current_key)) => candidate_key < current_key,
+        _ => false,
+    }
+}
+
+fn ensure_implicit_upgrade_is_not_downgrade(
+    requested_version: Option<&str>,
+    channel: UpgradeChannel,
+    current: &str,
+    candidate: &str,
+) -> anyhow::Result<()> {
+    if requested_version.is_none() && is_older_version(candidate, current) {
+        anyhow::bail!(
+            "Refusing to downgrade temps from {} to {} selected by the '{}' channel. \
+             Choose a channel that contains a newer release (for example `--channel beta`) \
+             or explicitly authorize the rollback with `--version {}`.",
+            current,
+            candidate,
+            channel.as_str(),
+            candidate
+        );
+    }
+    Ok(())
+}
+
 /// One background update check: fetch the newest release on this install's
 /// channel and return a notice if it is strictly newer than the running
 /// binary. Every failure path (network, GitHub quota, unparsable tags)
@@ -960,10 +1001,10 @@ pub(crate) fn platform_target() -> anyhow::Result<String> {
 
 /// Fetch the latest release on a given channel from GitHub.
 ///
-/// Pulls the first page of releases (per_page=20, GitHub's default ordering
-/// is most-recent-first) and returns the first one that belongs to the
-/// requested channel. 20 is enough to find the newest stable even on a
-/// project that ships many betas between stables.
+/// Pulls every release page and returns the greatest semantic version for the
+/// requested channel. GitHub orders by creation time, so nightly releases can
+/// push the latest stable beyond the first page and backfilled releases can
+/// violate semantic-version order.
 ///
 /// Note: this returns the channel's *newest* release, which may be older
 /// than the absolute newest tag — that's the point. A `Stable` host on a
@@ -971,30 +1012,48 @@ pub(crate) fn platform_target() -> anyhow::Result<String> {
 pub async fn fetch_latest_release_in_channel(
     channel: UpgradeChannel,
 ) -> anyhow::Result<GitHubRelease> {
+    fetch_latest_release_in_channel_from(channel, GITHUB_RELEASES_API).await
+}
+
+async fn fetch_latest_release_in_channel_from(
+    channel: UpgradeChannel,
+    releases_api: &str,
+) -> anyhow::Result<GitHubRelease> {
     let client = reqwest::Client::new();
-    let url = format!("{}?per_page=20", GITHUB_RELEASES_API);
-    let response = client
-        .get(&url)
-        .header("User-Agent", "temps-self-upgrade")
-        .header("Accept", "application/vnd.github.v3+json")
-        .send()
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to fetch releases: {}", e))?;
+    let mut releases = Vec::new();
+    let mut page = 1_u32;
+    loop {
+        let url = format!("{}?per_page=100&page={}", releases_api, page);
+        let response = client
+            .get(&url)
+            .header("User-Agent", "temps-self-upgrade")
+            .header("Accept", "application/vnd.github.v3+json")
+            .send()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to fetch release page {}: {}", page, e))?;
 
-    if !response.status().is_success() {
-        let status = response.status();
-        let body = response.text().await.unwrap_or_default();
-        return Err(anyhow::anyhow!(
-            "GitHub API returned {} when fetching releases: {}",
-            status,
-            body
-        ));
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(anyhow::anyhow!(
+                "GitHub API returned {} when fetching release page {}: {}",
+                status,
+                page,
+                body
+            ));
+        }
+
+        let page_releases: Vec<GitHubRelease> = response.json().await.map_err(|e| {
+            anyhow::anyhow!("Failed to parse releases response page {}: {}", page, e)
+        })?;
+        let fetch_next_page = release_page_requires_next(&page_releases);
+        releases.extend(page_releases);
+
+        if !fetch_next_page {
+            break;
+        }
+        page += 1;
     }
-
-    let releases: Vec<GitHubRelease> = response
-        .json()
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to parse releases response: {}", e))?;
 
     pick_release_for_channel(releases, channel).ok_or_else(|| match channel {
         UpgradeChannel::Stable => anyhow::anyhow!(
@@ -1009,12 +1068,23 @@ pub async fn fetch_latest_release_in_channel(
     })
 }
 
+fn release_page_requires_next(releases: &[GitHubRelease]) -> bool {
+    releases.len() == 100
+}
+
 /// Pure picker — split out so tests can drive it without an HTTP mock.
 fn pick_release_for_channel(
     releases: Vec<GitHubRelease>,
     channel: UpgradeChannel,
 ) -> Option<GitHubRelease> {
-    releases.into_iter().find(|r| channel.includes(r))
+    releases
+        .into_iter()
+        .filter(|release| channel.includes(release))
+        .filter_map(|release| {
+            version_sort_key(&release.tag_name).map(|sort_key| (sort_key, release))
+        })
+        .max_by(|left, right| left.0.cmp(&right.0))
+        .map(|(_, release)| release)
 }
 
 /// Normalize a caller-supplied version into a release tag, rejecting anything
@@ -2643,6 +2713,50 @@ mod tests {
     }
 
     #[test]
+    fn implicit_channel_selection_detects_downgrades() {
+        assert!(is_older_version("v0.0.8", "v0.1.0-beta.56"));
+        assert!(is_older_version("v1.0.0-beta.2", "v1.0.0"));
+        assert!(!is_older_version("v1.0.0", "v1.0.0-beta.2"));
+        assert!(!is_older_version("v1.0.0", "v1.0.0"));
+        assert!(!is_older_version("stable", "local-dev"));
+    }
+
+    #[test]
+    fn implicit_upgrade_policy_refuses_downgrades_but_allows_explicit_rollbacks() {
+        let error = ensure_implicit_upgrade_is_not_downgrade(
+            None,
+            UpgradeChannel::Stable,
+            "v0.1.0-beta.56",
+            "v0.0.8",
+        )
+        .expect_err("implicit stable selection must not downgrade a beta host");
+        assert!(error.to_string().contains("Refusing to downgrade"));
+        assert!(error.to_string().contains("--channel beta"));
+
+        assert!(ensure_implicit_upgrade_is_not_downgrade(
+            Some("v0.0.8"),
+            UpgradeChannel::Stable,
+            "v0.1.0-beta.56",
+            "v0.0.8",
+        )
+        .is_ok());
+        assert!(ensure_implicit_upgrade_is_not_downgrade(
+            None,
+            UpgradeChannel::Beta,
+            "v0.1.0-beta.56",
+            "v0.1.0-beta.57",
+        )
+        .is_ok());
+        assert!(ensure_implicit_upgrade_is_not_downgrade(
+            None,
+            UpgradeChannel::Stable,
+            "v1.0.0",
+            "v1.0.0",
+        )
+        .is_ok());
+    }
+
+    #[test]
     fn test_update_check_interval_defaults_to_two_hours() {
         assert_eq!(
             DEFAULT_UPDATE_CHECK_INTERVAL,
@@ -2741,17 +2855,15 @@ mod tests {
     }
 
     #[test]
-    fn picker_returns_first_matching_in_response_order() {
-        // GitHub returns releases newest-first. Picker takes the first
-        // match, which is the newest release on that channel. We trust
-        // GitHub's ordering here — re-sorting by semver locally would
-        // also have to handle prerelease ordering correctly, and we'd
-        // rather lean on GitHub than reimplement it.
+    fn picker_returns_highest_semver_even_when_response_order_differs() {
+        // Release creation order is not semantic-version order when a release
+        // is backfilled or republished. The picker must not select an older
+        // candidate merely because GitHub returned it first.
         let releases = vec![
-            release("v1.3.0-beta.2", true, false), // newest, beta
-            release("v1.3.0-beta.1", true, false),
-            release("v1.2.0", false, false), // newest stable
             release("v1.1.0", false, false),
+            release("v1.3.0-beta.1", true, false),
+            release("v1.2.0", false, false),
+            release("v1.3.0-beta.2", true, false),
         ];
 
         let picked_stable = pick_release_for_channel(releases.clone(), UpgradeChannel::Stable);
@@ -2782,6 +2894,97 @@ mod tests {
             picked.expect("should fall through to v1.9.0").tag_name,
             "v1.9.0"
         );
+    }
+
+    #[test]
+    fn picker_skips_malformed_release_tags() {
+        let mixed = vec![
+            release("latest", false, false),
+            release("v1.9.0", false, false),
+        ];
+        assert_eq!(
+            pick_release_for_channel(mixed, UpgradeChannel::Stable)
+                .expect("valid semantic release should remain")
+                .tag_name,
+            "v1.9.0"
+        );
+
+        let malformed_only = vec![release("latest", false, false)];
+        assert!(pick_release_for_channel(malformed_only, UpgradeChannel::Stable).is_none());
+    }
+
+    #[test]
+    fn release_lookup_continues_until_github_returns_a_short_page() {
+        let nightlies: Vec<_> = (0..100)
+            .map(|index| {
+                release(
+                    &format!("v1.0.0-nightly.202609{:02}.abc1234", index),
+                    true,
+                    false,
+                )
+            })
+            .collect();
+
+        assert!(release_page_requires_next(&nightlies));
+
+        let mut page_with_stable = nightlies;
+        page_with_stable[99] = release("v0.0.8", false, false);
+        assert!(release_page_requires_next(&page_with_stable));
+        assert!(!release_page_requires_next(&page_with_stable[..99]));
+    }
+
+    #[tokio::test]
+    async fn release_fetch_reads_second_page_before_selecting_stable_version() {
+        use axum::{extract::Query, routing::get, Json, Router};
+        use std::collections::HashMap;
+
+        async fn releases(Query(query): Query<HashMap<String, String>>) -> Json<serde_json::Value> {
+            let page = query.get("page").map(String::as_str).unwrap_or("1");
+            let releases = if page == "1" {
+                (0..100)
+                    .map(|index| {
+                        serde_json::json!({
+                            "tag_name": format!("v1.0.0-nightly.202609{:02}.abc1234", index),
+                            "prerelease": true,
+                            "draft": false,
+                            "assets": [],
+                            "html_url": "https://example.test/nightly"
+                        })
+                    })
+                    .collect::<Vec<_>>()
+            } else {
+                vec![serde_json::json!({
+                    "tag_name": "v0.0.8",
+                    "prerelease": false,
+                    "draft": false,
+                    "assets": [],
+                    "html_url": "https://example.test/stable"
+                })]
+            };
+            Json(serde_json::Value::Array(releases))
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test listener should bind");
+        let address = listener
+            .local_addr()
+            .expect("listener should have an address");
+        let server = tokio::spawn(async move {
+            axum::serve(listener, Router::new().route("/releases", get(releases)))
+                .await
+                .expect("test release server should run");
+        });
+
+        let selected = fetch_latest_release_in_channel_from(
+            UpgradeChannel::Stable,
+            &format!("http://{address}/releases"),
+        )
+        .await
+        .expect("stable release should be found on page two");
+
+        server.abort();
+        assert_eq!(selected.tag_name, "v0.0.8");
     }
 
     #[test]

--- a/crates/temps-cli/src/lib.rs
+++ b/crates/temps-cli/src/lib.rs
@@ -491,3 +491,130 @@ mod error_metrics_layer_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod command_tree_tests {
+    use std::collections::BTreeSet;
+
+    use clap::{error::ErrorKind, Command, CommandFactory};
+
+    use super::Cli;
+
+    fn leaf_paths(command: &Command, prefix: &[String], paths: &mut BTreeSet<String>) {
+        let visible_subcommands: Vec<&Command> = command
+            .get_subcommands()
+            .filter(|subcommand| !subcommand.is_hide_set())
+            .collect();
+
+        if visible_subcommands.is_empty() {
+            if !prefix.is_empty() {
+                paths.insert(prefix.join(" "));
+            }
+            return;
+        }
+
+        for subcommand in visible_subcommands {
+            let mut next = prefix.to_vec();
+            next.push(subcommand.get_name().to_string());
+            leaf_paths(subcommand, &next, paths);
+        }
+    }
+
+    fn expected_leaf_paths() -> BTreeSet<String> {
+        [
+            "agent",
+            "api-key",
+            "backfill clickhouse",
+            "backup list",
+            "backup restore",
+            "backup restore-service",
+            "build",
+            "deploy git",
+            "deploy image",
+            "deploy static",
+            "doctor",
+            "domain add",
+            "domain cert-status",
+            "domain delete",
+            "domain import",
+            "domain list",
+            "domain order cancel",
+            "domain order create",
+            "domain order finalize",
+            "domain order list",
+            "domain order show",
+            "domain provision",
+            "domain show",
+            "edge",
+            "firecracker setup",
+            "join",
+            "migrate",
+            "network diag",
+            "network peers",
+            "network status",
+            "node drain",
+            "node list",
+            "node remove",
+            "node show",
+            "node undrain",
+            "proxy",
+            "reset-admin-password",
+            "sandbox create",
+            "sandbox exec",
+            "sandbox list",
+            "sandbox show",
+            "sandbox stop",
+            "serve",
+            "services blob disable",
+            "services blob enable",
+            "services blob status",
+            "services kv disable",
+            "services kv enable",
+            "services kv status",
+            "setup",
+            "upgrade",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect()
+    }
+
+    #[test]
+    fn every_rust_cli_leaf_is_in_the_audited_inventory() {
+        Cli::command().debug_assert();
+        let command = Cli::command();
+
+        let mut actual = BTreeSet::new();
+        leaf_paths(&command, &[], &mut actual);
+
+        let expected = expected_leaf_paths();
+        let missing: Vec<_> = expected.difference(&actual).collect();
+        let unexpected: Vec<_> = actual.difference(&expected).collect();
+        assert!(
+            missing.is_empty() && unexpected.is_empty(),
+            "CLI command inventory drifted; missing={missing:?}, unexpected={unexpected:?}"
+        );
+    }
+
+    #[test]
+    fn every_rust_cli_leaf_renders_help_without_running_side_effects() {
+        let command = Cli::command();
+        let mut paths = BTreeSet::new();
+        leaf_paths(&command, &[], &mut paths);
+
+        for path in paths {
+            let mut argv = vec!["temps".to_string()];
+            argv.extend(path.split_whitespace().map(str::to_string));
+            argv.push("--help".to_string());
+
+            let error = Cli::command()
+                .try_get_matches_from(argv)
+                .expect_err("--help must short-circuit command execution");
+            assert_eq!(
+                error.kind(),
+                ErrorKind::DisplayHelp,
+                "`temps {path} --help` did not render help: {error}"
+            );
+        }
+    }
+}

--- a/crates/temps-deployer/src/compose.rs
+++ b/crates/temps-deployer/src/compose.rs
@@ -7818,7 +7818,18 @@ services:
         let override_yaml =
             executor.generate_security_override(compose, &[], &["webserver".to_string()]);
 
-        assert!(override_yaml.is_empty());
+        let override_value: Value = serde_yaml::from_str(&override_yaml).unwrap();
+        let webserver = override_value["services"]["webserver"]
+            .as_mapping()
+            .unwrap();
+        assert_eq!(
+            webserver.get("pids_limit").and_then(Value::as_u64),
+            Some(512)
+        );
+        assert_eq!(webserver.get("init"), None);
+        assert_eq!(webserver.get("privileged"), None);
+        assert!(!webserver.contains_key("cap_drop"));
+        assert!(!webserver.contains_key("security_opt"));
     }
 
     #[test]
@@ -7987,7 +7998,7 @@ services:
     }
 
     #[test]
-    fn test_security_override_skips_only_explicitly_unsandboxed_services() {
+    fn test_security_override_keeps_bounds_for_explicitly_unsandboxed_services() {
         let Some(executor) = test_executor() else {
             return;
         };
@@ -8002,12 +8013,21 @@ services:
         let override_yaml =
             executor.generate_security_override(compose, &[], &["webserver".to_string()]);
 
-        assert!(!override_yaml.contains("  webserver:"));
+        assert!(override_yaml.contains("  webserver:"));
         assert!(override_yaml.contains("  worker:"));
         assert_eq!(override_yaml.matches("cap_drop:").count(), 1);
         assert_eq!(override_yaml.matches("no-new-privileges:true").count(), 1);
-        assert_eq!(override_yaml.matches("pids_limit: 512").count(), 1);
+        assert_eq!(override_yaml.matches("pids_limit: 512").count(), 2);
         assert_eq!(override_yaml.matches("init: true").count(), 1);
+
+        let override_value: Value = serde_yaml::from_str(&override_yaml).unwrap();
+        let webserver = override_value["services"]["webserver"]
+            .as_mapping()
+            .unwrap();
+        assert_eq!(webserver.get("init"), None);
+        assert_eq!(webserver.get("privileged"), None);
+        assert!(!webserver.contains_key("cap_drop"));
+        assert!(!webserver.contains_key("security_opt"));
     }
 
     #[tokio::test]
@@ -8111,7 +8131,7 @@ services:
         assert_ne!(image_owned_host.init, Some(true));
         assert!(image_owned_host.cap_drop.unwrap_or_default().is_empty());
         assert!(image_owned_host.security_opt.unwrap_or_default().is_empty());
-        assert!(image_owned_host.pids_limit.is_none());
+        assert_eq!(image_owned_host.pids_limit, Some(512));
 
         let sandboxed_host = sandboxed.host_config.unwrap();
         assert_eq!(sandboxed_host.init, Some(true));
@@ -8501,7 +8521,7 @@ services:
     }
 
     #[test]
-    fn test_security_override_is_empty_when_every_service_is_unsandboxed() {
+    fn test_security_override_preserves_bounds_when_every_service_is_unsandboxed() {
         let Some(executor) = test_executor() else {
             return;
         };
@@ -8510,7 +8530,21 @@ services:
         let override_yaml =
             executor.generate_security_override(compose, &[], &["webserver".to_string()]);
 
-        assert!(override_yaml.is_empty());
+        let override_value: Value = serde_yaml::from_str(&override_yaml).unwrap();
+        let webserver = override_value["services"]["webserver"]
+            .as_mapping()
+            .unwrap();
+        assert_eq!(
+            webserver.get("pids_limit").and_then(Value::as_u64),
+            Some(512)
+        );
+        assert!(webserver.contains_key("cpus"));
+        assert!(webserver.contains_key("mem_limit"));
+        assert!(webserver.contains_key("logging"));
+        assert_eq!(webserver.get("init"), None);
+        assert_eq!(webserver.get("privileged"), None);
+        assert!(!webserver.contains_key("cap_drop"));
+        assert!(!webserver.contains_key("security_opt"));
     }
 
     #[test]
@@ -8532,7 +8566,7 @@ services:
     }
 
     #[tokio::test]
-    async fn test_write_compose_files_removes_stale_security_override() {
+    async fn test_write_compose_files_rewrites_stale_security_override_with_runtime_bounds() {
         let Some(executor) = test_executor() else {
             return;
         };
@@ -8568,7 +8602,14 @@ services:
             .await
             .unwrap();
 
-        assert!(!stale_override.exists());
+        let rewritten = tokio::fs::read_to_string(&stale_override).await.unwrap();
+        assert!(rewritten.contains("pids_limit: 512"));
+        assert!(rewritten.contains("cpus:"));
+        assert!(rewritten.contains("mem_limit:"));
+        assert!(rewritten.contains("logging:"));
+        assert!(!rewritten.contains("cap_drop:"));
+        assert!(!rewritten.contains("no-new-privileges:true"));
+        assert!(!rewritten.contains("init: true"));
     }
 
     #[test]

--- a/crates/temps-deployments/src/services/job_processor.rs
+++ b/crates/temps-deployments/src/services/job_processor.rs
@@ -17,7 +17,7 @@ use temps_entities::{
     prelude::{DeploymentConfigSnapshot, DeploymentMetadata, GitPushEvent},
     types::PipelineStatus,
 };
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, trace, warn};
 
 #[derive(Debug)]
 pub enum JobProcessorError {
@@ -283,11 +283,12 @@ impl JobProcessorService {
                             });
                         }
                         _ => {
-                            // Ignore jobs that aren't handled by this processor
-                            info!("Ignoring unhandled job: {}", job);
-                            debug!(
-                                "Job type not handled by deployment processor: {}",
-                                std::any::type_name_of_val(&job)
+                            // The queue is broadcast to several specialized
+                            // processors. Seeing another processor's event is
+                            // expected, not an unhandled system error.
+                            trace!(
+                                "Deployment processor skipped event owned by another subscriber: {}",
+                                job
                             );
                         }
                     }

--- a/crates/temps-dns/src/providers/cloudflare.rs
+++ b/crates/temps-dns/src/providers/cloudflare.rs
@@ -37,6 +37,13 @@ fn map_cf_error(context: &str, error: ApiFailure) -> DnsError {
     DnsError::ApiError(format!("{context}: {error:?}"))
 }
 
+fn map_cf_delete_error(record_id: &str, error: ApiFailure) -> DnsError {
+    if matches!(&error, ApiFailure::Error(status, _) if status.as_u16() == 404) {
+        return DnsError::RecordNotFound(record_id.to_string());
+    }
+    map_cf_error("Failed to delete record", error)
+}
+
 /// Cloudflare DNS provider
 pub struct CloudflareProvider {
     client: Client,
@@ -510,7 +517,7 @@ impl DnsProvider for CloudflareProvider {
         self.client
             .request(&endpoint)
             .await
-            .map_err(|e| DnsError::ApiError(format!("Failed to delete record: {:?}", e)))?;
+            .map_err(|error| map_cf_delete_error(record_id, error))?;
 
         info!("Deleted DNS record {} from zone {}", record_id, zone_id);
         Ok(())
@@ -520,6 +527,17 @@ impl DnsProvider for CloudflareProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cloudflare::framework::response::ApiErrors;
+
+    #[test]
+    fn delete_not_found_is_typed_for_idempotent_callers() {
+        let error = map_cf_delete_error(
+            "record-42",
+            ApiFailure::Error(reqwest::StatusCode::NOT_FOUND, ApiErrors::default()),
+        );
+
+        assert!(matches!(error, DnsError::RecordNotFound(id) if id == "record-42"));
+    }
 
     // ==================== Helper function tests ====================
 

--- a/crates/temps-dns/src/providers/digitalocean.rs
+++ b/crates/temps-dns/src/providers/digitalocean.rs
@@ -228,10 +228,7 @@ impl DigitalOceanProvider {
 
         if !status.is_success() {
             let error_body = response.text().await.unwrap_or_default();
-            return Err(DnsError::ApiError(format!(
-                "API returned status {}: {}",
-                status, error_body
-            )));
+            return Err(map_delete_failure(path, status, &error_body));
         }
 
         Ok(())
@@ -430,6 +427,14 @@ impl DigitalOceanProvider {
     }
 }
 
+fn map_delete_failure(path: &str, status: reqwest::StatusCode, body: &str) -> DnsError {
+    if status == reqwest::StatusCode::NOT_FOUND {
+        DnsError::RecordNotFound(path.to_string())
+    } else {
+        DnsError::ApiError(format!("API returned status {}: {}", status, body))
+    }
+}
+
 #[async_trait]
 impl DnsProvider for DigitalOceanProvider {
     fn provider_type(&self) -> DnsProviderType {
@@ -569,6 +574,21 @@ impl DnsProvider for DigitalOceanProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn delete_not_found_is_typed_for_idempotent_callers() {
+        let error = map_delete_failure(
+            "/domains/example.com/records/42",
+            reqwest::StatusCode::NOT_FOUND,
+            "not found",
+        );
+
+        assert!(matches!(
+            error,
+            DnsError::RecordNotFound(path)
+                if path == "/domains/example.com/records/42"
+        ));
+    }
 
     #[test]
     fn test_provider_type() {

--- a/crates/temps-domains/src/domain_service.rs
+++ b/crates/temps-domains/src/domain_service.rs
@@ -534,6 +534,7 @@ impl DomainService {
                 format!("No ACME order found for domain: {}. Please create an order first using POST /domains/{}/order",
                     domain_name, domain.id)
             ))?;
+        let retain_order_for_dns_cleanup = has_pending_dns_cleanup(order.authorizations.as_ref());
 
         // Check if order is in a valid state
         if order.status != "pending" && order.status != "ready" {
@@ -636,9 +637,16 @@ impl DomainService {
 
                 let updated_domain = domain_active.update(self.db.as_ref()).await?;
 
-                // Clean up ACME order
-                if let Some(order) = self.repository.find_acme_order_by_domain(domain_id).await? {
-                    self.repository.delete_acme_order(&order.order_url).await?;
+                // Keep orders carrying provider record receipts until the
+                // handler completes (or explicitly skips) external DNS
+                // cleanup. A transient provider failure can then be retried
+                // without reissuing the certificate.
+                if !retain_order_for_dns_cleanup {
+                    if let Some(order) =
+                        self.repository.find_acme_order_by_domain(domain_id).await?
+                    {
+                        self.repository.delete_acme_order(&order.order_url).await?;
+                    }
                 }
 
                 info!(
@@ -1535,6 +1543,14 @@ pub struct OnDemandCertStatus {
 /// `source()` level joined by `: ` — for the `on_demand_cert_attempts.error_chain`
 /// audit column (ADR-018 §5). This is the operator's first-line diagnostic, so it
 /// must preserve every nested cause rather than the top-level message alone.
+fn has_pending_dns_cleanup(authorizations: Option<&serde_json::Value>) -> bool {
+    authorizations.is_some_and(|metadata| {
+        metadata
+            .get(crate::tls::models::DNS_CLEANUP_PLAN_KEY)
+            .is_some()
+    })
+}
+
 fn error_chain_string(err: &dyn std::error::Error) -> String {
     let mut parts = vec![err.to_string()];
     let mut source = err.source();
@@ -1579,6 +1595,22 @@ mod tests {
     use super::*;
     use chrono::Datelike;
     use std::sync::Arc;
+
+    #[test]
+    fn acme_orders_with_dns_cleanup_receipts_are_retained_after_issuance() {
+        let with_receipt = serde_json::json!({
+            crate::tls::models::DNS_CLEANUP_PLAN_KEY: {
+                "provider_id": 7,
+                "zone": "example.com",
+                "records": []
+            }
+        });
+        let without_receipt = serde_json::json!({"challenge_type": "dns-01"});
+
+        assert!(has_pending_dns_cleanup(Some(&with_receipt)));
+        assert!(!has_pending_dns_cleanup(Some(&without_receipt)));
+        assert!(!has_pending_dns_cleanup(None));
+    }
 
     struct MockProvider;
 

--- a/crates/temps-domains/src/handlers/domain_handler.rs
+++ b/crates/temps-domains/src/handlers/domain_handler.rs
@@ -2749,16 +2749,19 @@ async fn cleanup_dns_txt_records(
     provider: &dyn temps_dns::providers::DnsProvider,
     plan: &DnsCleanupPlan,
 ) -> Result<DnsCleanupOutcome, DnsCleanupError> {
-    // These providers expose a distinct ID for each TXT value. Azure, GCP,
-    // Route53, Namecheap, and Pebble expose one synthetic ID per RRset/name:
-    // calling their
-    // delete_record implementation could remove a sibling ACME order's
-    // value even after our exact-value filter succeeds.
+    // Cloudflare and DigitalOcean expose a distinct ID for each TXT value.
+    // Pebble is the explicitly gated, local-test-only exception: its synthetic
+    // ID is the challenge FQDN and delete_record calls challtestsrv's
+    // post-validation clear-txt endpoint. Azure, GCP, Route53, and Namecheap
+    // expose one synthetic ID per RRset/name in real user-controlled zones, so
+    // calling their delete_record implementation could remove a sibling ACME
+    // order's value even after our exact-value filter succeeds.
     let provider_type = provider.provider_type();
     if !matches!(
         provider_type,
         temps_dns::providers::DnsProviderType::Cloudflare
             | temps_dns::providers::DnsProviderType::DigitalOcean
+            | temps_dns::providers::DnsProviderType::Pebble
     ) {
         return Err(DnsCleanupError::SharedRecordSet {
             provider: provider_type,
@@ -3734,6 +3737,34 @@ mod tests {
             }
         ));
         assert_eq!(provider.record_names().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn cleanup_allows_local_test_only_pebble_provider() {
+        let provider = MockDnsProvider::seed(vec![txt_record(
+            "_acme-challenge.example.com.",
+            "_acme-challenge",
+            "completed-order-token",
+        )])
+        .with_provider_type(DnsProviderType::Pebble);
+        let plan = dns_cleanup_plan(
+            42,
+            "example.com",
+            vec![DnsCleanupRecord {
+                name: "_acme-challenge".to_string(),
+                value: "completed-order-token".to_string(),
+                record_id: "_acme-challenge.example.com.".to_string(),
+            }],
+        );
+
+        let outcome = cleanup_dns_txt_records(&provider, &plan)
+            .await
+            .expect("the gated local Pebble provider should clear its test RRset");
+
+        assert_eq!(outcome.deleted, 1);
+        assert!(outcome.errors.is_empty());
+        assert!(outcome.remaining_records.is_empty());
+        assert!(provider.record_names().is_empty());
     }
 
     #[tokio::test]

--- a/crates/temps-domains/src/handlers/domain_handler.rs
+++ b/crates/temps-domains/src/handlers/domain_handler.rs
@@ -9,6 +9,7 @@ use super::types::{
     ListRenewalAttemptsResponse, OnDemandCertAttemptResponse, OnDemandCertRow, ProvisionResponse,
     RenewalAttemptResponse, SetupDnsChallengeRequest, SetupDnsChallengeResponse, TxtRecord,
 };
+use crate::tls::models::DNS_CLEANUP_PLAN_KEY;
 use crate::tls::{ProviderError, RepositoryError, TlsError};
 use crate::DomainServiceError;
 use temps_auth::{permission_guard, require_sensitive_action, RequireAuth};
@@ -37,6 +38,149 @@ struct DomainAudit {
     context: AuditContext,
     domain: String,
     action: String,
+}
+
+/// Exact provider records created by `setup-dns`. Values are retained inside
+/// the already-private ACME order so finalization removes only this order's
+/// challenges, never a concurrent wildcard/base-domain sibling record that
+/// happens to share the same `_acme-challenge` name.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+struct DnsCleanupPlan {
+    provider_id: i32,
+    zone: String,
+    records: Vec<DnsCleanupRecord>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+struct DnsCleanupRecord {
+    name: String,
+    value: String,
+    record_id: String,
+}
+
+#[derive(Debug)]
+struct DnsSetupOutcome {
+    results: Vec<DnsChallengeRecordResult>,
+    records_created: u32,
+    cleanup_records: Vec<DnsCleanupRecord>,
+}
+
+#[derive(Debug)]
+struct DnsCleanupOutcome {
+    deleted: u32,
+    errors: Vec<DnsCleanupError>,
+    remaining_records: Vec<DnsCleanupRecord>,
+}
+
+#[async_trait::async_trait]
+trait DnsCleanupReceiptStore: Send + Sync {
+    async fn save_cleanup_order(
+        &self,
+        order: crate::tls::models::AcmeOrder,
+    ) -> Result<(), RepositoryError>;
+    async fn delete_cleanup_order(&self, order_url: &str) -> Result<(), RepositoryError>;
+}
+
+#[async_trait::async_trait]
+impl<T> DnsCleanupReceiptStore for T
+where
+    T: crate::CertificateRepository + Send + Sync + ?Sized,
+{
+    async fn save_cleanup_order(
+        &self,
+        order: crate::tls::models::AcmeOrder,
+    ) -> Result<(), RepositoryError> {
+        self.save_acme_order(order).await.map(|_| ())
+    }
+
+    async fn delete_cleanup_order(&self, order_url: &str) -> Result<(), RepositoryError> {
+        self.delete_acme_order(order_url).await
+    }
+}
+
+#[derive(Debug)]
+enum DnsCleanupResolution {
+    Complete { deleted: u32 },
+    Pending { errors: Vec<DnsCleanupError> },
+    Manual { reason: DnsCleanupError },
+}
+
+#[derive(Debug, thiserror::Error)]
+enum DnsCleanupProgressError {
+    #[error("failed to serialize remaining DNS cleanup receipt: {source}")]
+    Serialize {
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("failed to save remaining DNS cleanup receipt: {source}")]
+    Save {
+        #[source]
+        source: RepositoryError,
+    },
+    #[error("failed to clear completed DNS cleanup receipt: {source}")]
+    Delete {
+        #[source]
+        source: RepositoryError,
+    },
+}
+
+#[derive(Debug, thiserror::Error)]
+enum DnsSetupProgressError {
+    #[error("failed to serialize pre-mutation DNS cleanup intent: {source}")]
+    IntentSerialize {
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("failed to save pre-mutation DNS cleanup intent: {source}")]
+    IntentSave {
+        #[source]
+        source: RepositoryError,
+    },
+    #[error(
+        "DNS records were changed but exact cleanup receipts could not be serialized: {source}"
+    )]
+    ReceiptSerialize {
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("DNS records were changed but exact cleanup receipts could not be saved: {source}")]
+    ReceiptSave {
+        #[source]
+        source: RepositoryError,
+    },
+}
+
+impl DnsSetupProgressError {
+    fn records_may_have_changed(&self) -> bool {
+        matches!(
+            self,
+            Self::ReceiptSerialize { .. } | Self::ReceiptSave { .. }
+        )
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum DnsCleanupError {
+    #[error(
+        "DNS provider '{provider}' represents TXT values as a shared record set; automatic ACME cleanup was skipped to preserve concurrent challenge values"
+    )]
+    SharedRecordSet {
+        provider: temps_dns::providers::DnsProviderType,
+    },
+    #[error(
+        "DNS cleanup receipt for TXT record '{name}' in zone '{zone}' has no provider record ID; automatic deletion is unsafe"
+    )]
+    MissingRecordId { zone: String, name: String },
+    #[error(
+        "Failed to delete ACME TXT record '{name}' (provider record {record_id}) in DNS zone '{zone}': {source}"
+    )]
+    DeleteRecord {
+        zone: String,
+        name: String,
+        record_id: String,
+        #[source]
+        source: Box<temps_dns::errors::DnsError>,
+    },
 }
 
 impl AuditOperation for DomainAudit {
@@ -536,8 +680,11 @@ async fn get_domain_by_host(
     path = "/domains/{domain}/provision",
     responses(
         (status = 200, description = "Certificate provisioning initiated", body = ProvisionResponse),
+        (status = 400, description = "Bad request - account email or challenge is invalid"),
         (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Domain permission denied or a user account is required"),
         (status = 404, description = "Domain not found"),
+        (status = 409, description = "DNS cleanup-aware order must use the finalize endpoint"),
         (status = 500, description = "Internal server error")
     ),
     params(
@@ -590,6 +737,33 @@ async fn provision_domain(
 
     // For DNS-01 domains, use request_challenge + complete_challenge flow
     if domain_model.verification_method == "dns-01" {
+        if let Some(order) = app_state
+            .repository
+            .find_acme_order_by_domain(domain_model.id)
+            .await?
+        {
+            match dns_provision_requires_cleanup_aware_finalize(&order) {
+                Ok(true) => {
+                    return Err(ErrorBuilder::new(StatusCode::CONFLICT)
+                        .title("DNS Cleanup-Aware Finalization Required")
+                        .detail(format!(
+                            "Domain {} has automated DNS cleanup receipts. Finalize it with `temps domain order finalize --domain-id {}` so certificate issuance and DNS cleanup complete together.",
+                            domain, domain_model.id
+                        ))
+                        .build());
+                }
+                Ok(false) => {}
+                Err(source) => {
+                    return Err(ErrorBuilder::new(StatusCode::INTERNAL_SERVER_ERROR)
+                        .title("Invalid DNS Cleanup Metadata")
+                        .detail(format!(
+                            "Cannot read persisted DNS cleanup metadata for domain {} (ID {}): {}",
+                            domain, domain_model.id, source
+                        ))
+                        .build());
+                }
+            }
+        }
         info!(
             "Starting DNS-01 challenge provisioning for domain: {} for user: {}",
             domain,
@@ -811,8 +985,13 @@ async fn check_domain_status(
     path = "/domains/{domain_id}/order/finalize",
     responses(
         (status = 200, description = "Order finalized successfully", body = DomainResponse),
+        (status = 400, description = "Bad request - account email or ACME order is invalid"),
         (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Domain or DNS provider permission denied"),
         (status = 404, description = "Domain or order not found"),
+        (status = 409, description = "Certificate issued but DNS cleanup requires operator action"),
+        (status = 502, description = "Certificate issued but DNS provider cleanup failed"),
+        (status = 503, description = "Certificate issued but DNS provider service is unavailable"),
         (status = 500, description = "Internal server error")
     ),
     params(
@@ -864,22 +1043,249 @@ async fn finalize_order(
         })?;
 
     let domain_name = domain_model.domain.clone();
+    let cleanup_order = if domain_model.verification_method == "dns-01" {
+        match app_state
+            .repository
+            .find_acme_order_by_domain(domain_id)
+            .await?
+        {
+            Some(order) => match load_dns_cleanup_plan(&order) {
+                Ok(Some(plan)) => Some((order, plan)),
+                Ok(None) => None,
+                Err(source) => {
+                    return Err(ErrorBuilder::new(StatusCode::INTERNAL_SERVER_ERROR)
+                        .title("Invalid DNS Cleanup Metadata")
+                        .detail(format!(
+                            "Cannot read persisted DNS cleanup metadata for domain {} (ID {}): {}",
+                            domain_name, domain_id, source
+                        ))
+                        .build())
+                }
+            },
+            None => None,
+        }
+    } else {
+        None
+    };
+    // Finalization normally needs only domain access. A persisted cleanup plan
+    // turns it into an external DNS mutation, so require the same DNS provider
+    // permission that setup-dns required when the plan was created.
+    ensure_dns_cleanup_permission(&auth, cleanup_order.is_some())?;
     info!(
         "Finalizing order for domain: {} (ID: {}) for user: {}",
         domain_name, domain_id, user_email
     );
 
-    // Complete the challenge (after user has added DNS record or HTTP token is served)
-    let domain = app_state
-        .domain_service
-        .complete_challenge(&domain_name, user_email)
-        .await
-        .map_err(|e| {
-            error!("Failed to finalize order for domain {}: {}", domain_name, e);
-            e
-        })?;
+    // A previous call may have issued the certificate but left the cleanup
+    // receipt for retry after a transient provider failure. Do not submit the
+    // already-finalized ACME order again in that case.
+    let domain =
+        if should_retry_dns_cleanup_without_issuance(&domain_model.status, cleanup_order.is_some())
+        {
+            info!(
+                "Retrying pending ACME DNS cleanup for already-active domain {} (ID {})",
+                domain_name, domain_id
+            );
+            domain_model
+        } else {
+            app_state
+                .domain_service
+                .complete_challenge(&domain_name, user_email)
+                .await
+                .map_err(|e| {
+                    error!("Failed to finalize order for domain {}: {}", domain_name, e);
+                    e
+                })?
+        };
 
     info!("Order finalized successfully for domain: {}", domain.domain);
+
+    let mut cleanup_problem = None;
+    let mut cleanup_audit_action = "DOMAIN_ORDER_FINALIZED";
+    if let Some((order, plan)) = cleanup_order {
+        match app_state.dns_provider_service.as_ref() {
+            Some(dns_provider_service) => match dns_provider_service.get(plan.provider_id).await {
+                Ok(provider) if provider.is_active => {
+                    match dns_provider_service.create_provider_instance(&provider) {
+                        Ok(provider_instance) => {
+                            match execute_dns_cleanup(
+                                provider_instance.as_ref(),
+                                app_state.repository.as_ref(),
+                                order,
+                                plan,
+                            )
+                            .await
+                            {
+                                Ok(DnsCleanupResolution::Complete { deleted }) => {
+                                    cleanup_audit_action =
+                                        "DOMAIN_ORDER_FINALIZED_DNS_CLEANUP_COMPLETE";
+                                    info!(
+                                        "Removed {} ACME DNS TXT record(s) for domain {} after certificate issuance",
+                                        deleted, domain_name
+                                    );
+                                }
+                                Ok(DnsCleanupResolution::Pending { errors }) => {
+                                    for cleanup_error in errors {
+                                        warn!(
+                                            "ACME DNS cleanup was incomplete for domain {} (ID {}): {}",
+                                            domain_name, domain_id, cleanup_error
+                                        );
+                                    }
+                                    cleanup_problem = Some(
+                                        ErrorBuilder::new(StatusCode::BAD_GATEWAY)
+                                            .title("Certificate Issued; DNS Cleanup Pending")
+                                            .detail(format!(
+                                                "The certificate for domain {} was issued, but one or more ACME TXT records could not be removed. Retry finalization to complete cleanup.",
+                                                domain_name
+                                            ))
+                                            .build(),
+                                    );
+                                    cleanup_audit_action =
+                                        "DOMAIN_ORDER_FINALIZED_DNS_CLEANUP_PENDING";
+                                }
+                                Ok(DnsCleanupResolution::Manual {
+                                    reason: DnsCleanupError::SharedRecordSet { provider },
+                                }) => {
+                                    warn!(
+                                        "Automatic ACME DNS cleanup is unsafe for provider {} on domain {} (ID {}); manual cleanup is required",
+                                        provider, domain_name, domain_id
+                                    );
+                                    cleanup_problem = Some(
+                                        ErrorBuilder::new(StatusCode::CONFLICT)
+                                            .title("Certificate Issued; Manual DNS Cleanup Required")
+                                            .detail(format!(
+                                                "The certificate for domain {} was issued, but provider {} cannot safely delete one TXT value from a shared record set. Inspect this order's DNS challenge values, remove them manually, then cancel the order to clear its retained cleanup receipt.",
+                                                domain_name, provider
+                                            ))
+                                            .build(),
+                                    );
+                                    cleanup_audit_action =
+                                        "DOMAIN_ORDER_FINALIZED_MANUAL_DNS_CLEANUP";
+                                }
+                                Ok(DnsCleanupResolution::Manual {
+                                    reason: DnsCleanupError::MissingRecordId { zone, name },
+                                }) => {
+                                    warn!(
+                                        "Automatic ACME DNS cleanup lacks a provider record ID for {} in zone {} on domain {} (ID {}); manual cleanup is required",
+                                        name, zone, domain_name, domain_id
+                                    );
+                                    cleanup_problem = Some(
+                                        ErrorBuilder::new(StatusCode::CONFLICT)
+                                            .title("Certificate Issued; Manual DNS Cleanup Required")
+                                            .detail(format!(
+                                                "The certificate for domain {} was issued, but an exact provider record ID was not available. Inspect this order's DNS challenge values, remove them manually, then cancel the order to clear its retained cleanup receipt.",
+                                                domain_name
+                                            ))
+                                            .build(),
+                                    );
+                                    cleanup_audit_action =
+                                        "DOMAIN_ORDER_FINALIZED_MANUAL_DNS_CLEANUP";
+                                }
+                                Ok(DnsCleanupResolution::Manual { reason }) => {
+                                    warn!(
+                                        "ACME DNS cleanup failed for domain {} (ID {}): {}",
+                                        domain_name, domain_id, reason
+                                    );
+                                    cleanup_problem = Some(
+                                        ErrorBuilder::new(StatusCode::BAD_GATEWAY)
+                                            .title("Certificate Issued; DNS Cleanup Pending")
+                                            .detail(format!(
+                                                "The certificate for domain {} was issued, but ACME TXT cleanup failed. Retry finalization to complete cleanup.",
+                                                domain_name
+                                            ))
+                                            .build(),
+                                    );
+                                    cleanup_audit_action =
+                                        "DOMAIN_ORDER_FINALIZED_DNS_CLEANUP_PENDING";
+                                }
+                                Err(source) => {
+                                    warn!(
+                                        "DNS cleanup progress could not be persisted for domain {} (ID {}): {}",
+                                        domain_name, domain_id, source
+                                    );
+                                    cleanup_problem = Some(
+                                        ErrorBuilder::new(StatusCode::INTERNAL_SERVER_ERROR)
+                                            .title("Certificate Issued; DNS Cleanup Progress Pending")
+                                            .detail(format!(
+                                                "The certificate for domain {} was issued, but cleanup progress could not be saved. Retry finalization; already-absent provider records are handled safely.",
+                                                domain_name
+                                            ))
+                                            .build(),
+                                    );
+                                    cleanup_audit_action =
+                                        "DOMAIN_ORDER_FINALIZED_DNS_CLEANUP_PROGRESS_PENDING";
+                                }
+                            }
+                        }
+                        Err(source) => {
+                            warn!(
+                                "Could not initialize DNS provider {} to clean ACME records for domain {} (ID {}): {}",
+                                plan.provider_id, domain_name, domain_id, source
+                            );
+                            cleanup_problem = Some(
+                                ErrorBuilder::new(StatusCode::BAD_GATEWAY)
+                                    .title("Certificate Issued; DNS Cleanup Pending")
+                                    .detail(format!(
+                                        "The certificate for domain {} was issued, but its DNS provider could not be initialized. Retry finalization to complete cleanup.",
+                                        domain_name
+                                    ))
+                                    .build(),
+                            );
+                            cleanup_audit_action = "DOMAIN_ORDER_FINALIZED_DNS_CLEANUP_PENDING";
+                        }
+                    }
+                }
+                Ok(_) => {
+                    warn!(
+                        "DNS provider {} is inactive; ACME TXT records for domain {} (ID {}) were not removed",
+                        plan.provider_id, domain_name, domain_id
+                    );
+                    cleanup_problem = Some(
+                        ErrorBuilder::new(StatusCode::CONFLICT)
+                            .title("Certificate Issued; DNS Cleanup Pending")
+                            .detail(format!(
+                                "The certificate for domain {} was issued, but DNS provider {} is inactive. Reactivate it and retry finalization to complete cleanup.",
+                                domain_name, plan.provider_id
+                            ))
+                            .build(),
+                    );
+                    cleanup_audit_action = "DOMAIN_ORDER_FINALIZED_DNS_CLEANUP_PENDING";
+                }
+                Err(source) => {
+                    warn!(
+                        "Could not load DNS provider {} to clean ACME records for domain {} (ID {}): {}",
+                        plan.provider_id, domain_name, domain_id, source
+                    );
+                    cleanup_problem = Some(
+                        ErrorBuilder::new(StatusCode::BAD_GATEWAY)
+                            .title("Certificate Issued; DNS Cleanup Pending")
+                            .detail(format!(
+                                "The certificate for domain {} was issued, but DNS provider {} could not be loaded. Retry finalization to complete cleanup.",
+                                domain_name, plan.provider_id
+                            ))
+                            .build(),
+                    );
+                    cleanup_audit_action = "DOMAIN_ORDER_FINALIZED_DNS_CLEANUP_PENDING";
+                }
+            },
+            None => {
+                warn!(
+                    "DNS provider service is unavailable; ACME TXT records for domain {} (ID {}) were not removed",
+                    domain_name, domain_id
+                );
+                cleanup_problem = Some(
+                    ErrorBuilder::new(StatusCode::SERVICE_UNAVAILABLE)
+                        .title("Certificate Issued; DNS Cleanup Pending")
+                        .detail(format!(
+                            "The certificate for domain {} was issued, but the DNS provider service is unavailable. Retry finalization to complete cleanup.",
+                            domain_name
+                        ))
+                        .build(),
+                );
+                cleanup_audit_action = "DOMAIN_ORDER_FINALIZED_DNS_CLEANUP_PENDING";
+            }
+        }
+    }
 
     app_state.telemetry.report(
         temps_core::telemetry::TelemetryEvent::new(
@@ -898,13 +1304,40 @@ async fn finalize_order(
             user_agent: metadata.user_agent.clone(),
         },
         domain: domain_name,
-        action: "DOMAIN_ORDER_FINALIZED".to_string(),
+        action: cleanup_audit_action.to_string(),
     };
     if let Err(e) = app_state.audit_service.create_audit_log(&audit).await {
         error!("Failed to create audit log: {}", e);
     }
 
+    if let Some(problem) = cleanup_problem {
+        return Err(problem);
+    }
+
     Ok((StatusCode::OK, Json(DomainResponse::from(domain))))
+}
+
+fn should_retry_dns_cleanup_without_issuance(
+    domain_status: &str,
+    has_cleanup_receipt: bool,
+) -> bool {
+    has_cleanup_receipt && domain_status == "active"
+}
+
+fn dns_provision_requires_cleanup_aware_finalize(
+    order: &crate::tls::models::AcmeOrder,
+) -> Result<bool, serde_json::Error> {
+    load_dns_cleanup_plan(order).map(|plan| plan.is_some())
+}
+
+fn ensure_dns_cleanup_permission(
+    auth: &temps_auth::AuthContext,
+    cleanup_required: bool,
+) -> Result<(), Problem> {
+    if cleanup_required {
+        permission_guard!(auth, DnsProvidersWrite);
+    }
+    Ok(())
 }
 
 /// Cancel ACME order for a domain
@@ -1868,23 +2301,7 @@ async fn list_orders(
 
     let orders: Vec<AcmeOrderResponse> = acme_orders
         .into_iter()
-        .map(|order| AcmeOrderResponse {
-            id: order.id,
-            order_url: order.order_url,
-            domain_id: order.domain_id,
-            email: order.email,
-            status: order.status,
-            identifiers: order.identifiers,
-            authorizations: order.authorizations,
-            finalize_url: order.finalize_url,
-            certificate_url: order.certificate_url,
-            error: order.error,
-            error_type: order.error_type,
-            created_at: order.created_at.timestamp(),
-            updated_at: order.updated_at.timestamp(),
-            expires_at: order.expires_at.map(|dt| dt.timestamp()),
-            challenge_validation: None,
-        })
+        .map(AcmeOrderResponse::from)
         .collect();
 
     Ok((StatusCode::OK, Json(ListOrdersResponse { orders })))
@@ -1964,6 +2381,7 @@ async fn get_http_challenge_debug(
         (status = 401, description = "Unauthorized"),
         (status = 403, description = "Insufficient permissions"),
         (status = 404, description = "Domain or DNS provider not found"),
+        (status = 409, description = "Ambiguous managed DNS zone"),
         (status = 500, description = "Internal server error")
     ),
     params(
@@ -2135,12 +2553,64 @@ async fn setup_dns_challenge(
         dns_provider.name
     );
 
-    let (results, records_created) = setup_dns_txt_records(
+    let setup_outcome = match execute_dns_setup(
         provider_instance.as_ref(),
+        app_state.repository.as_ref(),
+        order,
+        request.dns_provider_id,
         &authoritative_zone,
         &dns_txt_records,
     )
-    .await;
+    .await
+    {
+        Ok(outcome) => outcome,
+        Err(source) if source.records_may_have_changed() => {
+            error!(
+                "DNS records may have changed for domain {} (ID {}), but exact cleanup receipts could not be saved: {}",
+                domain.domain, domain_id, source
+            );
+            let audit = DomainAudit {
+                context: AuditContext {
+                    user_id: auth.user_id(),
+                    ip_address: Some(metadata.ip_address.clone()),
+                    user_agent: metadata.user_agent.clone(),
+                },
+                domain: domain.domain.clone(),
+                action: "DNS_CHALLENGE_SETUP_RECEIPT_UPDATE_FAILED".to_string(),
+            };
+            if let Err(audit_error) = app_state.audit_service.create_audit_log(&audit).await {
+                error!(
+                    "Failed to create DNS setup failure audit log: {}",
+                    audit_error
+                );
+            }
+            return Err(ErrorBuilder::new(StatusCode::INTERNAL_SERVER_ERROR)
+                .title("DNS Records Created; Cleanup Receipt Update Failed")
+                .detail(format!(
+                    "DNS challenge records may have been created for domain {} (ID {}), but their exact provider IDs could not be saved. The original cleanup intent was retained; inspect the order and DNS provider before retrying.",
+                    domain.domain, domain_id
+                ))
+                .build());
+        }
+        Err(source) => {
+            error!(
+                "DNS cleanup intent could not be persisted for domain {} (ID {}): {}",
+                domain.domain, domain_id, source
+            );
+            return Err(ErrorBuilder::new(StatusCode::INTERNAL_SERVER_ERROR)
+                .title("DNS Cleanup Intent Persistence Failed")
+                .detail(format!(
+                    "DNS records were not changed because cleanup intent could not be saved for domain {} (ID {}).",
+                    domain.domain, domain_id
+                ))
+                .build());
+        }
+    };
+    let DnsSetupOutcome {
+        results,
+        records_created,
+        ..
+    } = setup_outcome;
 
     let total_records = dns_txt_records.len() as u32;
     let all_success = records_created == total_records;
@@ -2205,6 +2675,8 @@ fn ensure_dns_provider_active(
 /// Extract the record name relative to the base domain
 /// e.g., "_acme-challenge.example.com" for base domain "example.com" -> "_acme-challenge"
 fn acme_txt_record_name(base_domain: &str, name: &str) -> String {
+    let base_domain = base_domain.trim_end_matches('.');
+    let name = name.trim_end_matches('.');
     if name.ends_with(&format!(".{}", base_domain)) {
         name.strip_suffix(&format!(".{}", base_domain))
             .unwrap_or(name)
@@ -2214,6 +2686,194 @@ fn acme_txt_record_name(base_domain: &str, name: &str) -> String {
     } else {
         name.to_string()
     }
+}
+
+fn dns_cleanup_plan(
+    provider_id: i32,
+    zone: &str,
+    cleanup_records: Vec<DnsCleanupRecord>,
+) -> DnsCleanupPlan {
+    let mut seen = std::collections::HashSet::new();
+    DnsCleanupPlan {
+        provider_id,
+        zone: zone.trim_end_matches('.').to_string(),
+        records: cleanup_records
+            .into_iter()
+            .filter(|record| {
+                seen.insert((
+                    record.record_id.clone(),
+                    record.name.clone(),
+                    record.value.clone(),
+                ))
+            })
+            .collect(),
+    }
+}
+
+fn store_dns_cleanup_plan(
+    order: &mut crate::tls::models::AcmeOrder,
+    plan: &DnsCleanupPlan,
+) -> Result<(), serde_json::Error> {
+    let authorizations = order
+        .authorizations
+        .get_or_insert_with(|| serde_json::json!({}));
+    let Some(object) = authorizations.as_object_mut() else {
+        return Err(<serde_json::Error as serde::de::Error>::custom(
+            "ACME order authorizations must be a JSON object",
+        ));
+    };
+    object.insert(
+        DNS_CLEANUP_PLAN_KEY.to_string(),
+        serde_json::to_value(plan)?,
+    );
+    Ok(())
+}
+
+fn load_dns_cleanup_plan(
+    order: &crate::tls::models::AcmeOrder,
+) -> Result<Option<DnsCleanupPlan>, serde_json::Error> {
+    order
+        .authorizations
+        .as_ref()
+        .and_then(|authorizations| authorizations.get(DNS_CLEANUP_PLAN_KEY))
+        .cloned()
+        .map(serde_json::from_value)
+        .transpose()
+}
+
+/// Remove the exact provider record IDs returned when this ACME order created
+/// its TXT values. Providers can have multiple values at the same name during
+/// wildcard issuance, so a later name-only lookup is unsafe and can also miss
+/// records beyond a provider's first list page.
+async fn cleanup_dns_txt_records(
+    provider: &dyn temps_dns::providers::DnsProvider,
+    plan: &DnsCleanupPlan,
+) -> Result<DnsCleanupOutcome, DnsCleanupError> {
+    // These providers expose a distinct ID for each TXT value. Azure, GCP,
+    // Route53, Namecheap, and Pebble expose one synthetic ID per RRset/name:
+    // calling their
+    // delete_record implementation could remove a sibling ACME order's
+    // value even after our exact-value filter succeeds.
+    let provider_type = provider.provider_type();
+    if !matches!(
+        provider_type,
+        temps_dns::providers::DnsProviderType::Cloudflare
+            | temps_dns::providers::DnsProviderType::DigitalOcean
+    ) {
+        return Err(DnsCleanupError::SharedRecordSet {
+            provider: provider_type,
+        });
+    }
+
+    let mut deleted = 0;
+    let mut errors = Vec::new();
+    let mut remaining_records = Vec::new();
+    for expected in &plan.records {
+        if expected.record_id.is_empty() {
+            return Err(DnsCleanupError::MissingRecordId {
+                zone: plan.zone.clone(),
+                name: expected.name.clone(),
+            });
+        }
+        match provider
+            .delete_record(&plan.zone, &expected.record_id)
+            .await
+        {
+            Ok(()) => deleted += 1,
+            // Deletion is idempotent: the provider may have applied a previous
+            // request whose response or subsequent receipt write was lost.
+            Err(temps_dns::errors::DnsError::RecordNotFound(_)) => deleted += 1,
+            Err(source) => {
+                remaining_records.push(expected.clone());
+                errors.push(DnsCleanupError::DeleteRecord {
+                    zone: plan.zone.clone(),
+                    name: expected.name.clone(),
+                    record_id: expected.record_id.clone(),
+                    source: Box::new(source),
+                });
+            }
+        }
+    }
+
+    Ok(DnsCleanupOutcome {
+        deleted,
+        errors,
+        remaining_records,
+    })
+}
+
+async fn execute_dns_setup<S>(
+    provider: &dyn temps_dns::providers::DnsProvider,
+    receipt_store: &S,
+    mut order: crate::tls::models::AcmeOrder,
+    provider_id: i32,
+    zone: &str,
+    dns_txt_records: &[(String, String)],
+) -> Result<DnsSetupOutcome, DnsSetupProgressError>
+where
+    S: DnsCleanupReceiptStore + ?Sized,
+{
+    let pending_records = dns_txt_records
+        .iter()
+        .map(|(name, value)| DnsCleanupRecord {
+            name: acme_txt_record_name(zone, name),
+            value: value.clone(),
+            record_id: String::new(),
+        })
+        .collect();
+    let pending_plan = dns_cleanup_plan(provider_id, zone, pending_records);
+    store_dns_cleanup_plan(&mut order, &pending_plan)
+        .map_err(|source| DnsSetupProgressError::IntentSerialize { source })?;
+    receipt_store
+        .save_cleanup_order(order.clone())
+        .await
+        .map_err(|source| DnsSetupProgressError::IntentSave { source })?;
+
+    let outcome = setup_dns_txt_records_with_cleanup(provider, zone, dns_txt_records).await;
+    let exact_plan = dns_cleanup_plan(provider_id, zone, outcome.cleanup_records.clone());
+    store_dns_cleanup_plan(&mut order, &exact_plan)
+        .map_err(|source| DnsSetupProgressError::ReceiptSerialize { source })?;
+    receipt_store
+        .save_cleanup_order(order)
+        .await
+        .map_err(|source| DnsSetupProgressError::ReceiptSave { source })?;
+    Ok(outcome)
+}
+
+async fn execute_dns_cleanup<S>(
+    provider: &dyn temps_dns::providers::DnsProvider,
+    receipt_store: &S,
+    mut order: crate::tls::models::AcmeOrder,
+    mut plan: DnsCleanupPlan,
+) -> Result<DnsCleanupResolution, DnsCleanupProgressError>
+where
+    S: DnsCleanupReceiptStore + ?Sized,
+{
+    let outcome = match cleanup_dns_txt_records(provider, &plan).await {
+        Ok(outcome) => outcome,
+        Err(reason) => return Ok(DnsCleanupResolution::Manual { reason }),
+    };
+
+    if outcome.errors.is_empty() {
+        receipt_store
+            .delete_cleanup_order(&order.order_url)
+            .await
+            .map_err(|source| DnsCleanupProgressError::Delete { source })?;
+        return Ok(DnsCleanupResolution::Complete {
+            deleted: outcome.deleted,
+        });
+    }
+
+    plan.records = outcome.remaining_records;
+    store_dns_cleanup_plan(&mut order, &plan)
+        .map_err(|source| DnsCleanupProgressError::Serialize { source })?;
+    receipt_store
+        .save_cleanup_order(order)
+        .await
+        .map_err(|source| DnsCleanupProgressError::Save { source })?;
+    Ok(DnsCleanupResolution::Pending {
+        errors: outcome.errors,
+    })
 }
 
 /// Remove stale TXT records left over from a previous order/renewal, then create every
@@ -2226,6 +2886,15 @@ pub(crate) async fn setup_dns_txt_records(
     base_domain: &str,
     dns_txt_records: &[(String, String)],
 ) -> (Vec<DnsChallengeRecordResult>, u32) {
+    let outcome = setup_dns_txt_records_with_cleanup(provider, base_domain, dns_txt_records).await;
+    (outcome.results, outcome.records_created)
+}
+
+async fn setup_dns_txt_records_with_cleanup(
+    provider: &dyn temps_dns::providers::DnsProvider,
+    base_domain: &str,
+    dns_txt_records: &[(String, String)],
+) -> DnsSetupOutcome {
     use std::collections::HashSet;
     use temps_dns::providers::DnsRecordType;
 
@@ -2247,15 +2916,24 @@ pub(crate) async fn setup_dns_txt_records(
 
     let mut results = Vec::new();
     let mut records_created: u32 = 0;
+    let mut cleanup_records = Vec::new();
     for (name, value) in dns_txt_records {
-        let result = create_acme_txt_record(provider, base_domain, name, value).await;
+        let (result, cleanup_record) =
+            create_acme_txt_record(provider, base_domain, name, value).await;
         if result.success {
             records_created += 1;
+        }
+        if let Some(cleanup_record) = cleanup_record {
+            cleanup_records.push(cleanup_record);
         }
         results.push(result);
     }
 
-    (results, records_created)
+    DnsSetupOutcome {
+        results,
+        records_created,
+        cleanup_records,
+    }
 }
 
 pub(crate) enum DnsAutomationAuthorization {
@@ -2343,7 +3021,7 @@ async fn create_acme_txt_record(
     base_domain: &str,
     name: &str,
     value: &str,
-) -> DnsChallengeRecordResult {
+) -> (DnsChallengeRecordResult, Option<DnsCleanupRecord>) {
     use temps_dns::providers::{DnsRecordContent, DnsRecordRequest};
 
     let record_name = acme_txt_record_name(base_domain, name);
@@ -2363,29 +3041,40 @@ async fn create_acme_txt_record(
     };
 
     match provider.create_record(base_domain, request).await {
-        Ok(_record) => {
+        Ok(record) => {
             info!(
                 "Successfully created TXT record {} for {}",
                 name, base_domain
             );
-            DnsChallengeRecordResult {
-                name: name.to_string(),
+            let cleanup_record = record.id.map(|record_id| DnsCleanupRecord {
+                name: record_name,
                 value: value.to_string(),
-                success: true,
-                message: "TXT record created successfully".to_string(),
-            }
+                record_id,
+            });
+            (
+                DnsChallengeRecordResult {
+                    name: name.to_string(),
+                    value: value.to_string(),
+                    success: true,
+                    message: "TXT record created successfully".to_string(),
+                },
+                cleanup_record,
+            )
         }
         Err(e) => {
             error!(
                 "Failed to create TXT record {} for {}: {}",
                 name, base_domain, e
             );
-            DnsChallengeRecordResult {
-                name: name.to_string(),
-                value: value.to_string(),
-                success: false,
-                message: format!("Failed to create TXT record: {}", e),
-            }
+            (
+                DnsChallengeRecordResult {
+                    name: name.to_string(),
+                    value: value.to_string(),
+                    success: false,
+                    message: format!("Failed to create TXT record: {}", e),
+                },
+                None,
+            )
         }
     }
 }
@@ -2615,6 +3304,48 @@ mod tests {
     };
     use temps_dns::DnsError;
 
+    fn test_auth(role: temps_auth::Role) -> temps_auth::AuthContext {
+        let now = chrono::Utc::now();
+        let user = temps_entities::users::Model {
+            id: 42,
+            name: "CLI Operator".to_string(),
+            email: "operator@example.test".to_string(),
+            password_hash: None,
+            email_verified: true,
+            email_verification_token: None,
+            email_verification_expires: None,
+            password_reset_token: None,
+            password_reset_expires: None,
+            must_change_password: false,
+            deleted_at: None,
+            mfa_secret: None,
+            mfa_enabled: false,
+            mfa_recovery_codes: None,
+            oidc_subject: None,
+            oidc_provider_id: None,
+            created_at: now,
+            updated_at: now,
+        };
+        temps_auth::AuthContext::new_session(user, role)
+    }
+
+    #[test]
+    fn dns_cleanup_permission_denial_precedes_cleanup_execution() {
+        let denied = ensure_dns_cleanup_permission(&test_auth(temps_auth::Role::Reader), true)
+            .expect_err("reader must not mutate DNS during finalization");
+        assert_eq!(denied.status_code, StatusCode::FORBIDDEN);
+
+        assert!(ensure_dns_cleanup_permission(&test_auth(temps_auth::Role::Reader), false).is_ok());
+        assert!(ensure_dns_cleanup_permission(&test_auth(temps_auth::Role::Admin), true).is_ok());
+    }
+
+    #[test]
+    fn active_domain_with_cleanup_receipt_retries_without_acme_reissuance() {
+        assert!(should_retry_dns_cleanup_without_issuance("active", true));
+        assert!(!should_retry_dns_cleanup_without_issuance("pending", true));
+        assert!(!should_retry_dns_cleanup_without_issuance("active", false));
+    }
+
     #[test]
     fn inactive_dns_provider_is_rejected_with_context() {
         let now = chrono::Utc::now();
@@ -2655,6 +3386,42 @@ mod tests {
         records: Mutex<Vec<DnsRecord>>,
         next_id: AtomicU32,
         fail_create_after: Option<u32>,
+        fail_delete_id: Option<String>,
+        provider_type: DnsProviderType,
+    }
+
+    #[derive(Default)]
+    struct RecordingCleanupReceiptStore {
+        saved: Mutex<Vec<crate::tls::models::AcmeOrder>>,
+        deleted: Mutex<Vec<String>>,
+        fail_save: bool,
+        fail_delete: bool,
+    }
+
+    #[async_trait]
+    impl DnsCleanupReceiptStore for RecordingCleanupReceiptStore {
+        async fn save_cleanup_order(
+            &self,
+            order: crate::tls::models::AcmeOrder,
+        ) -> Result<(), RepositoryError> {
+            if self.fail_save {
+                return Err(RepositoryError::Database(
+                    "injected receipt save failure".to_string(),
+                ));
+            }
+            self.saved.lock().unwrap().push(order);
+            Ok(())
+        }
+
+        async fn delete_cleanup_order(&self, order_url: &str) -> Result<(), RepositoryError> {
+            if self.fail_delete {
+                return Err(RepositoryError::Database(
+                    "injected receipt delete failure".to_string(),
+                ));
+            }
+            self.deleted.lock().unwrap().push(order_url.to_string());
+            Ok(())
+        }
     }
 
     impl MockDnsProvider {
@@ -2663,6 +3430,8 @@ mod tests {
                 records: Mutex::new(Vec::new()),
                 next_id: AtomicU32::new(1),
                 fail_create_after: None,
+                fail_delete_id: None,
+                provider_type: DnsProviderType::Cloudflare,
             }
         }
 
@@ -2677,7 +3446,19 @@ mod tests {
                 records: Mutex::new(Vec::new()),
                 next_id: AtomicU32::new(1),
                 fail_create_after: Some(successful_creates),
+                fail_delete_id: None,
+                provider_type: DnsProviderType::Cloudflare,
             }
+        }
+
+        fn with_provider_type(mut self, provider_type: DnsProviderType) -> Self {
+            self.provider_type = provider_type;
+            self
+        }
+
+        fn failing_delete(mut self, record_id: &str) -> Self {
+            self.fail_delete_id = Some(record_id.to_string());
+            self
         }
 
         fn record_names(&self) -> Vec<(String, String)> {
@@ -2708,7 +3489,7 @@ mod tests {
     #[async_trait]
     impl DnsProvider for MockDnsProvider {
         fn provider_type(&self) -> DnsProviderType {
-            DnsProviderType::Cloudflare
+            self.provider_type
         }
 
         fn capabilities(&self) -> DnsProviderCapabilities {
@@ -2789,12 +3570,347 @@ mod tests {
         }
 
         async fn delete_record(&self, _domain: &str, record_id: &str) -> Result<(), DnsError> {
-            self.records
-                .lock()
-                .unwrap()
-                .retain(|r| r.id.as_deref() != Some(record_id));
+            if self.fail_delete_id.as_deref() == Some(record_id) {
+                return Err(DnsError::ApiError("injected delete failure".to_string()));
+            }
+            let mut records = self.records.lock().unwrap();
+            let before = records.len();
+            records.retain(|r| r.id.as_deref() != Some(record_id));
+            if records.len() == before {
+                return Err(DnsError::RecordNotFound(record_id.to_string()));
+            }
             Ok(())
         }
+    }
+
+    fn test_acme_order(authorizations: Option<serde_json::Value>) -> crate::tls::models::AcmeOrder {
+        let now = chrono::Utc::now();
+        crate::tls::models::AcmeOrder {
+            id: 11,
+            order_url: "https://acme.example.test/order/11".to_string(),
+            domain_id: 17,
+            email: "operator@example.test".to_string(),
+            status: "pending".to_string(),
+            identifiers: serde_json::json!([]),
+            authorizations,
+            finalize_url: None,
+            certificate_url: None,
+            error: None,
+            error_type: None,
+            token: None,
+            key_authorization: None,
+            created_at: now,
+            updated_at: now,
+            expires_at: None,
+        }
+    }
+
+    #[test]
+    fn dns_cleanup_plan_round_trips_through_order_metadata() {
+        let records = vec![
+            DnsCleanupRecord {
+                name: "_acme-challenge".to_string(),
+                value: "order-token".to_string(),
+                record_id: "provider-record-7".to_string(),
+            },
+            DnsCleanupRecord {
+                name: "_acme-challenge".to_string(),
+                value: "wildcard-order-token".to_string(),
+                record_id: "provider-record-7".to_string(),
+            },
+            DnsCleanupRecord {
+                name: "_acme-challenge".to_string(),
+                value: "order-token".to_string(),
+                record_id: "provider-record-7".to_string(),
+            },
+        ];
+        let plan = dns_cleanup_plan(42, "example.com.", records);
+        let mut order = test_acme_order(Some(serde_json::json!({
+            "dns_txt_records": [{"name": "_acme-challenge.example.com", "value": "order-token"}]
+        })));
+
+        store_dns_cleanup_plan(&mut order, &plan).expect("cleanup metadata should serialize");
+
+        assert_eq!(load_dns_cleanup_plan(&order).unwrap(), Some(plan.clone()));
+        assert_eq!(plan.zone, "example.com");
+        assert_eq!(
+            plan.records.len(),
+            2,
+            "exact duplicates must be removed without losing sibling RRset values"
+        );
+        assert_eq!(plan.records[0].record_id, "provider-record-7");
+        assert_eq!(plan.records[1].value, "wildcard-order-token");
+        assert!(dns_provision_requires_cleanup_aware_finalize(&order)
+            .expect("cleanup-aware provision guard should decode metadata"));
+        assert!(
+            !dns_provision_requires_cleanup_aware_finalize(&test_acme_order(None))
+                .expect("orders without cleanup metadata should use the legacy path")
+        );
+    }
+
+    #[test]
+    fn acme_order_responses_use_epoch_milliseconds() {
+        let mut order = test_acme_order(None);
+        order.expires_at = Some(order.created_at + chrono::Duration::hours(1));
+        let expected_created_at = order.created_at.timestamp_millis();
+        let expected_updated_at = order.updated_at.timestamp_millis();
+        let expected_expires_at = order.expires_at.map(|value| value.timestamp_millis());
+
+        let response = AcmeOrderResponse::from(order);
+
+        assert_eq!(response.created_at, expected_created_at);
+        assert_eq!(response.updated_at, expected_updated_at);
+        assert_eq!(response.expires_at, expected_expires_at);
+        assert!(response.created_at > 1_000_000_000_000);
+    }
+
+    #[tokio::test]
+    async fn cleanup_removes_only_the_exact_acme_order_value() {
+        let provider = MockDnsProvider::seed(vec![
+            txt_record("1", "_acme-challenge", "completed-order-token"),
+            txt_record("2", "_acme-challenge", "concurrent-order-token"),
+            txt_record("3", "www", "unrelated"),
+        ]);
+        let plan = dns_cleanup_plan(
+            42,
+            "example.com",
+            vec![DnsCleanupRecord {
+                name: "_acme-challenge".to_string(),
+                value: "completed-order-token".to_string(),
+                record_id: "1".to_string(),
+            }],
+        );
+
+        let outcome = cleanup_dns_txt_records(&provider, &plan)
+            .await
+            .expect("record cleanup should succeed");
+
+        assert_eq!(outcome.deleted, 1);
+        assert!(outcome.errors.is_empty());
+        assert!(outcome.remaining_records.is_empty());
+        let remaining = provider.record_names();
+        assert!(!remaining
+            .iter()
+            .any(|(_, value)| value == "completed-order-token"));
+        assert!(remaining
+            .iter()
+            .any(|(_, value)| value == "concurrent-order-token"));
+        assert!(remaining.iter().any(|(name, _)| name == "www"));
+    }
+
+    #[tokio::test]
+    async fn cleanup_skips_providers_with_shared_txt_record_set_ids() {
+        let provider = MockDnsProvider::seed(vec![
+            txt_record(
+                "_acme-challenge::TXT",
+                "_acme-challenge",
+                "completed-order-token",
+            ),
+            txt_record(
+                "_acme-challenge::TXT",
+                "_acme-challenge",
+                "concurrent-order-token",
+            ),
+        ])
+        .with_provider_type(DnsProviderType::Azure);
+        let plan = dns_cleanup_plan(
+            42,
+            "example.com",
+            vec![DnsCleanupRecord {
+                name: "_acme-challenge".to_string(),
+                value: "completed-order-token".to_string(),
+                record_id: "_acme-challenge::TXT".to_string(),
+            }],
+        );
+
+        let error = cleanup_dns_txt_records(&provider, &plan)
+            .await
+            .expect_err("shared-record-set providers must not delete by synthetic ID");
+
+        assert!(matches!(
+            error,
+            DnsCleanupError::SharedRecordSet {
+                provider: DnsProviderType::Azure
+            }
+        ));
+        assert_eq!(provider.record_names().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn cleanup_reports_only_failed_records_for_a_safe_retry() {
+        let provider = MockDnsProvider::seed(vec![
+            txt_record("1", "_acme-challenge", "first-token"),
+            txt_record("2", "_acme-challenge", "second-token"),
+        ])
+        .failing_delete("2");
+        let plan = dns_cleanup_plan(
+            42,
+            "example.com",
+            vec![
+                DnsCleanupRecord {
+                    name: "_acme-challenge".to_string(),
+                    value: "first-token".to_string(),
+                    record_id: "1".to_string(),
+                },
+                DnsCleanupRecord {
+                    name: "_acme-challenge".to_string(),
+                    value: "second-token".to_string(),
+                    record_id: "2".to_string(),
+                },
+            ],
+        );
+
+        let outcome = cleanup_dns_txt_records(&provider, &plan)
+            .await
+            .expect("safe providers return a cleanup outcome");
+
+        assert_eq!(outcome.deleted, 1);
+        assert_eq!(outcome.errors.len(), 1);
+        assert_eq!(outcome.remaining_records.len(), 1);
+        assert_eq!(outcome.remaining_records[0].record_id, "2");
+        assert_eq!(
+            provider.record_names(),
+            vec![("_acme-challenge".to_string(), "second-token".to_string())]
+        );
+    }
+
+    #[tokio::test]
+    async fn cleanup_treats_an_already_absent_provider_record_as_complete() {
+        let provider = MockDnsProvider::new();
+        let plan = dns_cleanup_plan(
+            42,
+            "example.com",
+            vec![DnsCleanupRecord {
+                name: "_acme-challenge".to_string(),
+                value: "already-removed-token".to_string(),
+                record_id: "gone".to_string(),
+            }],
+        );
+
+        let outcome = cleanup_dns_txt_records(&provider, &plan)
+            .await
+            .expect("safe providers make missing-record cleanup idempotent");
+
+        assert_eq!(outcome.deleted, 1);
+        assert!(outcome.errors.is_empty());
+        assert!(outcome.remaining_records.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cleanup_retains_pre_mutation_intent_without_a_provider_record_id() {
+        let provider = MockDnsProvider::new();
+        let plan = dns_cleanup_plan(
+            42,
+            "example.com",
+            vec![DnsCleanupRecord {
+                name: "_acme-challenge".to_string(),
+                value: "durable-intent-token".to_string(),
+                record_id: String::new(),
+            }],
+        );
+
+        let error = cleanup_dns_txt_records(&provider, &plan)
+            .await
+            .expect_err("missing provider IDs require explicit manual cleanup");
+
+        assert!(matches!(
+            error,
+            DnsCleanupError::MissingRecordId { zone, name }
+                if zone == "example.com" && name == "_acme-challenge"
+        ));
+        assert!(provider.record_names().is_empty());
+    }
+
+    #[tokio::test]
+    async fn cleanup_workflow_deletes_exact_records_then_clears_the_receipt() {
+        let provider =
+            MockDnsProvider::seed(vec![txt_record("1", "_acme-challenge", "issued-token")]);
+        let store = RecordingCleanupReceiptStore::default();
+        let order = test_acme_order(None);
+        let order_url = order.order_url.clone();
+        let plan = dns_cleanup_plan(
+            42,
+            "example.com",
+            vec![DnsCleanupRecord {
+                name: "_acme-challenge".to_string(),
+                value: "issued-token".to_string(),
+                record_id: "1".to_string(),
+            }],
+        );
+
+        let resolution = execute_dns_cleanup(&provider, &store, order, plan)
+            .await
+            .expect("cleanup workflow should persist its terminal transition");
+
+        assert!(matches!(
+            resolution,
+            DnsCleanupResolution::Complete { deleted: 1 }
+        ));
+        assert!(provider.record_names().is_empty());
+        assert!(store.saved.lock().unwrap().is_empty());
+        assert_eq!(store.deleted.lock().unwrap().as_slice(), &[order_url]);
+    }
+
+    #[tokio::test]
+    async fn cleanup_workflow_persists_only_failures_then_retries_to_completion() {
+        let first_provider = MockDnsProvider::seed(vec![
+            txt_record("1", "_acme-challenge", "first-token"),
+            txt_record("2", "_acme-challenge", "second-token"),
+        ])
+        .failing_delete("2");
+        let store = RecordingCleanupReceiptStore::default();
+        let order = test_acme_order(None);
+        let plan = dns_cleanup_plan(
+            42,
+            "example.com",
+            vec![
+                DnsCleanupRecord {
+                    name: "_acme-challenge".to_string(),
+                    value: "first-token".to_string(),
+                    record_id: "1".to_string(),
+                },
+                DnsCleanupRecord {
+                    name: "_acme-challenge".to_string(),
+                    value: "second-token".to_string(),
+                    record_id: "2".to_string(),
+                },
+            ],
+        );
+
+        let first_resolution = execute_dns_cleanup(&first_provider, &store, order, plan)
+            .await
+            .expect("partial cleanup should save retry progress");
+        assert!(matches!(
+            first_resolution,
+            DnsCleanupResolution::Pending { ref errors } if errors.len() == 1
+        ));
+
+        let retry_order = store
+            .saved
+            .lock()
+            .unwrap()
+            .last()
+            .cloned()
+            .expect("partial cleanup should retain the order");
+        let retry_plan = load_dns_cleanup_plan(&retry_order)
+            .expect("retry receipt should decode")
+            .expect("retry receipt should exist");
+        assert_eq!(retry_plan.records.len(), 1);
+        assert_eq!(retry_plan.records[0].record_id, "2");
+
+        let retry_provider =
+            MockDnsProvider::seed(vec![txt_record("2", "_acme-challenge", "second-token")]);
+        let retry_resolution =
+            execute_dns_cleanup(&retry_provider, &store, retry_order, retry_plan)
+                .await
+                .expect("retry should clear the retained receipt");
+
+        assert!(matches!(
+            retry_resolution,
+            DnsCleanupResolution::Complete { deleted: 1 }
+        ));
+        assert!(retry_provider.record_names().is_empty());
+        assert_eq!(store.deleted.lock().unwrap().len(), 1);
     }
 
     // ==================== acme_txt_record_name ====================
@@ -2841,6 +3957,109 @@ mod tests {
         assert_eq!(remaining.len(), 2);
         assert!(remaining.iter().any(|(_, v)| v == "token-wildcard"));
         assert!(remaining.iter().any(|(_, v)| v == "token-base"));
+    }
+
+    #[tokio::test]
+    async fn setup_captures_exact_provider_record_ids_for_cleanup() {
+        let provider = MockDnsProvider::new();
+        let dns_txt_records = vec![
+            (
+                "_acme-challenge.example.com".to_string(),
+                "token-wildcard".to_string(),
+            ),
+            (
+                "_acme-challenge.example.com".to_string(),
+                "token-base".to_string(),
+            ),
+        ];
+
+        let outcome =
+            setup_dns_txt_records_with_cleanup(&provider, "example.com", &dns_txt_records).await;
+
+        assert_eq!(outcome.records_created, 2);
+        assert_eq!(outcome.cleanup_records.len(), 2);
+        assert_eq!(outcome.cleanup_records[0].record_id, "1");
+        assert_eq!(outcome.cleanup_records[0].value, "token-wildcard");
+        assert_eq!(outcome.cleanup_records[1].record_id, "2");
+        assert_eq!(outcome.cleanup_records[1].value, "token-base");
+    }
+
+    #[tokio::test]
+    async fn setup_workflow_persists_intent_before_replacing_it_with_exact_ids() {
+        let provider = MockDnsProvider::new();
+        let store = RecordingCleanupReceiptStore::default();
+        let records = vec![
+            (
+                "_acme-challenge.example.com".to_string(),
+                "token-wildcard".to_string(),
+            ),
+            (
+                "_acme-challenge.example.com".to_string(),
+                "token-base".to_string(),
+            ),
+        ];
+
+        let outcome = execute_dns_setup(
+            &provider,
+            &store,
+            test_acme_order(None),
+            42,
+            "example.com",
+            &records,
+        )
+        .await
+        .expect("setup should persist both lifecycle transitions");
+
+        assert_eq!(outcome.records_created, 2);
+        let saved = store.saved.lock().unwrap();
+        assert_eq!(saved.len(), 2);
+        let intent = load_dns_cleanup_plan(&saved[0])
+            .expect("intent should decode")
+            .expect("intent should exist");
+        assert_eq!(intent.records.len(), 2);
+        assert!(intent
+            .records
+            .iter()
+            .all(|record| record.record_id.is_empty()));
+        let exact = load_dns_cleanup_plan(&saved[1])
+            .expect("exact receipt should decode")
+            .expect("exact receipt should exist");
+        assert_eq!(
+            exact
+                .records
+                .iter()
+                .map(|record| record.record_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["1", "2"]
+        );
+    }
+
+    #[tokio::test]
+    async fn setup_workflow_does_not_mutate_dns_when_intent_save_fails() {
+        let provider = MockDnsProvider::new();
+        let store = RecordingCleanupReceiptStore {
+            fail_save: true,
+            ..Default::default()
+        };
+        let records = vec![(
+            "_acme-challenge.example.com".to_string(),
+            "must-not-be-created".to_string(),
+        )];
+
+        let error = execute_dns_setup(
+            &provider,
+            &store,
+            test_acme_order(None),
+            42,
+            "example.com",
+            &records,
+        )
+        .await
+        .expect_err("intent persistence failure must stop before DNS mutation");
+
+        assert!(matches!(error, DnsSetupProgressError::IntentSave { .. }));
+        assert!(!error.records_may_have_changed());
+        assert!(provider.record_names().is_empty());
     }
 
     #[tokio::test]

--- a/crates/temps-domains/src/tls/models.rs
+++ b/crates/temps-domains/src/tls/models.rs
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use serde::{Deserialize, Serialize};
+
+/// Private ACME-order metadata key used to retain DNS cleanup receipts until
+/// provider-side challenge records reach a terminal cleanup outcome.
+pub(crate) const DNS_CLEANUP_PLAN_KEY: &str = "temps_dns_cleanup";
 use temps_core::UtcDateTime;
 
 /// TLS certificate stored in the `domains` table.

--- a/crates/temps-routes/src/route_table.rs
+++ b/crates/temps-routes/src/route_table.rs
@@ -2033,7 +2033,7 @@ impl CachedPeerTable {
         }
 
         info!(
-            "Route table loaded with {} total entries ({} HTTP exact, {} TLS exact, {} HTTP wildcards, {} TLS wildcards)",
+            "Route table loaded with {} legacy routes; typed caches contain {} HTTP exact, {} TLS exact, {} HTTP wildcards, {} TLS wildcards",
             route_count, http_routes_count, tls_routes_count, http_wildcards_count, tls_wildcards_count
         );
         // Collect on-demand configs for awake environments so the idle sweep can track them.


### PR DESCRIPTION
## Description

Fixes the regressions reported in #899 and adds a complete, drift-detecting audit of the Rust CLI command tree.

- routes management CLI calls through the mounted `/api` prefix while preserving reverse-proxy base paths
- makes successful-response decoding errors actionable without leaking response bodies, credentials, query values, certificates, or DNS proofs
- supports `temps domain show --domain/-d`, with an exact-one-of ID/hostname contract and encoded hostname lookup
- fixes millisecond timestamp rendering in both TypeScript domain command groups and standardizes ACME order timestamps server-side
- persists ACME DNS cleanup intent before mutation, records exact provider IDs, safely cleans Cloudflare/DigitalOcean records, and retains retry/manual-cleanup state on partial or shared-RRset providers
- prevents the legacy DNS provision path from bypassing cleanup-aware finalization
- aligns `doctor` with the current and legacy data-directory layouts
- prevents implicit channel upgrades from downgrading beta installs, scans every release page, selects the highest semantic version, and ignores malformed tags
- downgrades misleading foreign-job log noise and clarifies legacy route/cache diagnostics
- inventories all 51 visible Rust CLI leaf commands and verifies every leaf renders help without side effects

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Verification evidence

- `cargo test --lib -p temps-cli` — 283 passed
- `cargo test --lib -p temps-domains` — 83 passed, 3 pre-existing ignored
- `cargo test --lib -p temps-dns` — 261 passed
- `cargo test --lib -p temps-deployments` — 775 passed, 3 pre-existing ignored
- `cargo test --lib -p temps-routes` — 82 passed
- `cargo check --lib` — passed
- `cargo clippy --lib -p temps-cli -p temps-domains -p temps-dns -- -D warnings` — passed
- pre-commit `cargo clippy --all-targets --all-features -- -D warnings` — passed
- `bun test src/commands/domains/index.test.ts src/commands/custom-domains/index.test.ts` — 19 passed
- `bunx tsc --noEmit` — passed
- compiled binary traversal — all 51 Rust CLI leaf commands accepted `--help`
- Rust review — approved
- security review — approved
- test coverage review — approved

## Checklist

- [x] I have written tests that cover the changes
- [x] All new and existing relevant tests pass (`cargo test --lib`)
- [x] `cargo check --lib` passes
- [x] My commits follow the Conventional Commits format
- [x] Every commit is signed off (`git commit -s`) per the DCO
- [x] Documentation/OpenAPI annotations are updated where necessary

## Related issues

Closes #899
