### PR TITLE
fix(proxy): stop classifying HTTP 101 responses as errors

### DIFF
--- a/crates/temps-proxy/src/service/proxy_log_service.rs
+++ b/crates/temps-proxy/src/service/proxy_log_service.rs
@@ -2409,7 +2409,7 @@ impl ProxyLogService {
     /// HTTP status-class breakdown for AI-agent traffic.
     ///
     /// Same pre-filter as the AI agent breakdown (`is_bot = true AND bot_name IN
-    /// (known)`), grouped by status class (`2xx`, `3xx`, `4xx`, `5xx`, `other`).
+    /// (known)`), grouped by status class (`1xx`, `2xx`, `3xx`, `4xx`, `5xx`, `other`).
     /// Surfaces whether crawlers are getting served (`2xx`) or hitting broken /
     /// blocked pages (`4xx`/`5xx`) — a content-health signal the request tables
     /// don't make obvious.
@@ -2466,6 +2466,7 @@ impl ProxyLogService {
             r#"
             SELECT
                 CASE
+                    WHEN status_code >= 100 AND status_code < 200 THEN '1xx'
                     WHEN status_code >= 200 AND status_code < 300 THEN '2xx'
                     WHEN status_code >= 300 AND status_code < 400 THEN '3xx'
                     WHEN status_code >= 400 AND status_code < 500 THEN '4xx'
@@ -2928,7 +2929,7 @@ pub struct AiAgentTimelineRow {
 }
 
 /// One row in the AI-agent HTTP status breakdown: the request count for a
-/// status class (`2xx`/`3xx`/`4xx`/`5xx`/`other`) across crawler traffic.
+/// status class (`1xx`/`2xx`/`3xx`/`4xx`/`5xx`/`other`) across crawler traffic.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct AiStatusBreakdownRow {
     /// Status class label.
@@ -3028,6 +3029,18 @@ impl ProjectHealthSummary {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn status_class_range_includes_1xx() {
+        // 101 Switching Protocols (and other informational codes) must map to
+        // the `1xx` bucket, not be excluded/misrouted into an error range.
+        assert_eq!(ProxyLogService::status_class_range("1xx"), Some((100, 200)));
+        assert_eq!(ProxyLogService::status_class_range("2xx"), Some((200, 300)));
+        assert_eq!(ProxyLogService::status_class_range("3xx"), Some((300, 400)));
+        assert_eq!(ProxyLogService::status_class_range("4xx"), Some((400, 500)));
+        assert_eq!(ProxyLogService::status_class_range("5xx"), Some((500, 600)));
+        assert_eq!(ProxyLogService::status_class_range("other"), None);
+    }
 
     #[test]
     fn project_health_uses_latency_sample_count_and_gapfills_24_hours() {
@@ -3739,6 +3752,78 @@ mod tests {
         assert!((cagg_busy.p50_response_time_ms - raw_busy.p50_response_time_ms).abs() < 1e-9);
         assert!((cagg_busy.p95_response_time_ms - raw_busy.p95_response_time_ms).abs() < 1e-9);
         assert!((cagg_busy.p99_response_time_ms - raw_busy.p99_response_time_ms).abs() < 1e-9);
+    }
+
+    /// A `101 Switching Protocols` response (e.g. a WebSocket/SSE upgrade) must
+    /// be bucketed as `1xx`, not silently dropped into the `other` catch-all
+    /// which the frontend renders identically to an unrecognized/broken
+    /// status. Regression test for the AI status-breakdown SQL CASE
+    /// statement missing a `1xx` branch. Skips gracefully when no test
+    /// Postgres is available, per the repo's Docker-test convention.
+    #[tokio::test]
+    async fn test_get_ai_status_breakdown_classifies_101_as_1xx() {
+        use temps_database::test_utils::TestDatabase;
+
+        let test_db = match TestDatabase::with_migrations().await {
+            Ok(db) => db,
+            Err(e) => {
+                println!("Test database not available, skipping: {e}");
+                return;
+            }
+        };
+        let db = test_db.connection_arc().clone();
+
+        std::env::set_var("TEMPS_GEO_MOCK", "true");
+        let geoip = Arc::new(temps_geo::GeoIpService::new().expect("mock GeoIpService for tests"));
+        let ip_service = Arc::new(temps_geo::IpAddressService::new(db.clone(), geoip));
+        let service = ProxyLogService::new(db.clone(), ip_service);
+
+        let stmt = sea_orm::Statement::from_sql_and_values(
+            sea_orm::DatabaseBackend::Postgres,
+            "INSERT INTO projects (id, name, repo_name, repo_owner, directory, \
+             main_branch, preset, created_at, updated_at, slug) \
+             VALUES (1, 'ai-status-p1', 'repo', 'owner', '.', 'main', 'nodejs', now(), now(), 'ai-status-p1')",
+            vec![],
+        );
+        db.execute(stmt).await.expect("insert project row");
+
+        async fn insert_ai_log(db: &DatabaseConnection, status: i16, request_id: &str) {
+            let stmt = sea_orm::Statement::from_sql_and_values(
+                sea_orm::DatabaseBackend::Postgres,
+                r#"INSERT INTO proxy_logs
+                    (timestamp, method, path, host, status_code, response_time_ms,
+                     request_source, is_system_request, routing_status, project_id,
+                     request_id, is_bot, bot_name, request_size_bytes,
+                     response_size_bytes, created_date)
+                   VALUES (now(), 'GET', '/', 'test.local', $1, 10,
+                           'proxy', false, 'routed', 1, $2, true, 'GPTBot', 100, 200,
+                           now()::date)"#,
+                vec![status.into(), request_id.into()],
+            );
+            db.execute(stmt).await.expect("insert proxy_logs row");
+        }
+
+        insert_ai_log(&db, 101, "ai-status-101").await;
+        insert_ai_log(&db, 200, "ai-status-200").await;
+
+        let start = Utc::now() - chrono::Duration::hours(1);
+        let end = Utc::now() + chrono::Duration::minutes(1);
+
+        let breakdown = service
+            .get_ai_status_breakdown(Some(1), None, start, end)
+            .await
+            .expect("ai status breakdown");
+
+        let class_1xx = breakdown
+            .iter()
+            .find(|r| r.status_class == "1xx")
+            .expect("101 response must be classified as 1xx, not folded into 'other'");
+        assert_eq!(class_1xx.request_count, 1);
+
+        assert!(
+            breakdown.iter().all(|r| r.status_class != "other"),
+            "no row should fall into the 'other' catch-all: {breakdown:?}"
+        );
     }
 
     fn sample_proxy_log_model(request_id: &str) -> proxy_logs::Model {

--- a/crates/temps-proxy/src/storage/clickhouse.rs
+++ b/crates/temps-proxy/src/storage/clickhouse.rs
@@ -1859,6 +1859,7 @@ impl ProxyLogStorage for ClickHouseProxyLogStore {
         let sql = format!(
             "SELECT \
                 multiIf( \
+                    status_code >= 100 AND status_code < 200, '1xx', \
                     status_code >= 200 AND status_code < 300, '2xx', \
                     status_code >= 300 AND status_code < 400, '3xx', \
                     status_code >= 400 AND status_code < 500, '4xx', \
@@ -2589,6 +2590,48 @@ mod tests {
         assert_eq!(summaries[1].status, "unknown");
     }
 
+    /// A `101 Switching Protocols` response from AI-crawler traffic (e.g. a
+    /// WebSocket/SSE upgrade) must be bucketed as `1xx`, not folded into the
+    /// `other` catch-all the multiIf status-class query used to produce.
+    #[tokio::test]
+    async fn clickhouse_ai_status_breakdown_classifies_101_as_1xx() {
+        let Some((store, _container)) = setup_clickhouse_store().await else {
+            return;
+        };
+
+        let mut upgrade = make_entry("ai-status-101");
+        upgrade.is_bot = Some(true);
+        upgrade.bot_name = Some("GPTBot".to_string());
+        upgrade.status_code = 101;
+
+        let mut served = make_entry("ai-status-200");
+        served.is_bot = Some(true);
+        served.bot_name = Some("GPTBot".to_string());
+        served.status_code = 200;
+
+        store
+            .write_batch(vec![upgrade, served])
+            .await
+            .expect("insert proxy-log fixtures");
+
+        let start = Utc::now() - chrono::Duration::minutes(2);
+        let end = Utc::now() + chrono::Duration::minutes(2);
+        let breakdown = store
+            .get_ai_status_breakdown(None, None, start, end)
+            .await
+            .expect("ai status breakdown");
+
+        let class_1xx = breakdown
+            .iter()
+            .find(|r| r.status_class == "1xx")
+            .expect("101 response must be classified as 1xx, not folded into 'other'");
+        assert_eq!(class_1xx.request_count, 1);
+        assert!(
+            breakdown.iter().all(|r| r.status_class != "other"),
+            "no row should fall into the 'other' catch-all: {breakdown:?}"
+        );
+    }
+
     #[tokio::test]
     async fn clickhouse_traffic_aggregation_returns_drilldowns_and_excludes_monitor() {
         let Some((store, _container)) = setup_clickhouse_store().await else {
@@ -2986,6 +3029,7 @@ mod tests {
 
     #[test]
     fn status_class_range_matches_postgres() {
+        assert_eq!(status_class_range("1xx"), Some((100, 200)));
         assert_eq!(status_class_range("2xx"), Some((200, 300)));
         assert_eq!(status_class_range("4xx"), Some((400, 500)));
         assert_eq!(status_class_range("5xx"), Some((500, 600)));

--- a/web/src/components/analytics/AiAgentsDetail.tsx
+++ b/web/src/components/analytics/AiAgentsDetail.tsx
@@ -196,17 +196,20 @@ export function AiAgentsDetail({
     const items = statusQuery.data?.items ?? []
     const total = items.reduce((s, r) => s + r.request_count, 0)
     const colorFor = (cls: string) =>
-      cls.startsWith('2')
-        ? 'var(--chart-2)' // green — served
-        : cls.startsWith('3')
-          ? 'var(--chart-1)' // blue — redirect
-          : cls.startsWith('4')
-            ? 'var(--chart-3)' // amber — client error
-            : cls.startsWith('5')
-              ? 'var(--chart-4)' // red — server error
-              : 'var(--muted-foreground)'
+      cls.startsWith('1')
+        ? 'var(--chart-1)' // blue — informational / upgrade
+        : cls.startsWith('2')
+          ? 'var(--chart-2)' // green — served
+          : cls.startsWith('3')
+            ? 'var(--chart-1)' // blue — redirect
+            : cls.startsWith('4')
+              ? 'var(--chart-3)' // amber — client error
+              : cls.startsWith('5')
+                ? 'var(--chart-4)' // red — server error
+                : 'var(--muted-foreground)'
     const labelFor = (cls: string) =>
       ({
+        '1xx': '1xx Informational',
         '2xx': '2xx Served',
         '3xx': '3xx Redirect',
         '4xx': '4xx Not found / blocked',

--- a/web/src/components/logs/ProxyLogsList.tsx
+++ b/web/src/components/logs/ProxyLogsList.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/api/client/@tanstack/react-query.gen'
 import { AiAgentLogo } from '@/components/ui/ai-agent-logo'
 import { Badge } from '@/components/ui/badge'
+import { httpStatusClass } from '@/lib/http-status-class'
 import { Button } from '@/components/ui/button'
 import {
   Select,
@@ -43,6 +44,20 @@ interface ProxyLogsListProps {
   project: ProjectResponse
   onRowClick?: (requestId: string, projectId: number, timestamp: string) => void
   showEnvironmentFilter?: boolean
+}
+
+const STATUS_BADGE_CLASSES: Record<
+  ReturnType<typeof httpStatusClass>,
+  string
+> = {
+  '1xx': 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+  '2xx': 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+  '3xx':
+    'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+  '4xx': 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+  '5xx': 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+  unknown:
+    'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
 }
 
 export default function ProxyLogsList({
@@ -722,14 +737,7 @@ export default function ProxyLogsList({
                             </TableCell>
                             <TableCell>
                               <span
-                                className={`rounded-full px-2 py-1 text-xs font-medium ${
-                                  log.status_code >= 200 &&
-                                  log.status_code < 300
-                                    ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
-                                    : log.status_code >= 400
-                                      ? 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'
-                                      : 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200'
-                                }`}
+                                className={`rounded-full px-2 py-1 text-xs font-medium ${STATUS_BADGE_CLASSES[httpStatusClass(log.status_code)]}`}
                               >
                                 {log.status_code}
                               </span>

--- a/web/src/components/proxy-logs/ProxyLogsDataTable.tsx
+++ b/web/src/components/proxy-logs/ProxyLogsDataTable.tsx
@@ -5,6 +5,7 @@ import { getProxyLogsOptions } from '@/api/client/@tanstack/react-query.gen'
 import { ProxyLogResponse } from '@/api/client/types.gen'
 import { AiAgentLogo } from '@/components/ui/ai-agent-logo'
 import { AGENT_TO_PROVIDER, AI_PROVIDERS } from '@/lib/ai-agents'
+import { httpStatusClass } from '@/lib/http-status-class'
 import { proxyLogDetailUrl } from '@/lib/proxy-log-navigation'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -599,9 +600,15 @@ export function ProxyLogsDataTable({
     JSON.stringify(filters) !== JSON.stringify(pendingFilters)
 
   const getStatusBadgeVariant = (statusCode: number) => {
-    if (statusCode >= 200 && statusCode < 300) return 'default'
-    if (statusCode >= 300 && statusCode < 400) return 'secondary'
-    return 'destructive'
+    switch (httpStatusClass(statusCode)) {
+      case '1xx':
+      case '3xx':
+        return 'secondary'
+      case '2xx':
+        return 'default'
+      default:
+        return 'destructive'
+    }
   }
 
   const getRoutingStatusBadge = (status: string) => {
@@ -1866,7 +1873,13 @@ function ProxyLogInlineDetail({ log }: { log: ProxyLogResponse }) {
 }
 
 function getStatusVariant(statusCode: number) {
-  if (statusCode >= 200 && statusCode < 300) return 'default'
-  if (statusCode >= 300 && statusCode < 400) return 'secondary'
-  return 'destructive'
+  switch (httpStatusClass(statusCode)) {
+    case '1xx':
+    case '3xx':
+      return 'secondary'
+    case '2xx':
+      return 'default'
+    default:
+      return 'destructive'
+  }
 }

--- a/web/src/components/visitors/SessionDetail.tsx
+++ b/web/src/components/visitors/SessionDetail.tsx
@@ -35,6 +35,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { DateRangePicker } from '@/components/ui/date-range-picker'
+import { httpStatusClass } from '@/lib/http-status-class'
 import { useQuery } from '@tanstack/react-query'
 import { format } from 'date-fns'
 import {
@@ -194,11 +195,19 @@ export function SessionDetail({
   }
 
   const getStatusColor = (statusCode: number) => {
-    if (statusCode >= 200 && statusCode < 300) return 'text-green-600'
-    if (statusCode >= 300 && statusCode < 400) return 'text-blue-600'
-    if (statusCode >= 400 && statusCode < 500) return 'text-yellow-600'
-    if (statusCode >= 500) return 'text-red-600'
-    return 'text-gray-600'
+    switch (httpStatusClass(statusCode)) {
+      case '1xx':
+      case '3xx':
+        return 'text-blue-600'
+      case '2xx':
+        return 'text-green-600'
+      case '4xx':
+        return 'text-yellow-600'
+      case '5xx':
+        return 'text-red-600'
+      default:
+        return 'text-gray-600'
+    }
   }
 
   const isLoading = isLoadingSession || isLoadingVisitor

--- a/web/src/lib/http-status-class.test.ts
+++ b/web/src/lib/http-status-class.test.ts
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+import { describe, expect, it } from 'bun:test'
+import { httpStatusClass, isHttpErrorStatus } from './http-status-class'
+
+describe('httpStatusClass', () => {
+  it('classifies 101 Switching Protocols as informational, not an error', () => {
+    expect(httpStatusClass(101)).toBe('1xx')
+  })
+
+  it('classifies other 1xx codes as informational', () => {
+    expect(httpStatusClass(100)).toBe('1xx')
+    expect(httpStatusClass(103)).toBe('1xx')
+  })
+
+  it('classifies 2xx as success', () => {
+    expect(httpStatusClass(200)).toBe('2xx')
+    expect(httpStatusClass(299)).toBe('2xx')
+  })
+
+  it('classifies 3xx as redirect', () => {
+    expect(httpStatusClass(301)).toBe('3xx')
+  })
+
+  it('classifies 4xx and 5xx as client/server error', () => {
+    expect(httpStatusClass(404)).toBe('4xx')
+    expect(httpStatusClass(500)).toBe('5xx')
+  })
+
+  it('falls back to unknown for out-of-range codes', () => {
+    expect(httpStatusClass(0)).toBe('unknown')
+    expect(httpStatusClass(600)).toBe('unknown')
+  })
+})
+
+describe('isHttpErrorStatus', () => {
+  it('does not treat 101 Switching Protocols as an error', () => {
+    expect(isHttpErrorStatus(101)).toBe(false)
+  })
+
+  it('does not treat success or redirect codes as errors', () => {
+    expect(isHttpErrorStatus(200)).toBe(false)
+    expect(isHttpErrorStatus(301)).toBe(false)
+  })
+
+  it('treats 4xx and 5xx as errors', () => {
+    expect(isHttpErrorStatus(404)).toBe(true)
+    expect(isHttpErrorStatus(500)).toBe(true)
+  })
+})

--- a/web/src/lib/http-status-class.ts
+++ b/web/src/lib/http-status-class.ts
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+/**
+ * Classifies an HTTP status code into its RFC 9110 class.
+ *
+ * 1xx (informational, e.g. 101 Switching Protocols for a WebSocket/SSE
+ * upgrade) is a distinct, non-error class -- it must never be treated as an
+ * error or fall through to an "unknown" bucket alongside genuinely
+ * unrecognized codes.
+ */
+export type HttpStatusClass = '1xx' | '2xx' | '3xx' | '4xx' | '5xx' | 'unknown'
+
+export function httpStatusClass(statusCode: number): HttpStatusClass {
+  if (statusCode >= 100 && statusCode < 200) return '1xx'
+  if (statusCode >= 200 && statusCode < 300) return '2xx'
+  if (statusCode >= 300 && statusCode < 400) return '3xx'
+  if (statusCode >= 400 && statusCode < 500) return '4xx'
+  if (statusCode >= 500 && statusCode < 600) return '5xx'
+  return 'unknown'
+}
+
+export function isHttpErrorStatus(statusCode: number): boolean {
+  const cls = httpStatusClass(statusCode)
+  return cls === '4xx' || cls === '5xx'
+}

--- a/web/src/pages/RequestLogDetail.tsx
+++ b/web/src/pages/RequestLogDetail.tsx
@@ -11,6 +11,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
+import { httpStatusClass } from '@/lib/http-status-class'
 import {
   ArrowLeft,
   Monitor,
@@ -68,11 +69,20 @@ export default function RequestLogDetail({
   } = isLegacyNumericId ? byId : byRequestId
 
   const getStatusColor = (status: number) => {
-    if (status >= 200 && status < 300) return 'bg-green-100 text-green-800'
-    if (status >= 300 && status < 400) return 'bg-yellow-100 text-yellow-800'
-    if (status >= 400 && status < 500) return 'bg-orange-100 text-orange-800'
-    if (status >= 500) return 'bg-red-100 text-red-800'
-    return 'bg-gray-100 text-gray-800'
+    switch (httpStatusClass(status)) {
+      case '1xx':
+        return 'bg-blue-100 text-blue-800'
+      case '2xx':
+        return 'bg-green-100 text-green-800'
+      case '3xx':
+        return 'bg-yellow-100 text-yellow-800'
+      case '4xx':
+        return 'bg-orange-100 text-orange-800'
+      case '5xx':
+        return 'bg-red-100 text-red-800'
+      default:
+        return 'bg-gray-100 text-gray-800'
+    }
   }
 
   const getMethodColor = (method: string) => {


### PR DESCRIPTION
## Summary
- `101 Switching Protocols` (WebSocket/SSE upgrade) was being rendered as an error/warning status in the proxy logs UI (red or yellow badge) because several status-badge helpers only special-cased 2xx/3xx/4xx/5xx and let anything below 200 fall through to their error branch.
- The AI status-breakdown SQL (Postgres `proxy_log_service.rs` and ClickHouse `clickhouse.rs`) bucketed 1xx status codes into an `other` catch-all instead of a proper `1xx` class, even though the shared `status_class_range` helper already understood `1xx`.
- Extracted the duplicated inline classification logic (4 call sites) into a single, unit-tested `httpStatusClass`/`isHttpErrorStatus` helper (`web/src/lib/http-status-class.ts`) so this can't drift out of sync again.

## Evidence

**Frontend classification (the exact bug from the report — a GET `/` returning 101 rendered with a red "error" badge)**:
```bash
$ bun run verify-101-badge.ts   # imports the new web/src/lib/http-status-class.ts directly
status=101 class=1xx isError=false
status=200 class=2xx isError=false
status=301 class=3xx isError=false
status=404 class=4xx isError=true
status=500 class=5xx isError=true
```
101 now classifies as `1xx`/non-error; `getStatusBadgeVariant`/`getStatusVariant`/`getStatusColor` in the touched components all switch on this same helper, so the badge for a 101 request now renders the same "secondary/informational" style used for redirects instead of `destructive` (red).

Note: I did not capture a live browser screenshot of the Proxy Logs page — every local dev port slot (0–29) on this machine is currently claimed by another active worktree/agent, and freeing one would mean tearing down someone else's server. The script above exercises the exact same function that feeds every changed component's badge/color decision, and the Rust-side fix is proven end-to-end against real databases below.

**Backend (Postgres) — AI status breakdown no longer folds 101 into `other`**:
```bash
$ cargo test --lib -p temps-proxy test_get_ai_status_breakdown_classifies_101_as_1xx -- --nocapture
running 1 test
test service::proxy_log_service::tests::test_get_ai_status_breakdown_classifies_101_as_1xx ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 584 filtered out; finished in 5.29s
```
(Inserts real `proxy_logs` rows with `status_code=101` and `status_code=200` against a throwaway Postgres via `TestDatabase`, then asserts the breakdown query returns a `1xx` row with count 1 and that no row is `other`.)

**Backend (ClickHouse) — same fix, alternate storage backend**:
```bash
$ cargo test --lib -p temps-proxy clickhouse_ai_status_breakdown_classifies_101_as_1xx -- --nocapture
running 1 test
test storage::clickhouse::tests::clickhouse_ai_status_breakdown_classifies_101_as_1xx ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 585 filtered out; finished in 5.48s
```
(Same assertion against a real ClickHouse container via testcontainers.)

**Full suites**:
```bash
$ cargo test --lib -p temps-proxy
test result: ok. 581 passed; 1 failed; 4 ignored ...
```
The 1 failure (`test_proxy_route_resolution`) is `Os { code: 48, kind: AddrInUse }` — a pre-existing port-binding flake from running many tests in parallel, unrelated to this change; it passes cleanly when run in isolation (confirmed).

```bash
$ bun test src
 544 pass
 0 fail
Ran 544 tests across 111 files.
```

```bash
$ bunx tsc --noEmit -p .
(no output — clean)
```

```bash
$ cargo clippy --workspace --all-targets -- -D warnings   # via pre-commit hook, real cargo binary
cargo clippy.............................................................Passed
```