### PR TITLE
fix(ci): unblock MariaDB PITR restores and stop DinD bridges taking the compute pool

### DIFF
--- a/crates/temps-backup/src/services/restore.rs
+++ b/crates/temps-backup/src/services/restore.rs
@@ -485,14 +485,15 @@ impl RestoreService {
         // logical dump object is named `dump.sql.gz`, so the generic
         // `.sql.gz` arm below would label it `pg_dump_restore` and the plan
         // would describe a `pg_restore` that never runs. Its physical base is
-        // `base.mbstream.gz`, which matches no generic arm at all and would
-        // land in `unsupported` even though it is the engine's PITR format.
+        // a WAL-G repository (or, in older buckets, a `base.mbstream.gz`
+        // object), neither of which matches a generic arm — both would land
+        // in `unsupported` even though they are the engine's PITR format.
         let target_is_mariadb = target.service_type.eq_ignore_ascii_case("mariadb");
         let engine_lower = target.service_type.to_ascii_lowercase();
         let strategy = if target_is_mariadb {
             // Same predicate the MariaDB engine itself dispatches on, so the
             // preview cannot promise a restore shape the executor won't take.
-            if temps_providers::externalsvc::mariadb::MariaDbService::is_physical_base_location(
+            if temps_providers::externalsvc::mariadb::MariaDbService::is_physical_base_backup_location(
                 &resolved_location,
             ) {
                 "mariadb_physical_restore"
@@ -1221,21 +1222,25 @@ fn validate_pitr_recovery_target(
 /// their base backups differently:
 ///
 ///   Postgres — WAL-G bases are stored as `s3://…` URLs.
-///   MariaDB  — physical (`mariadb-backup`) bases are stored as a BARE S3 key
-///              ending in `base.mbstream.gz` (see engines/mariadb_physical.rs),
-///              never with a scheme prefix.
+///   MariaDB  — physical (`mariadb-backup`) bases are stored either as a WAL-G
+///              repository ending in `/walg` (what `MariadbPhysicalEngine`
+///              writes today) or, in older buckets, as a bare S3 key ending in
+///              `base.mbstream.gz`.
 ///
 /// Applying the Postgres shape to MariaDB rejected every MariaDB PITR before
 /// it could start — with a "requires WAL-G" message that made no sense for the
 /// engine — even though `MariaDbService::restore_capabilities` advertises
 /// `pitr: true`. MariaDB is classified with the engine's own predicate so this
 /// guard, the plan preview, and the engine all agree on what a physical base is.
+/// That predicate must be the layout-agnostic one: testing only the legacy
+/// `base.mbstream.gz` object reintroduces the same class of bug, because a
+/// MariaDB WAL-G repository is a physical base the engine can and does replay.
 fn validate_pitr_backup_location(
     target_service_type: &str,
     backup_location: &str,
 ) -> Result<(), RestoreError> {
     if target_service_type.eq_ignore_ascii_case("mariadb") {
-        if !temps_providers::externalsvc::mariadb::MariaDbService::is_physical_base_location(
+        if !temps_providers::externalsvc::mariadb::MariaDbService::is_physical_base_backup_location(
             backup_location,
         ) {
             return Err(RestoreError::Validation {
@@ -1271,8 +1276,9 @@ fn validate_pitr_backup_location(
 ///   MongoDB  — patch only. `mongorestore` streams into a LIVE mongod that
 ///              still wants the TARGET's password until the restore lands.
 ///   MariaDB  — depends on the backup FORMAT, which the location encodes:
-///              a physical base replaces the whole datadir including the
-///              `mysql` system schema (so both, like Postgres), while a
+///              a physical base — WAL-G repository or legacy mbstream object
+///              alike — replaces the whole datadir including the `mysql`
+///              system schema (so both, like Postgres), while a
 ///              logical `mariadb_dump` explicitly EXCLUDES the `mysql` schema
 ///              (see engines/mariadb_dump.rs) and therefore carries no
 ///              credentials at all — merging there would authenticate the dump
@@ -1291,7 +1297,7 @@ fn credential_propagation_gates(target_service_type: &str, backup_location: &str
         "mongodb" => (true, false),
         "mariadb" => {
             let physical =
-                temps_providers::externalsvc::mariadb::MariaDbService::is_physical_base_location(
+                temps_providers::externalsvc::mariadb::MariaDbService::is_physical_base_backup_location(
                     backup_location,
                 );
             (physical, physical)
@@ -2950,6 +2956,41 @@ mod tests {
             matches!(&err, RestoreError::Validation { message } if message.contains("WAL-G")),
             "got {:?}",
             err
+        );
+    }
+
+    /// Regression: `MariadbPhysicalEngine` writes a WAL-G repository, not a
+    /// `base.mbstream.gz` object. Testing only the legacy layout rejected
+    /// every PITR restore of every backup the current engine produces, with
+    /// HTTP 400 at `startRestore` — before the engine (which handles the
+    /// repository layout fine) was ever reached.
+    #[test]
+    fn pitr_location_guard_accepts_a_walg_repository_base() {
+        let repository =
+            "s3://temps-backups/prod/external_services/mariadb/orders-mariadb-pitr/walg";
+
+        validate_pitr_backup_location("mariadb", repository)
+            .expect("a MariaDB WAL-G repository base must be accepted for PITR");
+        validate_pitr_backup_location("MariaDB", &format!("{repository}/"))
+            .expect("a trailing slash must not change the classification");
+    }
+
+    /// A WAL-G repository restore streams the whole datadir back — including
+    /// the `mysql` system schema — exactly like the legacy mbstream base, so
+    /// it must take the same credential-propagation path. Leaving it on the
+    /// logical-dump path would skip patching the target's stored password
+    /// after a cross-service restore and lock the operator out via UI/CLI.
+    #[test]
+    fn credential_gates_treat_a_walg_repository_as_physical() {
+        let repository =
+            "s3://temps-backups/prod/external_services/mariadb/orders-mariadb-pitr/walg";
+        assert_eq!(
+            credential_propagation_gates("mariadb", repository),
+            (true, true)
+        );
+        assert_eq!(
+            credential_propagation_gates("mariadb", &format!("{repository}/")),
+            (true, true)
         );
     }
 

--- a/crates/temps-backup/tests/mariadb_pitr_e2e.rs
+++ b/crates/temps-backup/tests/mariadb_pitr_e2e.rs
@@ -1745,8 +1745,11 @@ async fn run_logical_dump_restore_flow(env: &E2eEnv) -> anyhow::Result<()> {
     );
     // This is the exact predicate `credential_propagation_gates` keys off to
     // decide (false, false) for MariaDB — assert it on the REAL produced key.
+    // It must be the layout-agnostic one: the gate has to answer "physical"
+    // for a WAL-G repository as well as for a legacy mbstream base, so only a
+    // logical dump may fall through to (false, false).
     assert!(
-        !MariaDbService::is_physical_base_location(&dump_location),
+        !MariaDbService::is_physical_base_backup_location(&dump_location),
         "a logical dump must not classify as a physical base ({dump_location}); \
          if it did, the restore would merge the ORIGIN's credentials"
     );

--- a/crates/temps-providers/src/externalsvc/mariadb.rs
+++ b/crates/temps-providers/src/externalsvc/mariadb.rs
@@ -2393,8 +2393,15 @@ impl MariaDbService {
     // bind mounts (which `volumes_from` cannot express) and avoids feeding the
     // stream over an exec stdin pipe (which the log-mux would corrupt).
 
-    /// True when this backup location is a physical (`mariadb-backup` mbstream)
-    /// base — the only kind PITR can replay onto.
+    /// True when this backup location is a LEGACY single-object physical
+    /// (`mariadb-backup` mbstream) base.
+    ///
+    /// This is the pre-WAL-G layout only. Callers asking the broader question
+    /// "can PITR replay onto this base?" must use
+    /// [`Self::is_physical_base_backup_location`] instead — today's
+    /// `MariadbPhysicalEngine` writes a WAL-G repository, never a
+    /// `base.mbstream.gz` object, so this predicate alone is false for every
+    /// backup the current engine produces.
     ///
     /// `pub` because the generic restore orchestrator (`temps-backup`) has to
     /// classify a MariaDB backup location the *same* way this engine does when
@@ -2407,8 +2414,29 @@ impl MariaDbService {
 
     /// True when the backup location points at a WAL-G repository rather than
     /// a single legacy mbstream object.
-    pub(crate) fn is_walg_repository_location(location: &str) -> bool {
+    ///
+    /// `pub` for the same reason as [`Self::is_physical_base_location`]: the
+    /// orchestrator classifies locations this engine produced.
+    pub fn is_walg_repository_location(location: &str) -> bool {
         location.trim_end_matches('/').ends_with("/walg")
+    }
+
+    /// True when `location` is a physical (`mariadb-backup`) base in EITHER
+    /// on-disk layout — the WAL-G repository written by today's
+    /// `MariadbPhysicalEngine`, or the legacy single `base.mbstream.gz`
+    /// object still present in older buckets.
+    ///
+    /// This is the predicate that answers "can this back a PITR forward-roll,
+    /// and does restoring it replace the whole datadir (including the `mysql`
+    /// system schema)?" — the two questions the orchestrator actually asks.
+    /// It deliberately mirrors the dispatch inside [`Self::restore_pitr`] and
+    /// [`super::ExternalServiceProvider::restore_in_place`] so the guard, the
+    /// plan preview, and the executor cannot disagree: classifying only the
+    /// legacy layout made the orchestrator reject every backup the current
+    /// engine writes, so MariaDB PITR was unreachable through the API even
+    /// though the engine implemented it.
+    pub fn is_physical_base_backup_location(location: &str) -> bool {
+        Self::is_walg_repository_location(location) || Self::is_physical_base_location(location)
     }
 
     /// Derive the `metadata.json` companion key from a base backup key by
@@ -5235,6 +5263,37 @@ mod tests {
         assert!(!MariaDbService::is_walg_repository_location(
             "backups/mariadb/orders.sql.gz"
         ));
+    }
+
+    /// The orchestrator-facing predicate must accept BOTH physical layouts.
+    ///
+    /// `MariadbPhysicalEngine` only ever writes a WAL-G repository, so a
+    /// layout-agnostic answer here is what keeps `temps-backup`'s PITR guard,
+    /// plan preview, and credential-propagation gates from rejecting every
+    /// backup the engine actually produces.
+    #[test]
+    fn physical_base_predicate_accepts_both_layouts() {
+        // What MariadbPhysicalEngine writes today.
+        assert!(MariaDbService::is_physical_base_backup_location(
+            "s3://temps-backups/prod/external_services/mariadb/orders/walg"
+        ));
+        assert!(MariaDbService::is_physical_base_backup_location(
+            "prod/external_services/mariadb/orders/walg/"
+        ));
+        // Legacy single-object bases still in older buckets.
+        assert!(MariaDbService::is_physical_base_backup_location(
+            "backups/prod/external_services/mariadb/orders/2026/06/23/abc/base.mbstream.gz"
+        ));
+        // Logical dumps anchor nothing and must stay rejected.
+        assert!(!MariaDbService::is_physical_base_backup_location(
+            "backups/prod/mariadb_backup_20260623_010101.sql.gz"
+        ));
+        assert!(!MariaDbService::is_physical_base_backup_location(
+            "dump.sql.gz"
+        ));
+        // A legacy row whose location was never backfilled must not be
+        // mistaken for a physical base.
+        assert!(!MariaDbService::is_physical_base_backup_location(""));
     }
 
     #[test]

--- a/tools/dev-cluster/README.md
+++ b/tools/dev-cluster/README.md
@@ -179,6 +179,21 @@ auto-allocator ran but failed (most likely pool exhausted). Check
 worker gets a /24 from `172.20.0.0/16`, so there's room for 256 of
 them — exhaustion shouldn't happen here.
 
+**"compute pool 172.20.0.0/16 overlaps host route ... on device
+'br-\<hash\>'".** A Docker-allocated bridge inside the node landed on the
+cluster compute pool, so `temps network setup-multi-node` refuses to
+enable the overlay rather than build routes it cannot honour. Docker's
+built-in default address pool is `172.17.0.0/12`, so auto-allocated
+bridges climb 172.18, 172.19, 172.20 ... and collide once a node has a
+few of them (this node creates three at boot). `entrypoint.sh` pins the
+inner daemon (`--bip` plus `--default-address-pool`) so every
+auto-allocated bridge stays inside `10.98.0.0/24` + `10.99.0.0/16`,
+disjoint from the compute pool, from both cluster underlays, and from
+the outer daemon's own `172.16.0.0/12` defaults. On a node that
+entrypoint does not
+manage, either apply the same daemon pins or move the cluster pool with
+`temps network setup-multi-node --compute-pool-cidr <cidr>`.
+
 **Cross-node ping fails.** Run `./dev-cluster status` to see the
 overlay state on every worker. If the bridge or vxlan device is
 missing on one of them, look at that worker's logs — the

--- a/tools/dev-cluster/entrypoint.sh
+++ b/tools/dev-cluster/entrypoint.sh
@@ -73,15 +73,46 @@ start_dockerd() {
   # We let dockerd create its default docker0 bridge — BuildKit needs
   # *some* network for image-build RUN steps, and refuses to run with
   # `--bridge=none` (every RUN dies with "network bridge not found").
-  # Docker's default docker0 lives on 172.17.0.0/16, which doesn't
-  # collide with our compute pool (172.20.0.0/16). The temps-network
-  # crate creates `br-temps0` as a separate bridge anyway, so coexisting
-  # with docker0 is fine.
+  #
+  # Pin BOTH the default bridge and the pool user-defined bridges are
+  # carved from, so nothing Docker auto-allocates can ever land on the
+  # cluster compute pool (172.20.0.0/16, the `network_config` default).
+  #
+  # It is not enough to note that docker0 defaults to 172.17.0.0/16.
+  # Docker's *default* address pool is 172.17.0.0/12 with size 16, so
+  # every user-defined bridge walks up 172.18, 172.19, 172.20, … — and
+  # this node creates several at boot (the preview-gateway control and
+  # ingress networks, then `temps-app-network`). Whichever one lands
+  # fourth gets 172.20.0.0/16 and collides head-on with the compute
+  # pool, which makes `temps network setup-multi-node` refuse to enable
+  # the overlay:
+  #   "compute pool 172.20.0.0/16 overlaps host route 172.20.0.0/16
+  #    on device 'br-<hash>'"
+  # Because those boot-time reconcilers race, which network gets which
+  # /16 varies run to run — so the multinode e2e scenario failed only
+  # intermittently until this was pinned.
+  #
+  # The replacement pool must avoid 172.16.0.0/12 entirely, not just
+  # 172.20.0.0/16: this container's OWN eth0 is frequently on a
+  # 172.x bridge belonging to the outer daemon, and Docker refuses to
+  # subnet a pool that overlaps an existing route — pinning the pool to
+  # 172.17.0.0/16 makes every `docker network create` fail outright with
+  # "all predefined address pools have been fully subnetted".
+  #
+  # 10.98/10.99 is clear of the compute pool (172.20.0.0/16), of both
+  # cluster underlays (dev-cluster 10.42.0.0/24, e2e-multinode
+  # 10.52.0.0/24), and of the outer daemon's 172.16.0.0/12 defaults.
+  # 256 /24s is far more networks than any scenario creates. Overlay
+  # bridges (`br-temps0`) are created by the temps-network crate with an
+  # EXPLICIT subnet out of the compute pool, so they are unaffected by
+  # this pool and still land where the allocator expects.
   # --pidfile pinned so we know exactly which file to clean on restart.
   dockerd \
     --host=unix:///var/run/docker.sock \
     --pidfile=/var/run/docker.pid \
     --iptables=true \
+    --bip=10.98.0.1/24 \
+    --default-address-pool base=10.99.0.0/16,size=24 \
     --log-level=warn \
     >/var/log/docker.log 2>&1 &
 


### PR DESCRIPTION
## Summary

Root-causes and fixes the two Scenario E2E jobs that have been failing on `main`. They are unrelated to each other and unrelated to #931/#934 — those merges just happened to be the runs where they surfaced.

### 1. `Scenarios (recovery)` — real product bug, deterministic

The `mariadb-pitr-scenario` fails at the same step with byte-identical output on every run (checked [#931](https://github.com/gotempsh/temps/actions/runs/34155716051/job/101858498608) and [#934](https://github.com/gotempsh/temps/actions/runs/34162626388/job/101879854134)):

```
"step": "start an in-place PITR restore to the captured target time",
"detail": "startRestore failed (HTTP 400): {\"detail\":\"Validation error: PITR requires a
 physical (mariadb-backup) base backup; location was
 's3://temps-e2e-backups/<run>/external_services/mariadb/<svc>-mariadb-pitr/walg'\"}"
```

`MariadbPhysicalEngine` writes its physical base as a **WAL-G repository** ending in `/walg` (`engines/mariadb_physical.rs:128`) and never as the legacy single `base.mbstream.gz` object. The engine knows this — `MariaDbService::restore_pitr` and `restore_in_place` both dispatch on `is_walg_repository_location`. The orchestrator in `temps-backup` did not: it classified MariaDB locations with `is_physical_base_location`, which only matches the legacy object, so **every** backup the current engine produces was rejected at the API boundary before the engine ran. MariaDB PITR was unreachable through the API even though `restore_capabilities` advertises `pitr: true`.

The same misclassification hit two other sites keyed off the same predicate:

- **Restore plan preview** reported `unsupported` for every current MariaDB physical backup.
- **`credential_propagation_gates`** treated a full datadir swap as if it were a logical dump. For a *cross-service* physical restore that skips patching the target's stored password — the exact lockout the function's own doc comment says it exists to prevent. (Same-service in-place restores are unaffected: the caller short-circuits on `origin_id == target_service.id`, which is why the currently-green `mariadb-restore-scenario` never noticed.)

Fix: add `MariaDbService::is_physical_base_backup_location`, which answers the question the orchestrator actually asks — "is this a physical base in *either* layout?" — and use it at all three orchestrator sites. The layout-specific predicates stay for the paths that genuinely need them (legacy mbstream download, `base_binlog_anchor`).

### 2. `Scenario (multinode mTLS)` — real latent harness bug, raced into view

Not flaky-by-timing and not caused by #934. It fails at `setup-multi-node`:

```
compute pool 172.20.0.0/16 overlaps host route 172.20.0.0/16 on device 'br-c9e5c6c3512f'
```

`preflight_compute_pool_routes` is correct to refuse — a Docker bridge really had taken the cluster compute pool. The failing run's artifact shows exactly which one:

```
INFO creating internal preview gateway control network network=temps-preview-gateway-control-v7
INFO Creating network: temps-app-network
INFO control-plane DNS resolver listening (*.temps.local served locally) bridge=172.20.0.1
```

The bad assumption was in `tools/dev-cluster/entrypoint.sh`, which reasoned that docker0 sits on 172.17.0.0/16 and therefore cannot collide. Docker's **default address pool** is `172.17.0.0/12` with size 16, so every *user-defined* bridge walks up 172.18, 172.19, 172.20 … — and each node creates three at boot (preview-gateway control, preview-gateway ingress, then `temps-app-network`). Whichever lands fourth gets `172.20.0.0/16` exactly. Those boot-time reconcilers race, so the collision only happens on some runs — which is why this job passed on #562/#931 and failed on #934 with no relevant code change.

Fix: pin the inner daemon's `--bip` and `--default-address-pool` so nothing Docker auto-allocates can reach the compute pool.

## What changed

- `crates/temps-providers/src/externalsvc/mariadb.rs`: new `is_physical_base_backup_location`; `is_walg_repository_location` promoted to `pub`; doc comment on `is_physical_base_location` now says explicitly that it is legacy-layout-only.
- `crates/temps-backup/src/services/restore.rs`: `validate_pitr_backup_location`, the plan-preview strategy classifier, and `credential_propagation_gates` all use the layout-agnostic predicate.
- `crates/temps-backup/tests/mariadb_pitr_e2e.rs`: the assertion that mirrors `credential_propagation_gates` now names the predicate the gate actually uses.
- `tools/dev-cluster/entrypoint.sh`: `--bip=10.98.0.1/24 --default-address-pool base=10.99.0.0/16,size=24`.
- `tools/dev-cluster/README.md`: troubleshooting entry for the overlap error, since a real operator can hit it on a node this entrypoint does not manage.

The replacement range has to avoid `172.16.0.0/12` entirely rather than just `172.20.0.0/16`: a node container's own eth0 is often on a 172.x bridge of the *outer* daemon, and Docker refuses to subnet a pool overlapping an existing route. I verified that empirically — pinning to `172.17.0.0/16` makes every `docker network create` fail with "all predefined address pools have been fully subnetted". `10.98`/`10.99` is clear of the compute pool, of both cluster underlays (10.42.0.0/24, 10.52.0.0/24), and of the outer daemon's defaults. Overlay bridges (`br-temps0`) are created with an explicit subnet from the compute pool and are unaffected.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings`: clean (run via the resolved cargo path, not through rtk).
- [x] `cargo fmt`, `cargo check --lib -p temps-providers -p temps-backup`: clean.
- [x] `cargo test -p temps-backup --lib services::restore::tests`: 30 passed. Two new regression tests — `pitr_location_guard_accepts_a_walg_repository_base` and `credential_gates_treat_a_walg_repository_as_physical` — both fail against the old predicate, since `"…/walg".ends_with("base.mbstream.gz")` is false.
- [x] `cargo test -p temps-providers --lib externalsvc::mariadb`: 100 passed, including the new `physical_base_predicate_accepts_both_layouts` (both layouts accepted, logical dumps and empty locations still rejected).
- [x] `cargo test -p temps-backup --features docker-tests --test mariadb_pitr_e2e`: `..._binlog_retention_prune` and `..._logical_dump_restore_keeps_target_credentials` pass against real MinIO + MariaDB containers. The second one exercises the edited assertion against a REAL produced dump key.
- [x] Multinode collision reproduced and fixed empirically in a throwaway DinD container. With the current flags the third auto-allocated bridge lands on `172.20.0.0/16 dev br-<hash>` — the exact CI error. With the pinned flags on a 10.52.0.0/24 underlay (matching the e2e compose), six networks land on 10.99.0.0/24 … 10.99.5.0/24, docker0 on 10.98.0.0/24, and an explicit `172.20.7.0/24` network (the `br-temps0` shape) is still creatable.
- [x] `bash -n tools/dev-cluster/entrypoint.sh`.

**Not verified locally, stated plainly:**

- `mariadb_pitr_full_chain_e2e` gets as far as producing the WAL-G base at `s3://pitr-test-bucket/…/walg` with `engine: mariadb_physical, pitr: true`, archiving three binlog segments, and entering `restore_pitr` — then dies on `Bind for 127.0.0.1:3306 failed: port is already allocated`. That is a stuck host-port reservation on my sandbox (no container claims 3306 and no process listens on it, yet the daemon refuses to bind), unrelated to this change and downstream of the code it touches. CI runs this test with a working daemon.
- The multinode scenario itself needs the full DinD topology and a ~15-20 min in-container build; I verified the specific mechanism in isolation as described above rather than running the whole scenario.

## Known gap, deliberately not fixed here

`HealthMonitor::oldest_retained_mariadb_base_anchor` (`health_monitor.rs:717`) still uses the legacy-only predicate, so every WAL-G-repository base looks like "a physical backup we can't locate" and binlog pruning declines to run. It is fail-safe (warns, never prunes — costs storage, never data) and pre-existing; `mariadb_pitr_e2e.rs:1405` already documents it as tracked separately. Fixing it properly means teaching `base_binlog_anchor` to read a repository's per-backup `metadata.json` keyed by backup UUID, which is a real change with its own test needs and does not belong in a CI fix.

Not enabling auto-merge — a PR whose whole point is fixing CI should have a human look at its CI results first.
