### PR TITLE
fix(cloud): wake the backup mirror sweep on local backup completion

### DIFF
--- a/crates/temps-cloud/src/backup_mirror.rs
+++ b/crates/temps-cloud/src/backup_mirror.rs
@@ -26,7 +26,10 @@ use temps_entities::{
     backups, cloud_backup_mirror_cursors, cloud_backup_mirror_states, external_service_backups,
     external_services, s3_sources,
 };
-use tokio::{io::AsyncReadExt, sync::watch};
+use tokio::{
+    io::AsyncReadExt,
+    sync::{watch, Notify},
+};
 use tracing::{info, warn};
 use uuid::Uuid;
 
@@ -120,6 +123,7 @@ pub async fn run(
     db: Arc<DatabaseConnection>,
     encryption: Arc<EncryptionService>,
     mut cancel: watch::Receiver<bool>,
+    wake: Arc<Notify>,
 ) {
     info!("Cloud backup mirror started");
     // The first discovery pass is immediate. Subsequent failures back off,
@@ -146,28 +150,59 @@ pub async fn run(
                     slept_secs = retry_in.as_secs(),
                     "Cloud backup mirror sweep tick starting"
                 );
-                let outcome = match sweep(&link, &db, &encryption).await {
-                    Ok(outcome) => outcome,
-                    Err(error) => {
-                        warn!(error = %error, "Cloud backup mirror sweep failed; local backups remain authoritative");
-                        SweepOutcome::Retry
-                    }
-                };
-                retry_in = next_sweep_interval(retry_in, outcome);
-                tracing::debug!(
-                    outcome = ?outcome,
-                    next_tick_secs = retry_in.as_secs(),
-                    "Cloud backup mirror sweep tick finished"
-                );
-                if outcome == SweepOutcome::Retry {
-                    warn!(
-                        retry_in_secs = retry_in.as_secs(),
-                        "Cloud backup mirror retained local backup; retrying with exponential backoff"
-                    );
-                }
+                retry_in = run_sweep_tick(&link, &db, &encryption, retry_in).await;
+            }
+            // A backup that just finished locally shouldn't sit behind
+            // `retry_in`'s current backoff -- that backoff describes how hard
+            // Cloud or this instance's own S3 access has been failing, not how
+            // fresh the newest local backup is. `lifecycle_notify` fires this
+            // the moment a `Job::BackupCompleted` crosses the queue, so the
+            // common case (nothing was failing, the sweep was just idling at
+            // `BASE_SWEEP_INTERVAL`) reports to Cloud within the same second
+            // the local backup finished instead of up to `BASE_SWEEP_INTERVAL`
+            // later -- and, more importantly, instead of up to
+            // `MAX_SWEEP_INTERVAL` later if an unrelated backup on this same
+            // instance was mid-backoff from an earlier, now-resolved failure.
+            // A spurious or redundant wake costs one `sweep()` call against
+            // `DUE_BACKUPS_SQL`, which is a no-op query when nothing is due --
+            // cheap enough to not need debouncing.
+            _ = wake.notified() => {
+                tracing::debug!("Cloud backup mirror woken by a completed local backup");
+                retry_in = run_sweep_tick(&link, &db, &encryption, retry_in).await;
             }
         }
     }
+}
+
+/// Run one sweep and compute the next tick's delay. Shared by the timer and
+/// the early-wake paths in [`run`] so both go through identical outcome
+/// handling and logging.
+async fn run_sweep_tick(
+    link: &Arc<CloudLink>,
+    db: &Arc<DatabaseConnection>,
+    encryption: &Arc<EncryptionService>,
+    retry_in: Duration,
+) -> Duration {
+    let outcome = match sweep(link, db, encryption).await {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            warn!(error = %error, "Cloud backup mirror sweep failed; local backups remain authoritative");
+            SweepOutcome::Retry
+        }
+    };
+    let next = next_sweep_interval(retry_in, outcome);
+    tracing::debug!(
+        outcome = ?outcome,
+        next_tick_secs = next.as_secs(),
+        "Cloud backup mirror sweep tick finished"
+    );
+    if outcome == SweepOutcome::Retry {
+        warn!(
+            retry_in_secs = next.as_secs(),
+            "Cloud backup mirror retained local backup; retrying with exponential backoff"
+        );
+    }
+    next
 }
 
 async fn sweep(
@@ -3124,11 +3159,17 @@ mod tests {
             "mirror-loop-test",
         ));
         let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+        let wake = Arc::new(tokio::sync::Notify::new());
 
         // `run` starts with a zero-length first sleep, so its first sweep is
         // immediate and needs no clock manipulation to observe.
-        let loop_handle =
-            tokio::spawn(run(link.clone(), db.clone(), encryption.clone(), cancel_rx));
+        let loop_handle = tokio::spawn(run(
+            link.clone(),
+            db.clone(),
+            encryption.clone(),
+            cancel_rx,
+            wake,
+        ));
 
         let registered = tokio::time::timeout(Duration::from_secs(10), async {
             loop {

--- a/crates/temps-cloud/src/lifecycle_notify.rs
+++ b/crates/temps-cloud/src/lifecycle_notify.rs
@@ -29,6 +29,13 @@ pub async fn run(service: Arc<CloudService>, queue: Arc<dyn JobQueue>) {
                 let Some(stage_job) = to_lifecycle_job(&job) else {
                     continue;
                 };
+                // Independent of whether the lifecycle push below succeeds,
+                // is skipped for lack of a link, or Cloud is unreachable: the
+                // sweep does its own linked/candidate checks and this is
+                // strictly an early nudge, never the sweep's only trigger.
+                if stage_job.stage == BackupLifecycleStage::Completed {
+                    service.wake_backup_mirror();
+                }
                 if !service.link().is_linked() {
                     debug!("Cloud is not linked; skipping backup lifecycle push");
                     continue;

--- a/crates/temps-cloud/src/service.rs
+++ b/crates/temps-cloud/src/service.rs
@@ -15,7 +15,7 @@ use temps_cloud_protocol::{
 use temps_config::{ConfigService, ConfigServiceError};
 use temps_core::EncryptionService;
 use thiserror::Error;
-use tokio::sync::{watch, Mutex as AsyncMutex};
+use tokio::sync::{watch, Mutex as AsyncMutex, Notify};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
@@ -154,6 +154,11 @@ pub struct CloudService {
     backup_credential_rotation_task: Mutex<Option<tokio::task::JoinHandle<()>>>,
     heartbeat_task: Mutex<Option<tokio::task::JoinHandle<()>>>,
     lifecycle_notify_task: Mutex<Option<tokio::task::JoinHandle<()>>>,
+    /// Lets [`Self::wake_backup_mirror`] pull the next sweep tick forward the
+    /// moment a local backup finishes, instead of it waiting behind whatever
+    /// backoff `backup_mirror::run` is currently sitting on. See the comment
+    /// on that `select!` arm for why this matters.
+    backup_mirror_wake: Arc<Notify>,
     allow_loopback_development: bool,
     configuration_issue: RwLock<Option<String>>,
     managed_backup_setup: RwLock<Option<ManagedBackupSetup>>,
@@ -180,6 +185,7 @@ impl CloudService {
             backup_credential_rotation_task: Mutex::new(None),
             heartbeat_task: Mutex::new(None),
             lifecycle_notify_task: Mutex::new(None),
+            backup_mirror_wake: Arc::new(Notify::new()),
             allow_loopback_development,
             configuration_issue: RwLock::new(None),
             managed_backup_setup: RwLock::new(None),
@@ -242,12 +248,20 @@ impl CloudService {
             tracing::info!("Cloud service launching backup mirror task");
             let link = self.link.clone();
             let cancel = self.cancel.subscribe();
+            let wake = self.backup_mirror_wake.clone();
             *task = Some(tokio::spawn(async move {
-                crate::backup_mirror::run(link, db, encryption, cancel).await;
+                crate::backup_mirror::run(link, db, encryption, cancel, wake).await;
             }));
         } else {
             tracing::debug!("Cloud backup mirror task is already registered");
         }
+    }
+
+    /// Pull the backup mirror's next sweep tick forward immediately, rather
+    /// than leaving it to whatever backoff it currently sits on. Called by
+    /// [`crate::lifecycle_notify::run`] right after a local backup completes.
+    pub fn wake_backup_mirror(&self) {
+        self.backup_mirror_wake.notify_one();
     }
 
     /// Launch the background loop that keeps the Cloud-managed backup


### PR DESCRIPTION
## Summary
- The Cloud backup-mirror sweep only checked for new work on its own timer, which can back off up to `MAX_SWEEP_INTERVAL` (15 minutes) after any recent, unrelated failure — so a brand new, healthy backup could sit unreported to Cloud for up to 15 minutes behind a different backup's already-resolved retry backoff.
- `lifecycle_notify` already learns about every completed local backup instantly via the job queue, but never told the sweep.
- Adds a shared `tokio::sync::Notify` on `CloudService`; `lifecycle_notify::run` calls `wake_backup_mirror()` on `Job::BackupCompleted`, and `backup_mirror::run` races that alongside its existing timer/cancellation signal, running identical sweep logic either way (extracted into `run_sweep_tick` to avoid duplicating it).
- This intentionally does **not** make mirroring synchronous with local backup completion — Cloud must never be able to slow or block a local backup (see `temps/CLAUDE.md` / `temps-cloud-app-wt-metrics/CLAUDE.md`'s local-first invariant). It only removes an avoidable latency tax on an otherwise fully async, backoff-driven mirror.

## Test plan
- [x] `cargo test -p temps-cloud --lib backup_mirror::` — 34/34 pass, including the real end-to-end mirror-loop test, updated for the new `run()` signature
- [x] `cargo test -p temps-cloud --lib lifecycle_notify::` — 11/11 pass
- [x] `cargo clippy -p temps-cloud --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] No new test directly exercises the wake-vs-timer race under simulated backoff (would need paused-clock testing not otherwise used in this file); confidence instead comes from full pass of the existing suite against the refactored, logic-preserving `run_sweep_tick` extraction

## Evidence
No runtime behavior change to what a sweep tick does — only when it's allowed to run early. Verified via the existing real end-to-end test (`the_mirror_loop_registers_managed_backups_and_stops_on_request`), which spawns the actual `run()` loop against a live SQLite-backed fixture DB and asserts on real mirror-state rows.