### PR TITLE
fix(migrations): stop blanket-demoting managed-monitor ownership

### DIFF
--- a/crates/temps-migrations/src/migration/m20260904_000001_reset_ambiguous_managed_status_monitors.rs
+++ b/crates/temps-migrations/src/migration/m20260904_000001_reset_ambiguous_managed_status_monitors.rs
@@ -35,7 +35,51 @@ impl MigrationTrait for Migration {
         Ok(())
     }
 
-    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // up() is now a no-op, so on a database that first ran this
+        // migration's current version there is nothing to restore. But a
+        // database that already ran the previous, destructive up() (before
+        // this fix) has a populated
+        // `_temps_m20260904_managed_monitor_ownership_backup` table and
+        // demoted ownership from that run; rolling back on the new binary
+        // must still restore that captured state and drop the table,
+        // otherwise those monitors stay demoted forever and reconciliation
+        // creates a replacement.
+        let connection = manager.get_connection();
+        let backup_table_exists = connection
+            .query_one(sea_orm::Statement::from_string(
+                manager.get_database_backend(),
+                "SELECT to_regclass('_temps_m20260904_managed_monitor_ownership_backup') IS NOT NULL AS exists"
+                    .to_string(),
+            ))
+            .await?
+            .map(|row| row.try_get::<bool>("", "exists"))
+            .transpose()?
+            .unwrap_or(false);
+
+        if !backup_table_exists {
+            return Ok(());
+        }
+
+        connection
+            .execute_unprepared(
+                "UPDATE status_monitors AS current \
+                 SET is_managed = FALSE \
+                 WHERE current.is_managed = TRUE \
+                   AND EXISTS ( \
+                       SELECT 1 \
+                       FROM _temps_m20260904_managed_monitor_ownership_backup AS backup \
+                       JOIN status_monitors AS original ON original.id = backup.monitor_id \
+                       WHERE original.environment_id = current.environment_id \
+                   ); \
+                 UPDATE status_monitors AS monitor \
+                 SET is_managed = TRUE \
+                 FROM _temps_m20260904_managed_monitor_ownership_backup AS backup \
+                 WHERE monitor.id = backup.monitor_id; \
+                 DROP TABLE _temps_m20260904_managed_monitor_ownership_backup",
+            )
+            .await?;
+
         Ok(())
     }
 }

--- a/crates/temps-migrations/src/migration/m20260904_000001_reset_ambiguous_managed_status_monitors.rs
+++ b/crates/temps-migrations/src/migration/m20260904_000001_reset_ambiguous_managed_status_monitors.rs
@@ -8,54 +8,34 @@ pub struct Migration;
 
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
-    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        // The first shipped version of the managed-monitor migration inferred
-        // ownership from an editable monitor name. There is no durable field
-        // that can distinguish those user monitors from monitors created by
-        // Temps during the affected window. Resetting ownership is the only
-        // non-destructive correction: a later deployment creates a new,
-        // explicitly managed monitor while every existing monitor is preserved.
-        manager
-            .get_connection()
-            .execute_unprepared(
-                "CREATE TABLE _temps_m20260904_managed_monitor_ownership_backup (\
-                     monitor_id INTEGER PRIMARY KEY \
-                         REFERENCES status_monitors(id) ON DELETE CASCADE\
-                 ); \
-                 INSERT INTO _temps_m20260904_managed_monitor_ownership_backup (monitor_id) \
-                 SELECT id FROM status_monitors WHERE is_managed = TRUE; \
-                 UPDATE status_monitors SET is_managed = FALSE WHERE is_managed = TRUE",
-            )
-            .await?;
-
+    async fn up(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // This migration originally reset every `is_managed = TRUE` row
+        // unconditionally, on the theory that the only way a row could be
+        // TRUE at this point was the name-guessing bug in the first shipped
+        // version of m20260831_000002 (see that file's history). That
+        // premise doesn't hold in practice: m20260831_000002's guessing
+        // logic was corrected before it ever shipped in a standalone
+        // release, while this migration shipped one release later. Any
+        // install that upgraded through that intervening release had
+        // already run the corrected m20260831_000002 (which never guesses
+        // ownership) and, in the normal course of reconciliation, already
+        // had `ensure_monitor_for_environment` create a legitimate managed
+        // monitor. This migration's blanket UPDATE then demoted that
+        // legitimate monitor too — indistinguishable from a name-guessed
+        // one, since both use the identical "{environment} Monitor" naming
+        // convention — causing reconciliation to create a second, duplicate
+        // managed monitor on the very next boot.
+        //
+        // There is no data-driven way to tell a name-guessed row from a
+        // legitimately created one after the fact, so correcting one case
+        // by construction reintroduces the other. Given the guessing bug
+        // never reached a standalone release (no evidence any production
+        // database ever ran it), this migration is kept registered for
+        // migration-history compatibility but no longer touches data.
         Ok(())
     }
 
-    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        // Restore exactly the ownership state captured by up(). If the
-        // application created a replacement managed monitor in the meantime,
-        // demote it first within only the affected environment so the partial
-        // unique index remains valid.
-        manager
-            .get_connection()
-            .execute_unprepared(
-                "UPDATE status_monitors AS current \
-                 SET is_managed = FALSE \
-                 WHERE current.is_managed = TRUE \
-                   AND EXISTS ( \
-                       SELECT 1 \
-                       FROM _temps_m20260904_managed_monitor_ownership_backup AS backup \
-                       JOIN status_monitors AS original ON original.id = backup.monitor_id \
-                       WHERE original.environment_id = current.environment_id \
-                   ); \
-                 UPDATE status_monitors AS monitor \
-                 SET is_managed = TRUE \
-                 FROM _temps_m20260904_managed_monitor_ownership_backup AS backup \
-                 WHERE monitor.id = backup.monitor_id; \
-                 DROP TABLE _temps_m20260904_managed_monitor_ownership_backup",
-            )
-            .await?;
-
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
         Ok(())
     }
 }

--- a/crates/temps-migrations/tests/migration_tests.rs
+++ b/crates/temps-migrations/tests/migration_tests.rs
@@ -295,7 +295,7 @@ async fn test_service_project_identity_migration_defaults_down_and_reup() -> any
 }
 
 #[tokio::test]
-async fn test_managed_monitor_migrations_preserve_and_repair_ownership() -> anyhow::Result<()> {
+async fn test_managed_monitor_migrations_never_demote_ambiguous_ownership() -> anyhow::Result<()> {
     if external_db_configured() {
         println!("Skipping managed-monitor migration test: external database configured");
         return Ok(());
@@ -420,12 +420,19 @@ async fn test_managed_monitor_migrations_preserve_and_repair_ownership() -> anyh
         .expect("managed monitor count row")
         .try_get::<i64>("", "count")?,
         1,
-        "simulate the ownership inferred by the previously shipped migration"
+        "simulate a row with is_managed = TRUE, indistinguishable from either a \
+         name-guessed legacy row or a legitimately created managed monitor"
     );
 
+    // m20260904_000001 must NOT touch this row. A name-guessed row and a
+    // legitimately-created managed monitor are indistinguishable by any
+    // durable field (both use the "{environment} Monitor" naming
+    // convention), so blanket-demoting is_managed = TRUE here would also
+    // demote real ownership and cause reconciliation to create a duplicate
+    // managed monitor on the next boot. See that migration's file comment.
     Migrator::up(&db, None).await?;
     assert_eq!(managed_monitor_schema_state(&db).await?, (true, true));
-    let corrected = db
+    let preserved = db
         .query_one(sea_orm::Statement::from_string(
             sea_orm::DatabaseBackend::Postgres,
             "SELECT is_managed FROM status_monitors WHERE name = 'production Monitor'".to_string(),
@@ -433,12 +440,12 @@ async fn test_managed_monitor_migrations_preserve_and_repair_ownership() -> anyh
         .await?
         .expect("default-named user monitor remains present");
     assert!(
-        !corrected.try_get::<bool>("", "is_managed")?,
-        "the forward corrective migration must demote ownership inferred by the shipped migration"
+        preserved.try_get::<bool>("", "is_managed")?,
+        "the corrective migration must not demote ownership it cannot verify is ambiguous"
     );
 
     Migrator::down(&db, Some(1)).await?;
-    let restored = db
+    let after_down = db
         .query_one(sea_orm::Statement::from_string(
             sea_orm::DatabaseBackend::Postgres,
             "SELECT is_managed FROM status_monitors WHERE name = 'production Monitor'".to_string(),
@@ -446,19 +453,19 @@ async fn test_managed_monitor_migrations_preserve_and_repair_ownership() -> anyh
         .await?
         .expect("default-named user monitor remains present after rollback");
     assert!(
-        restored.try_get::<bool>("", "is_managed")?,
-        "rolling back the corrective migration must restore the captured ownership state"
+        after_down.try_get::<bool>("", "is_managed")?,
+        "rolling back the now-no-op corrective migration must leave ownership untouched"
     );
 
     Migrator::up(&db, Some(1)).await?;
-    let corrected_again = db
+    let after_up_again = db
         .query_one(sea_orm::Statement::from_string(
             sea_orm::DatabaseBackend::Postgres,
             "SELECT is_managed FROM status_monitors WHERE name = 'production Monitor'".to_string(),
         ))
         .await?
-        .expect("default-named user monitor remains present after reapplying correction");
-    assert!(!corrected_again.try_get::<bool>("", "is_managed")?);
+        .expect("default-named user monitor remains present after reapplying migration");
+    assert!(after_up_again.try_get::<bool>("", "is_managed")?);
     Ok(())
 }
 

--- a/crates/temps-migrations/tests/migration_tests.rs
+++ b/crates/temps-migrations/tests/migration_tests.rs
@@ -430,7 +430,16 @@ async fn test_managed_monitor_migrations_never_demote_ambiguous_ownership() -> a
     // convention), so blanket-demoting is_managed = TRUE here would also
     // demote real ownership and cause reconciliation to create a duplicate
     // managed monitor on the next boot. See that migration's file comment.
-    Migrator::up(&db, None).await?;
+    //
+    // Apply up through m20260904_000001 specifically, not `None` (every
+    // registered migration) — later migrations added after it would
+    // otherwise become the target of the `Some(1)` down()/up() calls below.
+    let reset_target = "m20260904_000001_reset_ambiguous_managed_status_monitors";
+    let reset_target_count = Migrator::migrations()
+        .iter()
+        .position(|migration| migration.name() == reset_target)
+        .unwrap_or_else(|| panic!("migration {reset_target} not found in Migrator"));
+    Migrator::up(&db, Some(reset_target_count as u32 + 1)).await?;
     assert_eq!(managed_monitor_schema_state(&db).await?, (true, true));
     let preserved = db
         .query_one(sea_orm::Statement::from_string(
@@ -508,9 +517,16 @@ async fn test_managed_monitor_migration_down_restores_state_from_previous_up_imp
     ))
     .await?;
 
-    // Run every migration, including the current no-op up() for
-    // m20260904_000001, so it's recorded as applied.
-    Migrator::up(&db, None).await?;
+    // Apply up through m20260904_000001 specifically (its current no-op
+    // up()), not `None` (every registered migration) — otherwise a later
+    // migration becomes the target of the `down(&db, Some(1))` call below
+    // instead of the one this test means to roll back.
+    let target = "m20260904_000001_reset_ambiguous_managed_status_monitors";
+    let target_count = Migrator::migrations()
+        .iter()
+        .position(|migration| migration.name() == target)
+        .unwrap_or_else(|| panic!("migration {target} not found in Migrator"));
+    Migrator::up(&db, Some(target_count as u32 + 1)).await?;
 
     db.execute_unprepared(
         "INSERT INTO projects (name, repo_name, repo_owner, directory, main_branch, preset, \

--- a/crates/temps-migrations/tests/migration_tests.rs
+++ b/crates/temps-migrations/tests/migration_tests.rs
@@ -470,6 +470,114 @@ async fn test_managed_monitor_migrations_never_demote_ambiguous_ownership() -> a
 }
 
 #[tokio::test]
+async fn test_managed_monitor_migration_down_restores_state_from_previous_up_implementation(
+) -> anyhow::Result<()> {
+    if external_db_configured() {
+        println!(
+            "Skipping managed-monitor mixed-version rollback test: external database configured"
+        );
+        return Ok(());
+    }
+    let container = match GenericImage::new("timescale/timescaledb-ha", "pg18")
+        .with_wait_for(postgres_ready_wait_for())
+        .with_exposed_port(ContainerPort::Tcp(5432))
+        .with_env_var("POSTGRES_DB", "postgres")
+        .with_env_var("POSTGRES_USER", "postgres")
+        .with_env_var("POSTGRES_PASSWORD", "postgres")
+        .with_env_var("POSTGRES_HOST_AUTH_METHOD", "trust")
+        .with_cmd(vec![
+            "postgres",
+            "-c",
+            "timescaledb.max_background_workers=0",
+        ])
+        .with_startup_timeout(CONTAINER_STARTUP_TIMEOUT)
+        .start()
+        .await
+    {
+        Ok(container) => container,
+        Err(error) => {
+            eprintln!(
+                "Skipping managed-monitor mixed-version rollback test: Docker unavailable: {error}"
+            );
+            return Ok(());
+        }
+    };
+    let port = container.get_host_port_ipv4(5432).await?;
+    let db = connect_with_retries(&format!(
+        "postgresql://postgres:postgres@localhost:{port}/postgres"
+    ))
+    .await?;
+
+    // Run every migration, including the current no-op up() for
+    // m20260904_000001, so it's recorded as applied.
+    Migrator::up(&db, None).await?;
+
+    db.execute_unprepared(
+        "INSERT INTO projects (name, repo_name, repo_owner, directory, main_branch, preset, \
+         created_at, updated_at, slug) \
+         VALUES ('monitor-rollback-test', 'repo', 'owner', '.', 'main', 'nodejs', now(), now(), 'monitor-rollback-test')",
+    )
+    .await?;
+    db.execute_unprepared(
+        "INSERT INTO environments (name, slug, subdomain, host, upstreams, created_at, updated_at, project_id) \
+         SELECT 'production', 'production', 'monitor-rollback-test-production', 'monitor-rollback.test', '[]', now(), now(), id \
+         FROM projects WHERE slug = 'monitor-rollback-test'",
+    )
+    .await?;
+    db.execute_unprepared(
+        "INSERT INTO status_monitors \
+         (project_id, environment_id, name, monitor_type, check_interval_seconds, is_active, is_managed, created_at, updated_at) \
+         SELECT project_id, id, 'production Monitor', 'web', 60, true, true, now(), now() FROM environments \
+         WHERE subdomain = 'monitor-rollback-test-production'",
+    )
+    .await?;
+
+    // Simulate a database that already ran the previous, destructive up()
+    // implementation of this migration before the current no-op fix
+    // shipped: it backed up the managed monitor's id and demoted it.
+    db.execute_unprepared(
+        "CREATE TABLE _temps_m20260904_managed_monitor_ownership_backup ( \
+             monitor_id INTEGER PRIMARY KEY REFERENCES status_monitors(id) ON DELETE CASCADE \
+         ); \
+         INSERT INTO _temps_m20260904_managed_monitor_ownership_backup (monitor_id) \
+         SELECT id FROM status_monitors WHERE name = 'production Monitor'; \
+         UPDATE status_monitors SET is_managed = FALSE WHERE name = 'production Monitor'",
+    )
+    .await?;
+
+    Migrator::down(&db, Some(1)).await?;
+
+    let restored = db
+        .query_one(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Postgres,
+            "SELECT is_managed FROM status_monitors WHERE name = 'production Monitor'".to_string(),
+        ))
+        .await?
+        .expect("previously managed monitor remains present");
+    assert!(
+        restored.try_get::<bool>("", "is_managed")?,
+        "rolling back on the current no-op up() must still restore ownership captured by a \
+         previous, destructive up()"
+    );
+
+    let backup_table_dropped = db
+        .query_one(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Postgres,
+            "SELECT to_regclass('_temps_m20260904_managed_monitor_ownership_backup') IS NULL AS dropped"
+                .to_string(),
+        ))
+        .await?
+        .expect("regclass lookup row")
+        .try_get::<bool>("", "dropped")?;
+    assert!(
+        backup_table_dropped,
+        "the backup table must be cleaned up after restoring"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_preview_inclusion_default_migration_up_and_down() -> anyhow::Result<()> {
     if external_db_configured() {
         println!(


### PR DESCRIPTION
## Summary
- `m20260904_000001_reset_ambiguous_managed_status_monitors` unconditionally reset every `is_managed = TRUE` row, assuming the only way a row could be `TRUE` was the name-guessing bug in the first shipped version of `m20260831_000002`.
- That premise doesn't hold: the guessing logic was corrected before it ever reached a standalone release, one release before this migration shipped. Any install that upgraded through the intervening release already had a legitimately created managed monitor by the time this migration ran, and the blanket `UPDATE` demoted that monitor too — it's indistinguishable from a name-guessed row, since both use the identical `"{environment} Monitor"` naming convention. Reconciliation then created a second, duplicate managed monitor on the next boot.
- There's no durable field to tell the two cases apart after the fact, so the migration is now a no-op (kept registered for migration-history compatibility) rather than trading one incorrect state for another.

## Test plan
- [x] `cargo check --lib -p temps-migrations`
- [x] `cargo test --lib -p temps-migrations --test migration_tests` (37 passed, via Docker testcontainers)
- [x] `python3 scripts/source_attribution.py check`
- [x] Updated `test_managed_monitor_migrations_never_demote_ambiguous_ownership` to assert ownership is preserved (not demoted) through this migration