### PR TITLE
fix(proxy): fall back to root index.html for asset-only directories

### DIFF
--- a/crates/temps-proxy/src/static_file_serving.rs
+++ b/crates/temps-proxy/src/static_file_serving.rs
@@ -219,7 +219,24 @@ pub(crate) async fn open_static_file(
 
     // This is intentionally the last pathname operation before File::open.
     // It catches directory-index symlinks as well as ordinary file symlinks.
-    let canonical_path = canonicalize(&final_candidate, "resolve final file").await?;
+    let canonical_path = match canonicalize(&final_candidate, "resolve final file").await {
+        Ok(path) => path,
+        Err(error) if candidate_metadata.is_dir() && is_spa_route(&relative_request_path) => {
+            // The request matched a real directory (e.g. an asset-only folder
+            // that happens to share a name with a client-side route) with no
+            // `index.html` of its own. Treat it the same as a missing file on
+            // an extensionless path: fall back to the deployment's root SPA
+            // shell instead of 404ing just because a same-named directory
+            // exists on disk.
+            let _ = error;
+            canonicalize(
+                &canonical_deployment_root.join("index.html"),
+                "resolve SPA fallback",
+            )
+            .await?
+        }
+        Err(error) => return Err(error),
+    };
     ensure_contained(
         &canonical_path,
         &canonical_deployment_root,
@@ -415,6 +432,39 @@ mod tests {
                 .expect("valid static request");
             assert!(opened.canonical_path.ends_with(suffix), "{request}");
         }
+    }
+
+    #[tokio::test]
+    async fn falls_back_to_root_index_for_a_real_directory_with_no_index_of_its_own() {
+        let (root, deployment) = deployment().await;
+        let assets_only_dir = deployment.join("guide");
+        fs::create_dir_all(&assets_only_dir)
+            .await
+            .expect("create asset-only directory");
+        fs::write(assets_only_dir.join("screenshot.png"), b"png")
+            .await
+            .expect("write asset inside directory");
+
+        // The bare directory path (no index.html inside it) must still resolve
+        // to the SPA shell — this is a client-side route that happens to share
+        // its first path segment with an asset directory in the build output.
+        for request in ["/guide", "/guide/"] {
+            let opened = open_static_file(root.path(), STORED_DIR, request)
+                .await
+                .unwrap_or_else(|error| panic!("{request} should fall back to SPA shell: {error}"));
+            assert!(
+                opened.canonical_path.ends_with("index.html")
+                    && !opened.canonical_path.ends_with("guide/index.html"),
+                "{request} resolved to {:?}, expected the deployment root index.html",
+                opened.canonical_path
+            );
+        }
+
+        // A real file inside that same directory must still resolve normally.
+        let asset = open_static_file(root.path(), STORED_DIR, "/guide/screenshot.png")
+            .await
+            .expect("existing asset inside the directory should still open");
+        assert!(asset.canonical_path.ends_with("guide/screenshot.png"));
     }
 
     #[tokio::test]

--- a/crates/temps-proxy/src/static_file_serving.rs
+++ b/crates/temps-proxy/src/static_file_serving.rs
@@ -221,14 +221,16 @@ pub(crate) async fn open_static_file(
     // It catches directory-index symlinks as well as ordinary file symlinks.
     let canonical_path = match canonicalize(&final_candidate, "resolve final file").await {
         Ok(path) => path,
-        Err(error) if candidate_metadata.is_dir() && is_spa_route(&relative_request_path) => {
+        Err(StaticFileUnavailable::NotFound { .. })
+            if candidate_metadata.is_dir() && is_spa_route(&relative_request_path) =>
+        {
             // The request matched a real directory (e.g. an asset-only folder
             // that happens to share a name with a client-side route) with no
             // `index.html` of its own. Treat it the same as a missing file on
             // an extensionless path: fall back to the deployment's root SPA
             // shell instead of 404ing just because a same-named directory
-            // exists on disk.
-            let _ = error;
+            // exists on disk. Any other failure (permission denied, symlink
+            // loop, etc.) still propagates as-is rather than being masked.
             canonicalize(
                 &canonical_deployment_root.join("index.html"),
                 "resolve SPA fallback",
@@ -465,6 +467,31 @@ mod tests {
             .await
             .expect("existing asset inside the directory should still open");
         assert!(asset.canonical_path.ends_with("guide/screenshot.png"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn directory_index_failures_other_than_not_found_are_not_masked_by_the_spa_fallback() {
+        use std::os::unix::fs::symlink;
+
+        let (root, deployment) = deployment().await;
+        let broken_dir = deployment.join("broken");
+        fs::create_dir_all(&broken_dir)
+            .await
+            .expect("create directory with a broken index");
+        // A self-referential symlink makes canonicalize fail with a symlink-loop
+        // error (not NotFound), simulating any non-missing resolution failure
+        // (permission denied, loop, etc.) on the directory's own index.html.
+        symlink("index.html", broken_dir.join("index.html")).expect("create symlink loop");
+
+        let error = open_static_file(root.path(), STORED_DIR, "/broken")
+            .await
+            .expect_err("a symlink-loop failure must not be masked as a missing index");
+
+        assert!(
+            matches!(error, StaticFileUnavailable::Unusable { .. }),
+            "expected the underlying resolution failure to propagate, got {error:?}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- `open_static_file()` only entered the SPA-fallback-to-`index.html` branch when the *initial* path lookup failed with `NotFound`. A request path that happens to match a real directory in the deployed build (e.g. a docs/assets folder holding only images, with no `index.html` of its own) resolves successfully on that first lookup, so it skips the fallback branch entirely — then hard-fails when `<dir>/index.html` doesn't exist, which gets mapped to a flat 404.
- Net effect: any client-side route whose first path segment happens to collide with a real, index-less directory in the static bundle 404s instead of serving the SPA shell, while every other unmatched route falls back correctly. Introduced in #812.
- Fix: when the final `<dir>/index.html` lookup fails for a directory candidate on an extensionless request path, retry against the deployment's root `index.html` — the same fallback semantics already applied to plain missing files.

## Test plan
- [x] `cargo test --lib -p temps-proxy static_file_serving` — added `falls_back_to_root_index_for_a_real_directory_with_no_index_of_its_own`, covering: a directory-only route (`/guide`, `/guide/`) now resolves to the deployment root `index.html`, while a real asset inside that same directory (`/guide/screenshot.png`) still resolves normally.
- [x] `cargo test --lib -p temps-proxy` — full suite passes (one pre-existing, unrelated flaky port-binding test, `test_proxy_route_resolution`, not touched by this change).
- [x] `cargo clippy -p temps-proxy --lib --all-targets -- -D warnings` — clean.
- [x] Reproduced against a live deployment whose build output contains a top-level directory holding only images with no `index.html` of its own: the bare directory path 404'd while every other extensionless route correctly served the SPA shell; confirmed the fix resolves it locally via the new test.