### PR TITLE
fix(auth): track pending-MFA-session origin so SSO enforcement can tell it apart from password login

### DIFF
--- a/crates/temps-auth/src/auth_service.rs
+++ b/crates/temps-auth/src/auth_service.rs
@@ -277,7 +277,19 @@ impl AuthService {
     }
 
     // Creates temporary session for MFA verification
-    pub async fn create_mfa_session(&self, user_id: i32) -> Result<String, AuthError> {
+    //
+    // `origin` records which login method created this pending challenge
+    // (e.g. `"password"`, `"oidc"`, `"saml"`) so a later caller can tell an
+    // SSO-originated challenge apart from a password-originated one -- see
+    // `mfa_session_origin`'s doc comment for why that distinction matters.
+    // Callers should use short, self-consistent values; they don't need to
+    // match any other string convention (e.g. audit-log `login_method`
+    // values) verbatim.
+    pub async fn create_mfa_session(
+        &self,
+        user_id: i32,
+        origin: &str,
+    ) -> Result<String, AuthError> {
         let session_token = self.generate_session_token();
         let expires_at = Utc::now() + Duration::minutes(5); // Short expiration for MFA sessions
 
@@ -288,12 +300,42 @@ impl AuthService {
             // Mark this as a pending MFA challenge so it can never be replayed
             // as a real session cookie -- `verify_session` rejects such rows.
             mfa_pending: Set(true),
+            mfa_pending_origin: Set(Some(origin.to_string())),
             ..Default::default()
         };
 
         new_session.insert(self.db.as_ref()).await?;
 
         Ok(session_token)
+    }
+
+    /// Look up the login method that created a still-pending MFA challenge,
+    /// without consuming it.
+    ///
+    /// Used by SSO enforcement (temps-ee-sso) so `POST /auth/verify-mfa` can
+    /// let an SSO-originated pending challenge (`"oidc"`/`"saml"`) through
+    /// even while enforcement is blocking password/magic-link/reset logins,
+    /// instead of permanently stranding an MFA+SSO account on the "Two-factor
+    /// authentication" screen.
+    ///
+    /// Applies the exact same filters `verify_mfa_challenge` uses (token
+    /// match, not expired, `mfa_pending = true`), so this never reports an
+    /// origin for a row `verify_mfa_challenge` would itself reject. Every
+    /// "not currently a valid pending MFA session" case -- unknown token,
+    /// expired, already consumed, or a fully authenticated session token --
+    /// collapses to `None`; callers don't need to distinguish them.
+    pub async fn mfa_session_origin(
+        &self,
+        session_token: &str,
+    ) -> Result<Option<String>, AuthError> {
+        let session = temps_entities::sessions::Entity::find()
+            .filter(temps_entities::sessions::Column::SessionToken.eq(session_token))
+            .filter(temps_entities::sessions::Column::ExpiresAt.gt(Utc::now()))
+            .filter(temps_entities::sessions::Column::MfaPending.eq(true))
+            .one(self.db.as_ref())
+            .await?;
+
+        Ok(session.and_then(|s| s.mfa_pending_origin))
     }
 
     // Verifies the MFA code
@@ -1476,7 +1518,10 @@ mod tests {
         let user = create_test_user(&db.db, "mfabypass@example.com", "password").await;
 
         // Token handed to the client as the `mfa_session` cookie.
-        let mfa_token = auth_service.create_mfa_session(user.id).await.unwrap();
+        let mfa_token = auth_service
+            .create_mfa_session(user.id, "password")
+            .await
+            .unwrap();
 
         // The attack: replay it on the normal session path.
         let result = auth_service.verify_session(&mfa_token).await;
@@ -1528,7 +1573,10 @@ mod tests {
         };
         let user = create_test_user(&db.db, "activecount@example.com", "password").await;
 
-        auth_service.create_mfa_session(user.id).await.unwrap();
+        auth_service
+            .create_mfa_session(user.id, "password")
+            .await
+            .unwrap();
         assert_eq!(
             auth_service.count_active_sessions(user.id).await.unwrap(),
             0,
@@ -2137,7 +2185,10 @@ mod tests {
         let (db, auth_service, _) = setup_test_env().await;
         let user = create_test_user(&db.db, "mfa@example.com", "password").await;
 
-        let mfa_session_token = auth_service.create_mfa_session(user.id).await.unwrap();
+        let mfa_session_token = auth_service
+            .create_mfa_session(user.id, "password")
+            .await
+            .unwrap();
 
         assert!(!mfa_session_token.is_empty());
 
@@ -2157,13 +2208,114 @@ mod tests {
         assert!(time_diff < 2); // Allow 2 seconds of variance
     }
 
+    /// Regression coverage for the SSO+MFA lockout fix: `create_mfa_session`
+    /// must persist the given origin, and `mfa_session_origin` must read it
+    /// back exactly -- this is the mechanism temps-ee-sso's enforcement
+    /// middleware relies on to tell an SSO-originated pending challenge
+    /// apart from a password-originated one. Runs it against a real
+    /// (Dockerized) database so the new `mfa_pending_origin` column is
+    /// proven to round-trip, not just compile against the entity model.
+    #[tokio::test]
+    async fn test_create_mfa_session_persists_origin_and_mfa_session_origin_reads_it_back() {
+        let (db, auth_service, _) = setup_test_env().await;
+        let user = create_test_user(&db.db, "mfa-origin@example.com", "password").await;
+
+        let oidc_token = auth_service
+            .create_mfa_session(user.id, "oidc")
+            .await
+            .unwrap();
+        let saml_token = auth_service
+            .create_mfa_session(user.id, "saml")
+            .await
+            .unwrap();
+        let password_token = auth_service
+            .create_mfa_session(user.id, "password")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            auth_service.mfa_session_origin(&oidc_token).await.unwrap(),
+            Some("oidc".to_string())
+        );
+        assert_eq!(
+            auth_service.mfa_session_origin(&saml_token).await.unwrap(),
+            Some("saml".to_string())
+        );
+        assert_eq!(
+            auth_service
+                .mfa_session_origin(&password_token)
+                .await
+                .unwrap(),
+            Some("password".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mfa_session_origin_returns_none_for_unknown_token() {
+        let (_db, auth_service, _) = setup_test_env().await;
+
+        let origin = auth_service
+            .mfa_session_origin("does-not-exist")
+            .await
+            .unwrap();
+
+        assert_eq!(origin, None);
+    }
+
+    #[tokio::test]
+    async fn test_mfa_session_origin_returns_none_for_expired_session() {
+        let (db, auth_service, _) = setup_test_env().await;
+        let user = create_test_user(&db.db, "mfa-origin-expired@example.com", "password").await;
+
+        let token = "expired_mfa_origin_session";
+        let session = sessions::ActiveModel {
+            user_id: Set(user.id),
+            session_token: Set(token.to_string()),
+            expires_at: Set(Utc::now() - Duration::minutes(1)),
+            mfa_pending: Set(true),
+            mfa_pending_origin: Set(Some("oidc".to_string())),
+            ..Default::default()
+        };
+        session.insert(db.db.as_ref()).await.unwrap();
+
+        let origin = auth_service.mfa_session_origin(token).await.unwrap();
+
+        assert_eq!(
+            origin, None,
+            "an expired pending session must not report an origin"
+        );
+    }
+
+    /// A fully authenticated (non-pending) session token must never report
+    /// an origin either -- `mfa_session_origin` filters on `mfa_pending =
+    /// true` exactly like `verify_mfa_challenge`, so a real session token
+    /// can never be mistaken for a pending SSO challenge by the enforcement
+    /// middleware.
+    #[tokio::test]
+    async fn test_mfa_session_origin_returns_none_for_real_session() {
+        let (db, auth_service, _) = setup_test_env().await;
+        let user = create_test_user(&db.db, "mfa-origin-real@example.com", "password").await;
+
+        let real_token = auth_service.create_session(user.id).await.unwrap();
+
+        let origin = auth_service.mfa_session_origin(&real_token).await.unwrap();
+
+        assert_eq!(
+            origin, None,
+            "a fully authenticated session must not report a pending-MFA origin"
+        );
+    }
+
     #[tokio::test]
     async fn test_verify_mfa_challenge_without_secret() {
         let (db, auth_service, _) = setup_test_env().await;
         let user = create_test_user(&db.db, "mfa@example.com", "password").await;
 
         // Create MFA session
-        let mfa_session_token = auth_service.create_mfa_session(user.id).await.unwrap();
+        let mfa_session_token = auth_service
+            .create_mfa_session(user.id, "password")
+            .await
+            .unwrap();
 
         // Try to verify without MFA secret set
         let result = auth_service
@@ -2200,7 +2352,10 @@ mod tests {
         };
         let user =
             create_test_user_with_mfa(&db.db, "wrong-code@example.com", "password", true).await;
-        let session_token = auth_service.create_mfa_session(user.id).await.unwrap();
+        let session_token = auth_service
+            .create_mfa_session(user.id, "password")
+            .await
+            .unwrap();
         let current_code = current_totp_code("JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP");
         let wrong_code = if current_code == "000000" {
             "000001"
@@ -2271,6 +2426,7 @@ mod tests {
             expires_at: now + Duration::minutes(5),
             mfa_pending: true,
             step_up_expires_at: None,
+            mfa_pending_origin: Some("password".to_string()),
         };
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results([vec![session]])

--- a/crates/temps-auth/src/handlers.rs
+++ b/crates/temps-auth/src/handlers.rs
@@ -1091,7 +1091,11 @@ pub async fn login(
             // Check if user has MFA enabled
             if user.mfa_enabled {
                 // Create temporary MFA session
-                match state.auth_service.create_mfa_session(user.id).await {
+                match state
+                    .auth_service
+                    .create_mfa_session(user.id, "password")
+                    .await
+                {
                     Ok(mfa_token) => {
                         // Encrypt the MFA token
                         let encrypted_token = match state.cookie_crypto.encrypt(&mfa_token) {

--- a/crates/temps-auth/src/oidc_handler.rs
+++ b/crates/temps-auth/src/oidc_handler.rs
@@ -366,7 +366,7 @@ async fn complete_oidc_login(
     if user.mfa_enabled {
         let mfa_token = state
             .auth_service
-            .create_mfa_session(user.id)
+            .create_mfa_session(user.id, "oidc")
             .await
             .map_err(|e| OidcError::DiscoveryFailed {
                 issuer: provider.issuer_url.clone(),

--- a/crates/temps-auth/src/sensitive_action.rs
+++ b/crates/temps-auth/src/sensitive_action.rs
@@ -432,6 +432,7 @@ mod tests {
             expires_at: Utc::now() + Duration::days(1),
             mfa_pending: false,
             step_up_expires_at,
+            mfa_pending_origin: None,
         }
     }
 

--- a/crates/temps-entities/src/sessions.rs
+++ b/crates/temps-entities/src/sessions.rs
@@ -22,6 +22,13 @@ pub struct Model {
     /// Until this instant the session may perform sensitive actions. `NULL`
     /// means the session has not completed recent step-up verification.
     pub step_up_expires_at: Option<DBDateTime>,
+    /// Which login method created this pending MFA challenge (e.g.
+    /// `"password"`, `"oidc"`, `"saml"`). Only ever set while `mfa_pending`
+    /// is true -- a fully authenticated session leaves this `NULL`. Lets SSO
+    /// enforcement distinguish a password-originated challenge (must stay
+    /// blocked) from an SSO-originated one (already completed at the IdP,
+    /// must be allowed to finish `verify-mfa`).
+    pub mfa_pending_origin: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/temps-external-plugins/src/host_api.rs
+++ b/crates/temps-external-plugins/src/host_api.rs
@@ -543,6 +543,7 @@ mod tests {
             expires_at: Utc::now() + ChronoDuration::minutes(30),
             mfa_pending: false,
             step_up_expires_at: None,
+            mfa_pending_origin: None,
         }
     }
 

--- a/crates/temps-migrations/src/migration/m20260907_000001_add_mfa_pending_origin_to_sessions.rs
+++ b/crates/temps-migrations/src/migration/m20260907_000001_add_mfa_pending_origin_to_sessions.rs
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Records which login method (password, OIDC, SAML) created a pending
+//! MFA-challenge `sessions` row.
+//!
+//! Every login flow that gates on `mfa_enabled` (password, OIDC, SAML)
+//! calls the same `AuthService::create_mfa_session`, so the resulting row
+//! was previously indistinguishable between a password-originated
+//! challenge and an SSO-originated one. That ambiguity is what let SSO
+//! enforcement's `POST /auth/verify-mfa` block correctly block a
+//! password-originated challenge while incorrectly also blocking a user
+//! who had already completed a legitimate OIDC/SAML login at their IdP,
+//! permanently stranding MFA+SSO accounts. This column lets enforcement
+//! tell the two cases apart.
+//!
+//! Nullable: fully authenticated sessions (`mfa_pending = false`) never
+//! set this column.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Alias::new("sessions"))
+                    .add_column_if_not_exists(
+                        ColumnDef::new(Alias::new("mfa_pending_origin"))
+                            .string_len(32)
+                            .null(),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Alias::new("sessions"))
+                    .drop_column(Alias::new("mfa_pending_origin"))
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn migration_name_is_stable() {
+        assert_eq!(
+            Migration.name(),
+            "m20260907_000001_add_mfa_pending_origin_to_sessions"
+        );
+    }
+}

--- a/crates/temps-migrations/src/migration/mod.rs
+++ b/crates/temps-migrations/src/migration/mod.rs
@@ -220,6 +220,7 @@ mod m20260902_000001_backup_safety_and_provenance;
 mod m20260903_000001_add_service_project_identity;
 mod m20260903_000001_add_vulnerability_scanning_enabled_to_projects;
 mod m20260904_000001_reset_ambiguous_managed_status_monitors;
+mod m20260907_000001_add_mfa_pending_origin_to_sessions;
 
 pub struct Migrator;
 
@@ -483,6 +484,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260831_000002_add_managed_status_monitors::Migration),
             Box::new(m20260903_000001_add_service_project_identity::Migration),
             Box::new(m20260904_000001_reset_ambiguous_managed_status_monitors::Migration),
+            Box::new(m20260907_000001_add_mfa_pending_origin_to_sessions::Migration),
         ]
     }
 }


### PR DESCRIPTION
## Summary

Password, OIDC, and SAML logins all call the same `AuthService::create_mfa_session(user_id)` when an
account has MFA enabled, producing an identical `sessions` row (`mfa_pending = true`) with no record of
which login method created it. A commercial SSO-enforcement plugin that blocks `POST /auth/verify-mfa`
while an instance-wide "Require SSO" mode is active had no way to distinguish a password-originated pending
challenge (which correctly should stay blocked, since password login itself is blocked at the door) from
one that already followed a completed SSO login at the identity provider (which should not be blocked at
all — the user already proved their identity there; blocking their account's own second factor doesn't
enforce SSO, it just permanently strands MFA-enabled SSO accounts on the two-factor screen).

- New nullable column `sessions.mfa_pending_origin` (migration `m20260907_000001`), reversible.
- `AuthService::create_mfa_session` now takes an `origin: &str` parameter and persists it. Updated the two
  OSS call sites (`crates/temps-auth/src/handlers.rs` → `"password"`, `crates/temps-auth/src/oidc_handler.rs`
  → `"oidc"`); a companion PR in the commercial SAML plugin passes `"saml"`.
- New read-only `AuthService::mfa_session_origin(session_token) -> Result<Option<String>, AuthError>`,
  applying the exact same filters `verify_mfa_challenge` itself already uses (token match, not expired,
  `mfa_pending = true`), so a caller checking origin before the fact and the handler that later consumes the
  session always agree on what counts as "currently pending."
- No behavior change in OSS itself — this only adds the column and the read/write plumbing a downstream
  consumer needs; nothing in this repo currently reads `mfa_session_origin` for a decision.

## Test plan

- [x] New tests: `create_mfa_session` persists the given origin and `mfa_session_origin` reads it back
      correctly, proven against a real Postgres via `TestDatabase::with_migrations()` (the actual new
      migration runs, not just a compile check); returns `None` for unknown/expired/already-consumed tokens.
- [x] Updated all existing `create_mfa_session` call sites (tests + two other model-literal sites) for the
      new signature.
- [x] `cargo check --workspace --lib` clean
- [x] `cargo test --lib -p temps-auth -p temps-migrations -p temps-entities` — 361 + 77 + 17 passed, 0 failed
- [x] Adversarially reviewed independently: migration is nullable/reversible, entity hand-maintained and
      updated correctly, `mfa_session_origin`'s query filters confirmed byte-identical to
      `verify_mfa_challenge`'s own lookup