### PR TITLE
feat(cloud-protocol): add backup lifecycle event wire types

### DIFF
--- a/crates/temps-cloud-protocol/src/lib.rs
+++ b/crates/temps-cloud-protocol/src/lib.rs
@@ -32,7 +32,8 @@
 pub mod messages;
 
 pub use messages::{
-    BackupArtifact, BackupCompleted, BackupCompression, BackupEngine, BackupFormat, BackupTarget,
+    BackupArtifact, BackupCompleted, BackupCompression, BackupEngine, BackupFormat,
+    BackupLifecycleEventAccepted, BackupLifecycleEventRequest, BackupLifecycleStage, BackupTarget,
     BackupTargetRequest, EnrollRequest, EnrollResponse, Envelope, Heartbeat, HeartbeatAck,
     IngestAck, ManagedAiAnalysisRequest, ManagedAiAnalysisResponse, ManagedAiCapability,
     ManagedAiChatRequest, ManagedAiChatResponse, ManagedAiCitation, ManagedAiEvidence,

--- a/crates/temps-cloud-protocol/src/messages.rs
+++ b/crates/temps-cloud-protocol/src/messages.rs
@@ -680,6 +680,45 @@ pub struct ManagedNotificationAccepted {
 }
 
 // ---------------------------------------------------------------------------
+// Backup lifecycle — OSS pushes started/completed/failed as they happen, so
+// Cloud can show a live "processing" state instead of waiting to notice the
+// result on its next mirror-sweep poll.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BackupLifecycleStage {
+    Started,
+    Completed,
+    Failed,
+}
+
+/// A backup lifecycle transition reported by an instance. `instance_id`
+/// binds it to the reporting instance's bearer token the same way every
+/// other backup-scoped call does; `backup_id` is that instance's local
+/// `backups.id`, not globally unique, so Cloud keys its own state on
+/// `(instance_id, backup_id)`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BackupLifecycleEventRequest {
+    pub instance_id: Uuid,
+    pub backup_id: i32,
+    pub engine: String,
+    pub stage: BackupLifecycleStage,
+    pub occurred_at: chrono::DateTime<chrono::Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub s3_location: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BackupLifecycleEventAccepted {
+    pub event_id: Uuid,
+}
+
+// ---------------------------------------------------------------------------
 // Liveness
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds `BackupLifecycleStage`, `BackupLifecycleEventRequest`, `BackupLifecycleEventAccepted` to `temps-cloud-protocol`, the shared wire types for reporting a backup's started/completed/failed transitions to Cloud as they happen.
- Cloud's receiving endpoint depends on these types to compile; this PR lands them standalone so that dependency is unblocked. The OSS-side publisher (job event, webhook wiring, Cloud push client) is separate, larger, in-progress work on this branch.

## Test plan
- [x] `cargo check --lib -p temps-cloud-protocol`
- [x] `cargo fmt` / `cargo clippy` via pre-commit hooks