### PR TITLE
fix(web): pin MariaDB managed preset to the real published WAL-G image digest

### DIFF
--- a/web/src/components/forms/ServiceTypePresets.tsx
+++ b/web/src/components/forms/ServiceTypePresets.tsx
@@ -187,15 +187,12 @@ export function useServiceTypePreset(serviceType: string | null): PresetState {
 // MariaDB preset — managed WAL-G image + custom.
 // -----------------------------------------------------------------------------
 
-// KNOWN GAP: this mutable tag currently fails backend validation
-// (`validate_immutable_mariadb_image` in mariadb.rs requires a pinned
-// `repository@sha256:<digest>` for any non-default MariaDB image). The image
-// itself hasn't been published yet — `.github/workflows/mariadb-walg-image.yml`
-// only runs `if: github.ref == 'refs/heads/main'`, so it can't produce a real
-// digest until this branch (PR #562) merges. Once it does, that workflow's
-// first run prints the real digest to its job summary — paste it in here as
-// `ghcr.io/gotempsh/mariadb-walg@sha256:<digest>` to make this preset work.
-const MARIADB_MANAGED_IMAGE = 'ghcr.io/gotempsh/mariadb-walg:11.4'
+// Pinned to the digest printed by .github/workflows/mariadb-walg-image.yml's
+// first run on main (11.4.12-walg-v3.0.8) -- validate_immutable_mariadb_image
+// in mariadb.rs requires a real repository@sha256:<digest> reference for any
+// non-default MariaDB image, so a mutable tag here is rejected at creation.
+const MARIADB_MANAGED_IMAGE =
+  'ghcr.io/gotempsh/mariadb-walg@sha256:fa4c9247f82c47ace7c1aa9b77010870f4905bbae57c4f0aa24ae6ba3b6cdbf3'
 
 const MARIADB_OPTIONS: PresetOption[] = [
   {


### PR DESCRIPTION
## Summary

- Follow-up to #929/#562. The "Managed + WAL-G" MariaDB preset sent a mutable tag which `validate_immutable_mariadb_image` rejects; the image itself hadn't been published anywhere until PR #562 merged and `mariadb-walg-image.yml` ran on `main` for the first time.
- That run succeeded (manually dispatched since a newly-added workflow file doesn't self-trigger on the push that introduces it): https://github.com/gotempsh/temps/actions/runs/34145461347
- This PR pins the preset to that run's real digest so MariaDB creation via this preset actually works.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] Pulled `ghcr.io/gotempsh/mariadb-walg@sha256:fa4c9247f82c47ace7c1aa9b77010870f4905bbae57c4f0aa24ae6ba3b6cdbf3` directly to confirm it's real and pullable
- [x] Live end-to-end verification against a local dev server: clicking "Create" now passes validation and reaches real Docker container creation (confirmed via server logs: `MariaDB image ...@sha256:... already present locally`, followed by an actual container-start attempt). The only remaining failure in that test was an unrelated port collision from pre-existing local test containers, not a code defect.