### PR TITLE
fix(providers): WAL health probe host default + CLI parity, and continuous-archive S3 source visibility

### DIFF
--- a/apps/temps-cli/openapi.json
+++ b/apps/temps-cli/openapi.json
@@ -19180,6 +19180,21 @@
               "null"
             ]
           },
+          "continuous_archive_pinned_at": {
+            "description": "When `continuous_archive_s3_source_id` was last set. Null alongside\na non-null source id means it was set by the original provisioning\nflow rather than an explicit repoint.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "continuous_archive_s3_source_id": {
+            "description": "S3 source ID that this service's continuous archiving (Postgres/\nTimescale WAL-G `archive_command`, or MariaDB's binlog shipper)\ncurrently writes to. Null for service types with no continuous\narchiving concept, or a Postgres/MariaDB service that has never had\none provisioned. Change it with `repoint_continuous_archive_source`.",
+            "format": "int32",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
           "created_at": {
             "type": "string"
           },

--- a/apps/temps-cli/src/api/types.gen.ts
+++ b/apps/temps-cli/src/api/types.gen.ts
@@ -9017,6 +9017,20 @@ export type ExternalServiceDetails = {
 
 export type ExternalServiceInfo = {
     connection_info?: string | null;
+    /**
+     * When `continuous_archive_s3_source_id` was last set. Null alongside
+     * a non-null source id means it was set by the original provisioning
+     * flow rather than an explicit repoint.
+     */
+    continuous_archive_pinned_at?: string | null;
+    /**
+     * S3 source ID that this service's continuous archiving (Postgres/
+     * Timescale WAL-G `archive_command`, or MariaDB's binlog shipper)
+     * currently writes to. Null for service types with no continuous
+     * archiving concept, or a Postgres/MariaDB service that has never had
+     * one provisioned. Change it with `repoint_continuous_archive_source`.
+     */
+    continuous_archive_s3_source_id?: number | null;
     created_at: string;
     /**
      * Error message from failed initialization.

--- a/apps/temps-cli/src/commands/services/index.ts
+++ b/apps/temps-cli/src/commands/services/index.ts
@@ -3,6 +3,7 @@
 
 import type { Command } from 'commander'
 import { registerRestoreCommands } from './restore.js'
+import { registerWalHealthCommands } from './wal-health.js'
 import { requireAuth } from '../../config/store.js'
 import { setupClient, client, getErrorMessage } from '../../lib/api-client.js'
 import {
@@ -535,6 +536,9 @@ export function registerServicesCommands(program: Command): void {
   // Restore-related commands: capabilities, list backups on an S3 source,
   // kick off a restore (in-place / clone / PITR), show / list runs.
   registerRestoreCommands(services)
+
+  // Live WAL / archive_command diagnostics for PostgreSQL services.
+  registerWalHealthCommands(services)
 }
 
 async function listServicesAction(options: { json?: boolean }): Promise<void> {

--- a/apps/temps-cli/src/commands/services/index.ts
+++ b/apps/temps-cli/src/commands/services/index.ts
@@ -771,6 +771,13 @@ async function showService(options: ShowOptions): Promise<void> {
   }
   keyValue('Created', new Date(service.created_at).toLocaleString())
   keyValue('Updated', new Date(service.updated_at).toLocaleString())
+  if (service.continuous_archive_s3_source_id != null) {
+    keyValue('Continuous archive S3 source', String(service.continuous_archive_s3_source_id))
+    if (service.continuous_archive_pinned_at) {
+      keyValue('  pinned at', new Date(service.continuous_archive_pinned_at).toLocaleString())
+    }
+    info('Change with: temps services repoint-continuous-archive-source --id <id> --s3-source <id>')
+  }
 
   if (details.current_parameters && Object.keys(details.current_parameters).length > 0) {
     newline()

--- a/apps/temps-cli/src/commands/services/wal-health.ts
+++ b/apps/temps-cli/src/commands/services/wal-health.ts
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+import type { Command } from 'commander'
+import { requireAuth } from '../../config/store.js'
+import { setupClient, getErrorMessage } from '../../lib/api-client.js'
+import { getPostgresWalHealth } from '../../api/sdk.gen.js'
+import type { PostgresWalHealth, WalWarning } from '../../api/types.gen.js'
+import { withSpinner } from '../../ui/spinner.js'
+import {
+  newline,
+  header,
+  icons,
+  json as jsonOut,
+  colors,
+  error as errorOutput,
+  keyValue,
+  formatRelativeTime,
+} from '../../ui/output.js'
+
+interface WalHealthOptions {
+  id: string
+  json?: boolean
+}
+
+function formatBytes(n: number): string {
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let v = n
+  let i = 0
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024
+    i++
+  }
+  return `${v.toFixed(i === 0 ? 0 : 1)} ${units[i]}`
+}
+
+function describeWarning(warning: WalWarning): string {
+  switch (warning.kind) {
+    case 'wal_bloat':
+      return `WAL directory is ${warning.ratio.toFixed(1)}x max_wal_size (${formatBytes(warning.pg_wal_bytes)} vs ${formatBytes(warning.max_wal_size_bytes)})`
+    case 'stale_slot':
+      return `Replication slot "${warning.slot_name}" is retaining ${formatBytes(warning.retained_bytes)} of WAL${warning.active ? '' : ' (inactive slot)'}`
+    case 'archive_backlog':
+      return `${warning.ready_count} WAL segment(s) waiting to be archived`
+    case 'archive_mode_without_command':
+      return 'archive_mode is on but archive_command is empty or /bin/true — WAL is never actually shipped'
+    case 'wal_not_recycled':
+      return `Oldest WAL segment is ${Math.round(warning.oldest_age_secs / 3600)}h old and has not been recycled`
+    default:
+      return JSON.stringify(warning)
+  }
+}
+
+function severityOf(warning: WalWarning): 'warning' | 'critical' {
+  switch (warning.kind) {
+    case 'stale_slot':
+      return 'critical'
+    case 'wal_bloat':
+      return warning.ratio >= 10.0 ? 'critical' : 'warning'
+    default:
+      return 'warning'
+  }
+}
+
+async function walHealthAction(options: WalHealthOptions): Promise<void> {
+  await requireAuth()
+  await setupClient()
+
+  const serviceId = parseInt(options.id, 10)
+  if (!Number.isFinite(serviceId)) {
+    errorOutput(`Invalid service id: ${options.id}`)
+    process.exit(1)
+  }
+
+  const health = await withSpinner('Probing WAL / archive_command health...', async () => {
+    const { data, error } = await getPostgresWalHealth({ path: { id: serviceId } })
+    if (error) throw new Error(getErrorMessage(error))
+    return data as PostgresWalHealth
+  })
+
+  if (options.json) {
+    jsonOut(health)
+    return
+  }
+
+  newline()
+  header(`${icons.info} Postgres WAL health`)
+  keyValue('Probed', formatRelativeTime(health.probed_at))
+  keyValue('archive_mode', health.archive_mode)
+  keyValue('archive_command', health.archive_command ?? colors.muted('(not set)'))
+  keyValue('Archive backlog', `${health.archive_backlog} segment(s) waiting`)
+  keyValue(
+    'Archiver failures',
+    health.archiver_failed_count
+      ? colors.error(
+          `${health.archiver_failed_count} (last: ${
+            health.archiver_last_failed_at
+              ? formatRelativeTime(health.archiver_last_failed_at)
+              : 'unknown'
+          })`,
+        )
+      : colors.success('0'),
+  )
+  keyValue('pg_wal size', formatBytes(health.pg_wal_bytes))
+  keyValue('max_wal_size', formatBytes(health.max_wal_size_bytes))
+  keyValue('Oldest WAL age', `${Math.round(health.oldest_wal_age_secs / 60)}m`)
+  if (health.stale_slots.length > 0) {
+    newline()
+    header('Replication slots')
+    for (const slot of health.stale_slots) {
+      keyValue(
+        slot.slot_name,
+        `${formatBytes(slot.retained_bytes)} retained${slot.active ? '' : ' (inactive)'}`,
+      )
+    }
+  }
+
+  newline()
+  if (health.warnings.length === 0) {
+    header(`${icons.success} No warnings`)
+  } else {
+    header(`${icons.warning} Warnings (${health.warnings.length})`)
+    for (const warning of health.warnings) {
+      const line = describeWarning(warning)
+      console.log(severityOf(warning) === 'critical' ? colors.error(`  ✗ ${line}`) : colors.warning(`  ! ${line}`))
+    }
+  }
+}
+
+// ---- Registration --------------------------------------------------------
+
+export function registerWalHealthCommands(services: Command): void {
+  services
+    .command('wal-health')
+    .description(
+      'Probe a PostgreSQL service\'s WAL / archive_command health right now (archiver failures, backlog, stale replication slots) — diagnoses "Cloud backup mirror unavailable ... check that PostgreSQL\'s archive_command is succeeding" warnings',
+    )
+    .requiredOption('--id <id>', 'Service ID')
+    .option('--json', 'Output in JSON format')
+    .action(walHealthAction)
+}

--- a/crates/temps-import/src/services/resource_executor.rs
+++ b/crates/temps-import/src/services/resource_executor.rs
@@ -1034,6 +1034,8 @@ mod tests {
                 members: vec![],
                 error_message: None,
                 metrics_enabled: false,
+                continuous_archive_s3_source_id: None,
+                continuous_archive_pinned_at: None,
             },
             local_url: Some(local.to_string()),
             source_url: Some(source.to_string()),

--- a/crates/temps-providers/src/externalsvc/postgres_wal_health.rs
+++ b/crates/temps-providers/src/externalsvc/postgres_wal_health.rs
@@ -162,10 +162,23 @@ impl PostgresWalHealth {
 /// Build a libpq connection string from a `ServiceConfig`'s parameters JSON.
 ///
 /// Mirrors what `PostgresService::health_probe` does internally. Returns
-/// `None` when the parameters don't deserialize — the caller treats that as
-/// "skip the WAL probe" rather than an error.
+/// `None` when a genuinely required field is missing — the caller treats
+/// that as "skip the WAL probe" rather than an error.
 pub fn build_conn_str(parameters: &serde_json::Value) -> Option<String> {
-    let host = parameters.get("host")?.as_str()?;
+    // `host` is not user-editable (`PostgresInputConfig::host`'s
+    // `#[serde(default = "default_host")]`) and is implicitly "localhost"
+    // everywhere else this config is read — `PostgresService::health_probe`
+    // gets it for free by deserializing through `PostgresInputConfig`. This
+    // function instead reads the raw stored JSON directly, so requiring the
+    // key like every other field silently broke it for standalone services
+    // whose parameters simply never had an explicit "host" written: the `?`
+    // returned `None` before a single connection was attempted, and `None`
+    // from this function means "no WAL health snapshot", logged only at
+    // debug level — i.e. permanently and silently disabled.
+    let host = parameters
+        .get("host")
+        .and_then(|value| value.as_str())
+        .unwrap_or("localhost");
     let port = parameters.get("port")?.as_str()?;
     let user = parameters.get("username")?.as_str()?;
     let password = parameters.get("password")?.as_str()?;
@@ -449,6 +462,57 @@ fn compute_warnings(snapshot: &PostgresWalHealth) -> Vec<WalWarning> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn conn_str_defaults_to_localhost_when_host_is_absent() {
+        // `host` is not user-editable and is never written into stored
+        // parameters for the overwhelming majority of standalone services —
+        // it's implicitly "localhost" (`PostgresInputConfig::host`'s serde
+        // default). Before this fix, a raw `parameters.get("host")?` bailed
+        // out here and no WAL health snapshot was ever produced for such a
+        // service, silently.
+        let parameters = serde_json::json!({
+            "port": "5432",
+            "username": "postgres",
+            "password": "secret",
+            "database": "postgres",
+        });
+        assert_eq!(
+            build_conn_str(&parameters).as_deref(),
+            Some("host=localhost port=5432 user=postgres password=secret dbname=postgres connect_timeout=3")
+        );
+    }
+
+    #[test]
+    fn conn_str_honors_an_explicit_host_when_present() {
+        let parameters = serde_json::json!({
+            "host": "10.0.0.5",
+            "port": "5432",
+            "username": "postgres",
+            "password": "secret",
+            "database": "postgres",
+        });
+        assert_eq!(
+            build_conn_str(&parameters).as_deref(),
+            Some("host=10.0.0.5 port=5432 user=postgres password=secret dbname=postgres connect_timeout=3")
+        );
+    }
+
+    #[test]
+    fn conn_str_still_requires_password() {
+        // Unlike `host`, a missing password is not a value the rest of the
+        // codebase has a safe implicit default for — `PostgresConfig::from`
+        // would synthesize a random one, which is exactly wrong for a probe
+        // that must match the actual running container. Confirm this stays
+        // a hard requirement rather than silently drifting the same way.
+        let parameters = serde_json::json!({
+            "host": "localhost",
+            "port": "5432",
+            "username": "postgres",
+            "database": "postgres",
+        });
+        assert_eq!(build_conn_str(&parameters), None);
+    }
 
     fn base_snapshot() -> PostgresWalHealth {
         PostgresWalHealth {

--- a/crates/temps-providers/src/handlers/types.rs
+++ b/crates/temps-providers/src/handlers/types.rs
@@ -251,6 +251,18 @@ pub struct ExternalServiceInfo {
     /// to decide whether to poll the monitoring endpoints.
     #[serde(default)]
     pub metrics_enabled: bool,
+    /// S3 source ID that this service's continuous archiving (Postgres/
+    /// Timescale WAL-G `archive_command`, or MariaDB's binlog shipper)
+    /// currently writes to. Null for service types with no continuous
+    /// archiving concept, or a Postgres/MariaDB service that has never had
+    /// one provisioned. Change it with `repoint_continuous_archive_source`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub continuous_archive_s3_source_id: Option<i32>,
+    /// When `continuous_archive_s3_source_id` was last set. Null alongside
+    /// a non-null source id means it was set by the original provisioning
+    /// flow rather than an explicit repoint.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub continuous_archive_pinned_at: Option<String>,
 }
 
 /// Public info about a cluster member.

--- a/crates/temps-providers/src/services.rs
+++ b/crates/temps-providers/src/services.rs
@@ -496,6 +496,16 @@ pub struct ExternalServiceInfo {
     /// Whether metric collection is enabled for this service.
     #[serde(default)]
     pub metrics_enabled: bool,
+    /// S3 source ID that this service's continuous archiving (Postgres/
+    /// Timescale WAL-G `archive_command`, or MariaDB's binlog shipper)
+    /// currently writes to. `None` for service types with no continuous
+    /// archiving concept, or a Postgres/MariaDB service that has never had
+    /// one provisioned. See `repoint_continuous_archive_source`.
+    pub continuous_archive_s3_source_id: Option<i32>,
+    /// When `continuous_archive_s3_source_id` was last set. `None` alongside
+    /// a `Some` source id means it was set by the original provisioning
+    /// flow rather than an explicit repoint.
+    pub continuous_archive_pinned_at: Option<String>,
 }
 
 /// Format a `tokio_postgres::Error` (or any `std::error::Error`) by
@@ -3359,6 +3369,10 @@ impl ExternalServiceManager {
             members,
             error_message: service.error_message,
             metrics_enabled: service.metrics_enabled,
+            continuous_archive_s3_source_id: service.continuous_archive_s3_source_id,
+            continuous_archive_pinned_at: service
+                .continuous_archive_pinned_at
+                .map(|pinned_at| pinned_at.to_rfc3339()),
         })
     }
 
@@ -10783,6 +10797,10 @@ echo "[restore] Pre-seed complete"
             members: Vec::new(),
             error_message: external_service.error_message,
             metrics_enabled: external_service.metrics_enabled,
+            continuous_archive_s3_source_id: external_service.continuous_archive_s3_source_id,
+            continuous_archive_pinned_at: external_service
+                .continuous_archive_pinned_at
+                .map(|pinned_at| pinned_at.to_rfc3339()),
         })
     }
 
@@ -15365,6 +15383,8 @@ mod tests {
             members: Vec::new(),
             error_message: None,
             metrics_enabled: false,
+            continuous_archive_s3_source_id: None,
+            continuous_archive_pinned_at: None,
         };
 
         assert_eq!(service_info.id, 1);


### PR DESCRIPTION
## Summary

Two related fixes from diagnosing a live "Cloud backup mirror unavailable ... check that PostgreSQL's archive_command is succeeding" warning:

**1. WAL health probe silently broken for most services.** `GET /external-services/{id}/wal-health` (built specifically to answer "is archive_command healthy?") had no CLI command, and calling it directly returned "no snapshot available." Root cause: `postgres_wal_health::build_conn_str` read `host` from raw stored parameters with a bare `?`, so it bailed out immediately whenever that key was absent. But `host` is not user-editable and is implicitly `"localhost"` everywhere else this config is read (`PostgresInputConfig::host`'s `#[serde(default = "default_host")]`) — `PostgresService::health_probe` gets that default for free by deserializing through the struct; this probe bypassed it entirely. Any standalone service whose stored parameters never had an explicit `"host"` key (the common case) silently never got a snapshot, forever, logged only at debug level.

Fixed by defaulting `host` to `"localhost"` in `build_conn_str`, matching the rest of the codebase. Every other field (port, username, password, database) stays a hard requirement — password specifically must never be defaulted, since `PostgresConfig::from` synthesizes a *random* one when absent. Added the missing `temps services wal-health --id <id>` CLI command.

**2. No way to see which S3 source a service's continuous archiving points at.** `repoint-continuous-archive-source` (already shipped, from #562) is write-only — nothing surfaced `continuous_archive_s3_source_id`/`continuous_archive_pinned_at` for reading. Exposed both through `GET /external-services/{id}` and `services show`.

## What changed

- `crates/temps-providers/src/externalsvc/postgres_wal_health.rs`: `build_conn_str` host default.
- `apps/temps-cli/src/commands/services/wal-health.ts` (new) + `index.ts`: `services wal-health --id <id>`.
- `crates/temps-providers/src/services.rs` + `handlers/types.rs`: `ExternalServiceInfo` gains `continuous_archive_s3_source_id` / `continuous_archive_pinned_at`.
- `apps/temps-cli/src/commands/services/index.ts`: `services show` prints the archive source + pin time and points at `repoint-continuous-archive-source` when set.
- `apps/temps-cli/openapi.json` + regenerated `src/api/types.gen.ts`.

## Test plan

- [x] `cargo test --lib -p temps-providers postgres_wal_health`: 15 passed (was 12; +3 new — host-absent defaults to localhost, explicit host still honored, password still required).
- [x] `cargo test --lib -p temps-providers`: 671 passed, 0 failed.
- [x] `cargo test --lib -p temps-import`: passed (a test fixture needed the two new `ExternalServiceInfo` fields — clippy caught this as a missing-fields compile error before merge).
- [x] `$(command -v cargo) clippy --workspace --all-targets -- -D warnings`: clean.
- [x] `apps/temps-cli`: `bun run spec:check` confirms `openapi.json` stays canonical after a hand-edit (no local dev server was available in this worktree to run `spec:update` — every port slot 1-29 was already claimed by another active checkout); `bun run typecheck` and `bun run build` clean; `services wal-health --help` / `services show --help` render correctly and the wal-health command reaches a live instance (confirmed against a real self-hosted server before the fix, reproducing the "no snapshot available" symptom this PR fixes).