### PR TITLE
fix(error-tracking): honor Sentry envelope event ID

### DIFF
--- a/crates/temps-error-tracking/src/sentry/envelope.rs
+++ b/crates/temps-error-tracking/src/sentry/envelope.rs
@@ -280,13 +280,17 @@ impl Envelope {
                     let val: serde_json::Value = serde_json::from_str(payload).map_err(|e| {
                         EnvelopeError::InvalidPayload(format!("Failed to parse event: {}", e))
                     })?;
-                    Some(EnvelopeItem::Event(Event::from_value(val.into())))
+                    let mut event = Event::from_value(val.into());
+                    apply_envelope_event_id(&mut event, header.event_id);
+                    Some(EnvelopeItem::Event(event))
                 }
                 ItemType::Transaction => {
                     let val: serde_json::Value = serde_json::from_str(payload).map_err(|e| {
                         EnvelopeError::InvalidPayload(format!("Failed to parse transaction: {}", e))
                     })?;
-                    Some(EnvelopeItem::Transaction(Event::from_value(val.into())))
+                    let mut transaction = Event::from_value(val.into());
+                    apply_envelope_event_id(&mut transaction, header.event_id);
+                    Some(EnvelopeItem::Transaction(transaction))
                 }
                 ItemType::Session => {
                     let session = SessionUpdate::parse(payload.as_bytes()).map_err(|e| {
@@ -363,6 +367,16 @@ impl Envelope {
     }
 }
 
+/// Apply the canonical envelope event ID to an event or transaction payload.
+///
+/// Sentry requires the ID in the envelope header and permits payloads to omit
+/// it. When both locations contain an ID, the envelope header takes precedence.
+fn apply_envelope_event_id(event: &mut Annotated<Event>, event_id: Option<EventId>) {
+    if let (Some(event), Some(event_id)) = (event.value_mut(), event_id) {
+        event.id.set_value(Some(event_id));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -378,6 +392,75 @@ mod tests {
 
         let envelope = envelope.unwrap();
         assert_eq!(envelope.items().count(), 1);
+    }
+
+    #[test]
+    fn event_uses_event_id_from_envelope_header() {
+        let envelope_data = "{\"event_id\":\"9ec79c33ec9942ab8353589fcb2e04dc\"}\n\
+            {\"type\":\"event\",\"content_type\":\"application/json\"}\n\
+            {\"level\":\"error\",\"platform\":\"php\",\"message\":\"Synthetic test\"}\n";
+
+        let envelope = Envelope::from_slice(envelope_data.as_bytes())
+            .unwrap_or_else(|error| panic!("PHP SDK envelope should parse: {error}"));
+        let event = match envelope.items().next() {
+            Some(EnvelopeItem::Event(event)) => event,
+            _ => panic!("expected one event item"),
+        };
+
+        assert_eq!(
+            event
+                .value()
+                .and_then(|event| event.id.value())
+                .map(ToString::to_string)
+                .as_deref(),
+            Some("9ec79c33ec9942ab8353589fcb2e04dc")
+        );
+    }
+
+    #[test]
+    fn envelope_header_event_id_takes_precedence_over_event_payload() {
+        let envelope_data = "{\"event_id\":\"9ec79c33ec9942ab8353589fcb2e04dc\"}\n\
+            {\"type\":\"event\"}\n\
+            {\"event_id\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"level\":\"error\",\"platform\":\"other\"}\n";
+
+        let envelope = Envelope::from_slice(envelope_data.as_bytes())
+            .unwrap_or_else(|error| panic!("event envelope should parse: {error}"));
+        let event = match envelope.items().next() {
+            Some(EnvelopeItem::Event(event)) => event,
+            _ => panic!("expected one event item"),
+        };
+
+        assert_eq!(
+            event
+                .value()
+                .and_then(|event| event.id.value())
+                .map(ToString::to_string)
+                .as_deref(),
+            Some("9ec79c33ec9942ab8353589fcb2e04dc")
+        );
+    }
+
+    #[test]
+    fn transaction_uses_event_id_from_envelope_header() {
+        let envelope_data = "{\"event_id\":\"9ec79c33ec9942ab8353589fcb2e04dc\"}\n\
+            {\"type\":\"transaction\"}\n\
+            {\"type\":\"transaction\",\"transaction\":\"GET /example\",\"platform\":\"php\"}\n";
+
+        let envelope = Envelope::from_slice(envelope_data.as_bytes())
+            .unwrap_or_else(|error| panic!("transaction envelope should parse: {error}"));
+        let transaction = match envelope.items().next() {
+            Some(EnvelopeItem::Transaction(transaction)) => transaction,
+            _ => panic!("expected one transaction item"),
+        };
+
+        assert_eq!(
+            transaction
+                .value()
+                .and_then(|event| event.id.value())
+                .map(ToString::to_string)
+                .as_deref(),
+            Some("9ec79c33ec9942ab8353589fcb2e04dc")
+        );
     }
 
     #[test]

--- a/crates/temps-error-tracking/src/sentry/handlers.rs
+++ b/crates/temps-error-tracking/src/sentry/handlers.rs
@@ -802,8 +802,8 @@ mod tests {
         let app = configure_routes().with_state(ctx.app_state);
         let server = TestServer::new(app);
 
-        // Create a valid Sentry SDK error envelope
-        let envelope_data = "{\"event_id\":\"9ec79c33ec9942ab8353589fcb2e04dc\",\"sent_at\":\"2023-06-28T14:30:00.000Z\"}\n{\"type\":\"event\"}\n{\"event_id\":\"9ec79c33ec9942ab8353589fcb2e04dc\",\"timestamp\":1687962600.0,\"platform\":\"javascript\",\"level\":\"error\",\"exception\":{\"values\":[{\"type\":\"Error\",\"value\":\"Test error message\",\"stacktrace\":{\"frames\":[{\"filename\":\"app.js\",\"function\":\"onClick\",\"lineno\":42,\"colno\":15}]}}]},\"environment\":\"production\",\"release\":\"1.0.0\"}\n";
+        // The official PHP SDK places event_id only in the envelope header.
+        let envelope_data = "{\"event_id\":\"9ec79c33ec9942ab8353589fcb2e04dc\",\"sent_at\":\"2023-06-28T14:30:00.000Z\"}\n{\"type\":\"event\",\"content_type\":\"application/json\"}\n{\"timestamp\":1687962600.0,\"platform\":\"php\",\"level\":\"error\",\"exception\":{\"values\":[{\"type\":\"Error\",\"value\":\"Test error message\",\"stacktrace\":{\"frames\":[{\"filename\":\"app.php\",\"function\":\"handleRequest\",\"lineno\":42}]}}]},\"environment\":\"production\",\"release\":\"1.0.0\"}\n";
 
         let auth_header = format!("Sentry sentry_key={},sentry_version=7", ctx.dsn_key);
 
@@ -818,12 +818,7 @@ mod tests {
             .await;
 
         // Should successfully ingest the event
-        assert!(
-            response.status_code() == StatusCode::OK
-                || response.status_code() == StatusCode::BAD_REQUEST,
-            "Expected 200 or 400, got {}",
-            response.status_code()
-        );
+        assert_eq!(response.status_code(), StatusCode::OK);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- propagate the canonical envelope `event_id` into parsed event and transaction payloads
- follow the Sentry envelope specification by giving the header ID precedence over a conflicting payload ID
- cover the PHP-style envelope shape at both parser and HTTP endpoint levels

## Root cause

The envelope parser retained the header ID separately while the ingestion provider validated only the parsed item payload. SDKs that correctly place `event_id` only in the envelope header therefore reached `Validation error: Event missing ID`.

Closes #910.

## Evidence

**Backend parser:** header-only IDs are propagated and header precedence is enforced for events and transactions.

```bash
cargo test --lib -p temps-error-tracking sentry::envelope::tests:: -- --nocapture
```

```text
cargo test: 5 passed, 128 filtered out (1 suite, 0.00s)
```

**HTTP endpoint:** a PHP-style Sentry envelope with no payload-level ID is accepted and stored.

```bash
cargo test --lib -p temps-error-tracking sentry::handlers::tests::test_envelope_endpoint_with_valid_error_event -- --nocapture
```

```text
cargo test: 1 passed, 132 filtered out (1 suite, 5.35s)
```

**Regression suite:**

```bash
cargo test --lib -p temps-error-tracking
```

```text
cargo test: 133 passed (1 suite, 89.25s)
```

**Static checks:**

```bash
cargo check --lib -p temps-error-tracking
cargo clippy --lib -p temps-error-tracking -- -D warnings
cargo fmt --check
git diff --check origin/main...HEAD
```

```text
cargo check: 0 errors
cargo clippy: 0 errors
format and diff checks passed
```

**Secret scan:** the single branch commit and exact added lines were scanned before push.

```bash
gitleaks git --log-opts='origin/main..HEAD' --no-banner --redact --log-level info .
```

```text
1 commits scanned
scanned ~4216 bytes (4.22 KB)
no leaks found
```
