### PR TITLE
fix(providers,web): MariaDB docker_image schema default + silent form-validation feedback

### DIFF
--- a/crates/temps-providers/src/externalsvc/mariadb.rs
+++ b/crates/temps-providers/src/externalsvc/mariadb.rs
@@ -412,7 +412,8 @@ pub struct MariaDbInputConfig {
     pub root_password: Option<String>,
 
     /// Full Docker image reference.
-    #[schemars(example = example_docker_image())]
+    #[serde(default = "default_docker_image")]
+    #[schemars(example = example_docker_image(), default = "default_docker_image")]
     pub docker_image: String,
 
     /// Managed service size/tuning profile.
@@ -516,6 +517,17 @@ fn default_database() -> String {
 
 fn default_username() -> String {
     "app".to_string()
+}
+
+/// Mirrors the runtime fallback in `parameter_strategies.rs` (which already
+/// substitutes `MARIADB_DEFAULT_IMAGE` for a missing/empty `docker_image` at
+/// request time) so the *advertised* schema agrees with actual behavior:
+/// without this, `schemars` marks `docker_image` required with no default,
+/// and a client that renders this field as hidden/preset-owned (filling it in
+/// only after its own form validation runs) rejects the submission before
+/// ever sending a request the server would have accepted.
+fn default_docker_image() -> String {
+    MARIADB_DEFAULT_IMAGE.to_string()
 }
 
 fn mariadb_image_pull_failure_message(image: &str, error: &str) -> String {
@@ -6219,6 +6231,30 @@ mod tests {
         assert!(
             !schema.to_string().contains("container_name"),
             "container_name leaked into the MariaDB create schema"
+        );
+    }
+
+    /// Regression guard: `docker_image` was schema-required with no default,
+    /// even though the server has always accepted a missing/empty value and
+    /// substituted `MARIADB_DEFAULT_IMAGE` (`parameter_strategies.rs`). A
+    /// client that renders `docker_image` as a hidden, preset-owned field
+    /// (filling it in only *after* its own form validation runs, e.g. the
+    /// "Managed + WAL-G" preset) rejected every submission before ever
+    /// sending a request the server would have accepted, with no way to
+    /// surface an error for a field that isn't on screen.
+    #[test]
+    fn test_docker_image_is_not_required_and_has_a_default() {
+        let schema = serde_json::to_value(schemars::schema_for!(MariaDbInputConfig)).unwrap();
+        let required = schema["required"].as_array().cloned().unwrap_or_default();
+        assert!(
+            !required.iter().any(|value| value == "docker_image"),
+            "docker_image must not be schema-required: {:?}",
+            required
+        );
+        assert_eq!(
+            schema["properties"]["docker_image"]["default"],
+            serde_json::json!(MARIADB_DEFAULT_IMAGE),
+            "docker_image's advertised schema default must match the runtime fallback"
         );
     }
 

--- a/web/src/components/forms/JsonSchemaForm.tsx
+++ b/web/src/components/forms/JsonSchemaForm.tsx
@@ -34,7 +34,8 @@ import {
   Sparkles,
 } from 'lucide-react'
 import { type ReactNode, useEffect, useMemo, useState } from 'react'
-import { useForm } from 'react-hook-form'
+import { type FieldErrors, useForm } from 'react-hook-form'
+import { toast } from 'sonner'
 import * as z from 'zod'
 
 interface JsonSchemaProperty {
@@ -368,6 +369,38 @@ export function JsonSchemaForm({
     await onSubmit(cleanedValues)
   }
 
+  // React Hook Form's own `handleSubmit` silently drops the submission when
+  // validation fails and does nothing else -- no toast, no console warning.
+  // That's invisible for a field that isn't rendered at all (hidden or
+  // preset-owned, e.g. a Docker image the preset fills in only after this
+  // validation already ran and rejected it), which previously made a broken
+  // schema/preset combination look identical to a truly unresponsive button.
+  // Surface *something* every time submission is blocked, so this class of
+  // bug is diagnosable instead of silent.
+  const onInvalid = (errors: FieldErrors<FormValues>) => {
+    const fieldNames = Object.keys(errors)
+    if (fieldNames.length === 0) return
+
+    const hiddenFailures = fieldNames.filter((name) =>
+      effectiveHiddenFields.includes(name)
+    )
+
+    if (hiddenFailures.length > 0) {
+      // The field can't be fixed by the user -- it isn't on screen -- so this
+      // is a form/schema bug, not a validation message to act on.
+      toast.error('Unable to create service', {
+        description: `Internal form error: ${hiddenFailures
+          .map(humanizeLabel)
+          .join(', ')} failed validation but ${
+          hiddenFailures.length === 1 ? "isn't" : "aren't"
+        } shown on this form. Please report this as a bug.`,
+      })
+      return
+    }
+
+    toast.error('Check the highlighted fields before creating this service')
+  }
+
   const isPairedField = (fieldName: string, nextFieldName?: string) => {
     if (!nextFieldName) return false
     return pairedFields.some(
@@ -607,7 +640,10 @@ export function JsonSchemaForm({
 
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-6">
+      <form
+        onSubmit={form.handleSubmit(handleSubmit, onInvalid)}
+        className="space-y-6"
+      >
         {useGrouping ? (
           <>
             {nonAdvancedGroups.map((group) => {

--- a/web/src/components/forms/ServiceTypePresets.tsx
+++ b/web/src/components/forms/ServiceTypePresets.tsx
@@ -187,6 +187,14 @@ export function useServiceTypePreset(serviceType: string | null): PresetState {
 // MariaDB preset — managed WAL-G image + custom.
 // -----------------------------------------------------------------------------
 
+// KNOWN GAP: this mutable tag currently fails backend validation
+// (`validate_immutable_mariadb_image` in mariadb.rs requires a pinned
+// `repository@sha256:<digest>` for any non-default MariaDB image). The image
+// itself hasn't been published yet — `.github/workflows/mariadb-walg-image.yml`
+// only runs `if: github.ref == 'refs/heads/main'`, so it can't produce a real
+// digest until this branch (PR #562) merges. Once it does, that workflow's
+// first run prints the real digest to its job summary — paste it in here as
+// `ghcr.io/gotempsh/mariadb-walg@sha256:<digest>` to make this preset work.
 const MARIADB_MANAGED_IMAGE = 'ghcr.io/gotempsh/mariadb-walg:11.4'
 
 const MARIADB_OPTIONS: PresetOption[] = [


### PR DESCRIPTION
## Summary

- The "Create MariaDB" button in the Databases UI silently did nothing when the "Managed + WAL-G" preset was selected — no request sent, no error shown.
- Root cause: `docker_image` was schema-required with no default (diverging from the runtime fallback already in `parameter_strategies.rs`). The preset renders the field as hidden/owned and only fills it in *after* react-hook-form's own submit validation runs, so the empty required field failed validation before a request was ever sent.
- Fixed both ends:
  - **Backend**: `docker_image` now has a schemars/serde default matching `MARIADB_DEFAULT_IMAGE`, so the advertised schema agrees with actual server behavior. Added a regression test.
  - **Frontend**: `JsonSchemaForm` now has an `onInvalid` handler, so any future case of submit validation failing on a hidden/preset-owned field surfaces a toast instead of failing silently.
- While verifying live, found a second, separate, pre-existing issue: the MariaDB "Managed + WAL-G" preset's image has never actually been published (its publish workflow only runs `if: github.ref == 'refs/heads/main'`, gated behind this branch's own merge), so that preset still can't succeed today even with this fix. Documented in a code comment pointing at the workflow's own printed digest as the follow-up fix once this branch merges — out of scope to fix here since there's no real image/digest to reference yet.

## Test plan

- [x] `cargo check --lib -p temps-providers` clean
- [x] `cargo test --lib -p temps-providers mariadb` — 126 passed, including new `test_docker_image_is_not_required_and_has_a_default`
- [x] `bunx tsc --noEmit` clean
- [x] `bun test src/components/forms/JsonSchemaForm.test.tsx` — existing tests still pass
- [x] Live verification via local dev server + browser automation: before the fix, clicking "Create mariadb-*" sent zero requests; after the fix, it sends a real `POST /api/external-services` and a real server error (from the separate WAL-G-image issue above) now surfaces as a toast instead of nothing happening