### PR TITLE
fix(agents): support secure sandbox networks on older Docker

### DIFF
--- a/crates/temps-agents/src/docker_network_isolation.rs
+++ b/crates/temps-agents/src/docker_network_isolation.rs
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: 2024-2026 Temps Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use bollard::errors::Error;
+use bollard::models::NetworkCreateRequest;
+use bollard::Docker;
+use std::collections::HashMap;
+
+pub(crate) const BRIDGE_GATEWAY_MODE_IPV4_OPTION: &str =
+    "com.docker.network.bridge.gateway_mode_ipv4";
+pub(crate) const BRIDGE_INHIBIT_IPV4_OPTION: &str = "com.docker.network.bridge.inhibit_ipv4";
+const ISOLATED_GATEWAY_MODE: &str = "isolated";
+
+/// Configure an internal bridge so the Docker host has no address on it.
+///
+/// Docker 28 added the explicit `isolated` gateway mode. Older daemons provide
+/// the same IPv4 isolation through `inhibit_ipv4`; network creation retries
+/// with that compatible spelling only when the daemon rejects the newer one.
+pub(crate) fn with_host_isolation(mut request: NetworkCreateRequest) -> NetworkCreateRequest {
+    request.driver = Some("bridge".to_string());
+    request.internal = Some(true);
+    request.enable_ipv6 = Some(false);
+    request.options.get_or_insert_with(HashMap::new).insert(
+        BRIDGE_GATEWAY_MODE_IPV4_OPTION.to_string(),
+        ISOLATED_GATEWAY_MODE.to_string(),
+    );
+    request
+}
+
+fn with_legacy_host_isolation(mut request: NetworkCreateRequest) -> NetworkCreateRequest {
+    let options = request.options.get_or_insert_with(HashMap::new);
+    options.remove(BRIDGE_GATEWAY_MODE_IPV4_OPTION);
+    options.insert(BRIDGE_INHIBIT_IPV4_OPTION.to_string(), "true".to_string());
+    request
+}
+
+pub(crate) fn has_host_isolation(options: Option<&HashMap<String, String>>) -> bool {
+    options.is_some_and(|options| {
+        options
+            .get(BRIDGE_GATEWAY_MODE_IPV4_OPTION)
+            .is_some_and(|value| value == ISOLATED_GATEWAY_MODE)
+            || options
+                .get(BRIDGE_INHIBIT_IPV4_OPTION)
+                .is_some_and(|value| value == "true")
+    })
+}
+
+fn rejects_isolated_gateway_mode(error: &Error) -> bool {
+    let Error::DockerResponseServerError {
+        status_code: 400,
+        message,
+    } = error
+    else {
+        return false;
+    };
+
+    let message = message.to_ascii_lowercase();
+    message.contains(BRIDGE_GATEWAY_MODE_IPV4_OPTION)
+        && (message.contains("unknown gateway mode")
+            || message.contains("unknown option")
+            || message.contains("invalid value"))
+}
+
+fn compatibility_request(
+    error: &Error,
+    request: NetworkCreateRequest,
+) -> Option<NetworkCreateRequest> {
+    rejects_isolated_gateway_mode(error).then(|| with_legacy_host_isolation(request))
+}
+
+pub(crate) async fn create_host_isolated_network(
+    docker: &Docker,
+    request: NetworkCreateRequest,
+) -> Result<(), Error> {
+    let request = with_host_isolation(request);
+    match docker.create_network(request.clone()).await {
+        Ok(_) => Ok(()),
+        Err(error) => {
+            let Some(compatibility_request) = compatibility_request(&error, request) else {
+                return Err(error);
+            };
+            tracing::warn!(
+                network = %compatibility_request.name,
+                modern_error = %error,
+                "Docker does not support isolated gateway mode; using the equivalent internal inhibit_ipv4 policy"
+            );
+            docker
+                .create_network(compatibility_request)
+                .await
+                .map(|_| ())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request_with_existing_option() -> NetworkCreateRequest {
+        NetworkCreateRequest {
+            name: "sandbox-network".to_string(),
+            internal: Some(true),
+            options: Some(HashMap::from([(
+                "com.docker.network.bridge.enable_ip_masquerade".to_string(),
+                "false".to_string(),
+            )])),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn modern_and_legacy_requests_preserve_host_isolation() {
+        let modern = with_host_isolation(request_with_existing_option());
+        assert_eq!(modern.driver.as_deref(), Some("bridge"));
+        assert_eq!(modern.internal, Some(true));
+        assert_eq!(modern.enable_ipv6, Some(false));
+        assert!(has_host_isolation(modern.options.as_ref()));
+        assert_eq!(
+            modern
+                .options
+                .as_ref()
+                .and_then(|options| options.get("com.docker.network.bridge.enable_ip_masquerade"))
+                .map(String::as_str),
+            Some("false")
+        );
+
+        let legacy = with_legacy_host_isolation(modern);
+        assert_eq!(legacy.name, "sandbox-network");
+        assert_eq!(legacy.driver.as_deref(), Some("bridge"));
+        assert_eq!(legacy.internal, Some(true));
+        assert_eq!(legacy.enable_ipv6, Some(false));
+        assert!(has_host_isolation(legacy.options.as_ref()));
+        assert_eq!(
+            legacy
+                .options
+                .as_ref()
+                .and_then(|options| options.get(BRIDGE_INHIBIT_IPV4_OPTION))
+                .map(String::as_str),
+            Some("true")
+        );
+        assert_eq!(
+            legacy
+                .options
+                .as_ref()
+                .and_then(|options| options.get("com.docker.network.bridge.enable_ip_masquerade"))
+                .map(String::as_str),
+            Some("false")
+        );
+        assert!(!legacy
+            .options
+            .as_ref()
+            .is_some_and(|options| options.contains_key(BRIDGE_GATEWAY_MODE_IPV4_OPTION)));
+    }
+
+    #[test]
+    fn production_daemon_error_selects_the_secure_compatibility_path() {
+        let unsupported = Error::DockerResponseServerError {
+            status_code: 400,
+            message: format!(
+                "failed to parse {BRIDGE_GATEWAY_MODE_IPV4_OPTION} value: isolated (unknown gateway mode isolated)"
+            ),
+        };
+        let unrelated = Error::DockerResponseServerError {
+            status_code: 400,
+            message: "invalid subnet allocation".to_string(),
+        };
+        let older_daemon = Error::DockerResponseServerError {
+            status_code: 400,
+            message: format!("unknown option {BRIDGE_GATEWAY_MODE_IPV4_OPTION}"),
+        };
+        let server_failure = Error::DockerResponseServerError {
+            status_code: 500,
+            message: format!(
+                "failed to parse {BRIDGE_GATEWAY_MODE_IPV4_OPTION} value: isolated (unknown gateway mode isolated)"
+            ),
+        };
+
+        let fallback = compatibility_request(
+            &unsupported,
+            with_host_isolation(request_with_existing_option()),
+        )
+        .expect("the reported unsupported mode must use the secure compatibility request");
+        assert!(has_host_isolation(fallback.options.as_ref()));
+        assert_eq!(
+            fallback
+                .options
+                .as_ref()
+                .and_then(|options| options.get(BRIDGE_INHIBIT_IPV4_OPTION))
+                .map(String::as_str),
+            Some("true")
+        );
+        assert!(compatibility_request(&older_daemon, request_with_existing_option()).is_some());
+        assert!(compatibility_request(&unrelated, request_with_existing_option()).is_none());
+        assert!(compatibility_request(&server_failure, request_with_existing_option()).is_none());
+    }
+
+    #[test]
+    fn networks_without_either_supported_isolation_option_fail_policy_validation() {
+        assert!(!has_host_isolation(Some(&HashMap::new())));
+        assert!(!has_host_isolation(None));
+        for options in [
+            HashMap::from([(
+                BRIDGE_GATEWAY_MODE_IPV4_OPTION.to_string(),
+                "nat".to_string(),
+            )]),
+            HashMap::from([(BRIDGE_INHIBIT_IPV4_OPTION.to_string(), "false".to_string())]),
+        ] {
+            assert!(!has_host_isolation(Some(&options)));
+        }
+    }
+}

--- a/crates/temps-agents/src/lib.rs
+++ b/crates/temps-agents/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 pub mod ai_cli;
+mod docker_network_isolation;
 pub mod error;
 pub mod handlers;
 pub mod plugin;

--- a/crates/temps-agents/src/preview_gateway.rs
+++ b/crates/temps-agents/src/preview_gateway.rs
@@ -45,6 +45,14 @@ use std::sync::Arc;
 use temps_core::PreviewGatewaySettings;
 use tracing::{debug, info, warn};
 
+use crate::docker_network_isolation::{
+    create_host_isolated_network, has_host_isolation, with_host_isolation,
+};
+#[cfg(test)]
+use crate::docker_network_isolation::{
+    BRIDGE_GATEWAY_MODE_IPV4_OPTION, BRIDGE_INHIBIT_IPV4_OPTION,
+};
+
 /// Immutable multi-platform manifest reference. Bumped per release.
 pub const PREVIEW_GATEWAY_IMAGE: &str = "ghcr.io/gotempsh/temps-preview-gateway@sha256:02d5cdd382c3285d569032e84321d5ce8fc089372a3f08651119f6eda8cb1448";
 
@@ -139,7 +147,6 @@ const PREVIEW_GATEWAY_SECURITY_PROTOCOL_LABEL: &str = "sh.temps.preview-gateway-
 const PREVIEW_GATEWAY_SECURITY_PROTOCOL_VERSION: &str = "strip-token-v1";
 const BRIDGE_ENABLE_ICC_OPTION: &str = "com.docker.network.bridge.enable_icc";
 const BRIDGE_ENABLE_MASQUERADE_OPTION: &str = "com.docker.network.bridge.enable_ip_masquerade";
-const BRIDGE_GATEWAY_MODE_IPV4_OPTION: &str = "com.docker.network.bridge.gateway_mode_ipv4";
 const SANDBOX_NETWORK_OWNER_LABEL: &str = "sh.temps.sandbox-network-for";
 const PREVIEW_GATEWAY_INGRESS_SCRIPT: &str = r#"
 const net = require("net");
@@ -404,45 +411,58 @@ async fn connect_sandbox_networks(docker: &Docker, container_name: &str) -> Resu
 }
 
 async fn ensure_network(docker: &Docker, name: &str) -> Result<()> {
-    let networks = docker
-        .list_networks(None::<ListNetworksOptions>)
+    let (network, created) = match docker
+        .inspect_network(
+            name,
+            None::<bollard::query_parameters::InspectNetworkOptions>,
+        )
         .await
-        .context("failed to list docker networks")?;
-    if let Some(network) = networks.iter().find(|n| n.name.as_deref() == Some(name)) {
-        let policy_label = network
-            .labels
-            .as_ref()
-            .and_then(|labels| labels.get(PREVIEW_GATEWAY_NETWORK_LABEL));
-        let options = network.options.as_ref();
-        if network.driver.as_deref() != Some("bridge")
-            || network.internal != Some(true)
-            || network.enable_ipv6 != Some(false)
-            || policy_label.map(String::as_str) != Some(PREVIEW_GATEWAY_NETWORK_POLICY_VERSION)
-            || options
-                .and_then(|value| value.get(BRIDGE_ENABLE_MASQUERADE_OPTION))
-                .map(String::as_str)
-                != Some("false")
-            || options
-                .and_then(|value| value.get(BRIDGE_GATEWAY_MODE_IPV4_OPTION))
-                .map(String::as_str)
-                != Some("isolated")
-        {
-            return Err(anyhow!(
-                "existing preview network {name} does not match the managed internal control policy"
+    {
+        Ok(network) => (network, false),
+        Err(bollard::errors::Error::DockerResponseServerError {
+            status_code: 404, ..
+        }) => {
+            info!(network = %name, "creating internal preview gateway control network");
+            create_host_isolated_network(docker, preview_gateway_network_request(name))
+                .await
+                .map_err(|error| {
+                    docker_operation_error(
+                        format!("failed to create preview gateway control network {name}"),
+                        error,
+                    )
+                })?;
+            let network = docker
+                .inspect_network(
+                    name,
+                    None::<bollard::query_parameters::InspectNetworkOptions>,
+                )
+                .await
+                .map_err(|error| {
+                    docker_operation_error(
+                        format!("failed to verify preview gateway control network {name}"),
+                        error,
+                    )
+                })?;
+            (network, true)
+        }
+        Err(error) => {
+            return Err(docker_operation_error(
+                format!("failed to inspect preview gateway control network {name}"),
+                error,
             ));
         }
-        return Ok(());
+    };
+    if !preview_gateway_network_matches_policy(&network) {
+        let state = if created { "newly created" } else { "existing" };
+        return Err(anyhow!(
+            "{state} preview network {name} does not match the managed internal control policy"
+        ));
     }
-    info!(network = %name, "creating internal preview gateway control network");
-    docker
-        .create_network(preview_gateway_network_request(name))
-        .await
-        .with_context(|| format!("failed to create network {}", name))?;
     Ok(())
 }
 
 fn preview_gateway_network_request(name: &str) -> NetworkCreateRequest {
-    NetworkCreateRequest {
+    with_host_isolation(NetworkCreateRequest {
         name: name.to_string(),
         driver: Some("bridge".to_string()),
         internal: Some(true),
@@ -452,21 +472,31 @@ fn preview_gateway_network_request(name: &str) -> NetworkCreateRequest {
             PREVIEW_GATEWAY_NETWORK_POLICY_VERSION.to_string(),
         )])),
         // The relay and router must be able to communicate on this private
-        // network, so ICC remains enabled. Isolated gateway mode removes the
-        // host-side bridge address as well as external routing; disabled
-        // masquerading is retained as an explicit defense-in-depth policy.
-        options: Some(HashMap::from([
-            (
-                BRIDGE_ENABLE_MASQUERADE_OPTION.to_string(),
-                "false".to_string(),
-            ),
-            (
-                BRIDGE_GATEWAY_MODE_IPV4_OPTION.to_string(),
-                "isolated".to_string(),
-            ),
-        ])),
+        // network, so ICC remains enabled. Host isolation removes the bridge
+        // address as well as external routing; disabled masquerading remains
+        // an explicit defense-in-depth policy.
+        options: Some(HashMap::from([(
+            BRIDGE_ENABLE_MASQUERADE_OPTION.to_string(),
+            "false".to_string(),
+        )])),
         ..Default::default()
-    }
+    })
+}
+
+fn preview_gateway_network_matches_policy(network: &bollard::models::NetworkInspect) -> bool {
+    let options = network.options.as_ref();
+    network.driver.as_deref() == Some("bridge")
+        && network.internal == Some(true)
+        && network.enable_ipv6 == Some(false)
+        && network
+            .labels
+            .as_ref()
+            .and_then(|labels| labels.get(PREVIEW_GATEWAY_NETWORK_LABEL))
+            .is_some_and(|value| value == PREVIEW_GATEWAY_NETWORK_POLICY_VERSION)
+        && options
+            .and_then(|options| options.get(BRIDGE_ENABLE_MASQUERADE_OPTION))
+            .is_some_and(|value| value == "false")
+        && has_host_isolation(options)
 }
 
 async fn ensure_ingress_network(docker: &Docker) -> Result<()> {
@@ -1600,14 +1630,49 @@ mod tests {
                 .map(String::as_str),
             Some("false")
         );
-        assert_eq!(
-            request
-                .options
-                .as_ref()
-                .and_then(|options| options.get(BRIDGE_GATEWAY_MODE_IPV4_OPTION))
-                .map(String::as_str),
-            Some("isolated")
-        );
+        assert!(has_host_isolation(request.options.as_ref()));
+    }
+
+    #[test]
+    fn existing_gateway_control_network_accepts_only_complete_host_isolation_policy() {
+        let request = preview_gateway_network_request("preview-test");
+        let modern = bollard::models::NetworkInspect {
+            name: Some(request.name),
+            driver: request.driver,
+            internal: request.internal,
+            enable_ipv6: request.enable_ipv6,
+            labels: request.labels,
+            options: request.options,
+            ..Default::default()
+        };
+        assert!(preview_gateway_network_matches_policy(&modern));
+
+        let mut legacy = modern.clone();
+        let legacy_options = legacy.options.get_or_insert_with(HashMap::new);
+        legacy_options.remove(BRIDGE_GATEWAY_MODE_IPV4_OPTION);
+        legacy_options.insert(BRIDGE_INHIBIT_IPV4_OPTION.to_string(), "true".to_string());
+        assert!(preview_gateway_network_matches_policy(&legacy));
+
+        let mut masquerading = legacy.clone();
+        masquerading
+            .options
+            .get_or_insert_with(HashMap::new)
+            .insert(
+                BRIDGE_ENABLE_MASQUERADE_OPTION.to_string(),
+                "true".to_string(),
+            );
+        assert!(!preview_gateway_network_matches_policy(&masquerading));
+
+        let mut externally_routed = legacy.clone();
+        externally_routed.internal = Some(false);
+        assert!(!preview_gateway_network_matches_policy(&externally_routed));
+
+        let mut disabled_isolation = legacy;
+        disabled_isolation
+            .options
+            .get_or_insert_with(HashMap::new)
+            .insert(BRIDGE_INHIBIT_IPV4_OPTION.to_string(), "false".to_string());
+        assert!(!preview_gateway_network_matches_policy(&disabled_isolation));
     }
 
     #[test]

--- a/crates/temps-agents/src/sandbox/docker.rs
+++ b/crates/temps-agents/src/sandbox/docker.rs
@@ -19,6 +19,13 @@ use super::{
     SandboxHandle, SandboxProvider, PTY_AGENT_SOCKET,
 };
 use crate::ai_cli::OnEventCallback;
+use crate::docker_network_isolation::{
+    create_host_isolated_network, has_host_isolation, with_host_isolation,
+};
+#[cfg(test)]
+use crate::docker_network_isolation::{
+    BRIDGE_GATEWAY_MODE_IPV4_OPTION, BRIDGE_INHIBIT_IPV4_OPTION,
+};
 use crate::error::AgentError;
 
 /// Container naming prefix — used for recovery after server restarts.
@@ -566,8 +573,6 @@ pub(crate) fn find_surviving_sensitive_keys(env: &[String]) -> Vec<String> {
 /// Keep in sync with `preview_gateway::PREVIEW_GATEWAY_NETWORK`.
 const SANDBOX_NETWORK_PREFIX: &str = "temps-sandbox-net-v3-";
 const SANDBOX_NETWORK_OWNER_LABEL: &str = "sh.temps.sandbox-network-for";
-const SANDBOX_ISOLATED_GATEWAY_OPTION: &str = "com.docker.network.bridge.gateway_mode_ipv4";
-const SANDBOX_ISOLATED_GATEWAY_VALUE: &str = "isolated";
 
 /// The egress proxy is the only container with a NIC on both the internal
 /// sandbox network and this ordinary outbound bridge.
@@ -584,6 +589,41 @@ pub const SANDBOX_MODEL_RELAY_BASE_URL: &str =
     "http://temps-sandbox-egress-proxy:3128/.temps/model-relay";
 const SANDBOX_EGRESS_POLICY_LABEL: &str = "sh.temps.sandbox-egress-policy";
 const SANDBOX_EGRESS_POLICY_VERSION: &str = "1";
+
+fn isolated_sandbox_network_request(
+    name: &str,
+    container_name: &str,
+) -> bollard::models::NetworkCreateRequest {
+    with_host_isolation(bollard::models::NetworkCreateRequest {
+        name: name.to_string(),
+        labels: Some(HashMap::from([
+            (
+                SANDBOX_EGRESS_POLICY_LABEL.to_string(),
+                SANDBOX_EGRESS_POLICY_VERSION.to_string(),
+            ),
+            (
+                SANDBOX_NETWORK_OWNER_LABEL.to_string(),
+                container_name.to_string(),
+            ),
+        ])),
+        ..Default::default()
+    })
+}
+
+fn sandbox_network_matches_isolation_policy(
+    network: &bollard::models::NetworkInspect,
+    container_name: &str,
+) -> bool {
+    let labels = network.labels.as_ref();
+    docker_network_matches_policy(network, true, false)
+        && labels
+            .and_then(|labels| labels.get(SANDBOX_EGRESS_POLICY_LABEL))
+            .is_some_and(|value| value == SANDBOX_EGRESS_POLICY_VERSION)
+        && labels
+            .and_then(|labels| labels.get(SANDBOX_NETWORK_OWNER_LABEL))
+            .is_some_and(|value| value == container_name)
+        && has_host_isolation(network.options.as_ref())
+}
 const SANDBOX_MCP_RELAY_BASE_URL: &str = "http://temps-sandbox-egress-proxy:3128/.temps/mcp";
 
 /// Small CONNECT/HTTP forward proxy used as the sandbox's only internet
@@ -2003,35 +2043,17 @@ impl DockerSandboxProvider {
         let network = match inspected {
             Ok(network) => network,
             Err(error) if docker_error_is_not_found(&error) => {
-                self.docker
-                    .create_network(bollard::models::NetworkCreateRequest {
-                        name: name.to_string(),
-                        driver: Some("bridge".to_string()),
-                        internal: Some(true),
-                        enable_ipv6: Some(false),
-                        labels: Some(HashMap::from([
-                            (
-                                SANDBOX_EGRESS_POLICY_LABEL.to_string(),
-                                SANDBOX_EGRESS_POLICY_VERSION.to_string(),
-                            ),
-                            (
-                                SANDBOX_NETWORK_OWNER_LABEL.to_string(),
-                                container_name.to_string(),
-                            ),
-                        ])),
-                        options: Some(HashMap::from([(
-                            SANDBOX_ISOLATED_GATEWAY_OPTION.to_string(),
-                            SANDBOX_ISOLATED_GATEWAY_VALUE.to_string(),
-                        )])),
-                        ..Default::default()
-                    })
-                    .await
-                    .map_err(|source| AgentError::SandboxProviderUnavailable {
-                        provider: "docker".to_string(),
-                        reason: format!(
-                            "create isolated network for sandbox '{container_name}': {source}"
-                        ),
-                    })?;
+                create_host_isolated_network(
+                    &self.docker,
+                    isolated_sandbox_network_request(name, container_name),
+                )
+                .await
+                .map_err(|source| AgentError::SandboxProviderUnavailable {
+                    provider: "docker".to_string(),
+                    reason: format!(
+                        "create isolated network for sandbox '{container_name}': {source}"
+                    ),
+                })?;
                 self.docker
                     .inspect_network(
                         name,
@@ -2055,27 +2077,11 @@ impl DockerSandboxProvider {
             }
         };
 
-        let labels = network.labels.as_ref();
-        let policy_matches = labels
-            .and_then(|labels| labels.get(SANDBOX_EGRESS_POLICY_LABEL))
-            .is_some_and(|value| value == SANDBOX_EGRESS_POLICY_VERSION);
-        let owner_matches = labels
-            .and_then(|labels| labels.get(SANDBOX_NETWORK_OWNER_LABEL))
-            .is_some_and(|value| value == container_name);
-        let isolated_gateway = network
-            .options
-            .as_ref()
-            .and_then(|options| options.get(SANDBOX_ISOLATED_GATEWAY_OPTION))
-            .is_some_and(|value| value == SANDBOX_ISOLATED_GATEWAY_VALUE);
-        if !docker_network_matches_policy(&network, true, false)
-            || !policy_matches
-            || !owner_matches
-            || !isolated_gateway
-        {
+        if !sandbox_network_matches_isolation_policy(&network, container_name) {
             return Err(AgentError::SandboxProviderUnavailable {
                 provider: "docker".to_string(),
                 reason: format!(
-                    "sandbox isolation is unavailable because Docker did not preserve the required isolated-gateway policy for '{name}'"
+                    "sandbox isolation is unavailable because Docker did not preserve the required host-isolation policy for '{name}'"
                 ),
             });
         }
@@ -5487,6 +5493,87 @@ mod tests {
             ..Default::default()
         };
         assert!(docker_network_matches_policy(&shared, false, false));
+    }
+
+    #[test]
+    fn per_sandbox_network_request_requires_host_isolation() {
+        let request = isolated_sandbox_network_request("sandbox-network", "sandbox-container");
+
+        assert_eq!(request.name, "sandbox-network");
+        assert_eq!(request.driver.as_deref(), Some("bridge"));
+        assert_eq!(request.internal, Some(true));
+        assert_eq!(request.enable_ipv6, Some(false));
+        assert!(has_host_isolation(request.options.as_ref()));
+        assert_eq!(
+            request
+                .labels
+                .as_ref()
+                .and_then(|labels| labels.get(SANDBOX_EGRESS_POLICY_LABEL))
+                .map(String::as_str),
+            Some(SANDBOX_EGRESS_POLICY_VERSION)
+        );
+        assert_eq!(
+            request
+                .labels
+                .as_ref()
+                .and_then(|labels| labels.get(SANDBOX_NETWORK_OWNER_LABEL))
+                .map(String::as_str),
+            Some("sandbox-container")
+        );
+    }
+
+    #[test]
+    fn existing_per_sandbox_network_accepts_only_complete_host_isolation_policy() {
+        let request = isolated_sandbox_network_request("sandbox-network", "sandbox-container");
+        let modern = bollard::models::NetworkInspect {
+            name: Some(request.name),
+            driver: request.driver,
+            internal: request.internal,
+            enable_ipv6: request.enable_ipv6,
+            labels: request.labels,
+            options: request.options,
+            ..Default::default()
+        };
+        assert!(sandbox_network_matches_isolation_policy(
+            &modern,
+            "sandbox-container"
+        ));
+
+        let mut legacy = modern.clone();
+        let legacy_options = legacy.options.get_or_insert_with(HashMap::new);
+        legacy_options.remove(BRIDGE_GATEWAY_MODE_IPV4_OPTION);
+        legacy_options.insert(BRIDGE_INHIBIT_IPV4_OPTION.to_string(), "true".to_string());
+        assert!(sandbox_network_matches_isolation_policy(
+            &legacy,
+            "sandbox-container"
+        ));
+
+        let mut wrong_owner = legacy.clone();
+        wrong_owner.labels.get_or_insert_with(HashMap::new).insert(
+            SANDBOX_NETWORK_OWNER_LABEL.to_string(),
+            "another-container".to_string(),
+        );
+        assert!(!sandbox_network_matches_isolation_policy(
+            &wrong_owner,
+            "sandbox-container"
+        ));
+
+        let mut externally_routed = legacy.clone();
+        externally_routed.internal = Some(false);
+        assert!(!sandbox_network_matches_isolation_policy(
+            &externally_routed,
+            "sandbox-container"
+        ));
+
+        let mut disabled_isolation = legacy;
+        disabled_isolation
+            .options
+            .get_or_insert_with(HashMap::new)
+            .insert(BRIDGE_INHIBIT_IPV4_OPTION.to_string(), "false".to_string());
+        assert!(!sandbox_network_matches_isolation_policy(
+            &disabled_isolation,
+            "sandbox-container"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- preserve host-isolated Docker sandbox networks on engines that predate `gateway_mode_ipv4=isolated`
- retry only the recognized Docker 400 compatibility failure with the equivalent secure bridge option, `com.docker.network.bridge.inhibit_ipv4=true`
- re-inspect and validate both sandbox and preview-gateway networks before attaching or starting workloads

## Root cause

Temps always requested `com.docker.network.bridge.gateway_mode_ipv4=isolated`. Older Docker engines reject that newer gateway mode with HTTP 400, so the Docker sandbox provider became unavailable even though those engines support the equivalent internal bridge configuration.

## Security behavior

The fallback does not enable unrestricted networking. Both variants require:

- bridge driver
- `internal=true`
- IPv6 disabled
- no IPv4 address on the host bridge
- the expected Temps policy and ownership labels
- preview-gateway IP masquerading disabled

Fallback is limited to a Docker 400 response that names the exact unsupported gateway-mode option and reports an unsupported option/value shape. Any unrelated response or invalid persisted network state fails closed.

## Verification

- `cargo test -p temps-agents --lib` — 404 passed, 1 ignored
- `cargo check -p temps-agents --lib` — passed
- `cargo clippy -p temps-agents --lib --tests -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- `python3 scripts/source_attribution.py check` — passed
- live Docker legacy-network probe reported `internal=true`, `enable_ipv6=false`, and `inhibit_ipv4=true`
- Rust review: approved
- regression-test review: approved
- security review: approved, no findings or merge blockers
