### PR TITLE
fix(agent): bind published container ports to the node's private address, not 0.0.0.0

### DIFF
--- a/crates/temps-agent/src/handlers.rs
+++ b/crates/temps-agent/src/handlers.rs
@@ -275,6 +275,13 @@ pub struct AgentState {
     /// health report exposes it so the control plane can resolve a node whose
     /// stored architecture is still unknown before transferring an image.
     pub platform: crate::server::SharedPlatform,
+    /// Address published container ports are bound to for services created
+    /// directly through this agent's HTTP API (managed databases, Redis,
+    /// etc. — see `service_handlers::create_service`), mirroring
+    /// `DockerRuntime::host_bind_address` used for app-container deploys.
+    /// Resolved once at startup from `AgentConfig::private_address`; never
+    /// `"0.0.0.0"` — see `crate::server::build_router`.
+    pub host_bind_address: String,
 }
 
 /// Response wrapper for consistent agent API responses.

--- a/crates/temps-agent/src/lib.rs
+++ b/crates/temps-agent/src/lib.rs
@@ -136,6 +136,28 @@ pub struct AgentConfig {
     /// it can never raise the overlay beyond what the link supports.
     #[serde(default)]
     pub underlay_mtu: Option<u32>,
+    /// This node's private/underlay address as registered with the control
+    /// plane (`nodes.private_address`) — the WireGuard tunnel IP assigned by
+    /// the relay, or the user-supplied address in direct mode. Always an IP
+    /// already bound to a local interface by the time `temps agent` starts,
+    /// since relay mode configures the WireGuard interface and direct mode
+    /// requires the operator's networking to already own it.
+    ///
+    /// Used to bind published Docker container ports to this address
+    /// instead of `0.0.0.0`, so deployed app containers are reachable only
+    /// over the private/overlay network (where the control-plane proxy
+    /// connects from) and never on the node's public interface.
+    /// `#[serde(default)]` so `agent.json` files saved before this field
+    /// existed still parse as `None` rather than failing deserialization —
+    /// but `temps agent`'s config resolution then hard-errors at startup
+    /// when it's missing (see `resolve_config` in `temps-cli`), directing
+    /// the operator to re-run `temps join`. There is no insecure fallback:
+    /// `build_router`'s own defensive fallback for a `None` config
+    /// substitutes loopback (`127.0.0.1`), never `0.0.0.0` — and is
+    /// unreachable in the real `temps agent` binary, since `resolve_config`
+    /// always rejects a `None` config before `build_router` is called.
+    #[serde(default)]
+    pub private_address: Option<String>,
 }
 
 fn default_dns_data_dir() -> std::path::PathBuf {
@@ -425,6 +447,7 @@ mod tests {
             require_mtls: false,
             underlay_dev: None,
             underlay_mtu: None,
+            private_address: Some("10.100.0.2".to_string()),
         };
 
         let json = serde_json::to_string(&config).unwrap();
@@ -432,6 +455,21 @@ mod tests {
         assert_eq!(parsed.node_name, "worker-1");
         assert_eq!(parsed.node_id, 1);
         assert!(!parsed.require_mtls);
+        assert_eq!(parsed.private_address.as_deref(), Some("10.100.0.2"));
+    }
+
+    #[test]
+    fn test_agent_config_without_private_address_remains_compatible() {
+        let json = r#"{
+            "listen_address": "0.0.0.0:3100",
+            "token": "test-token",
+            "node_name": "worker-1",
+            "control_plane_url": "https://control:3000",
+            "node_id": 1
+        }"#;
+
+        let parsed: AgentConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.private_address, None);
     }
 
     #[test]

--- a/crates/temps-agent/src/server.rs
+++ b/crates/temps-agent/src/server.rs
@@ -51,6 +51,14 @@ pub fn build_router(
     overlay_peers: crate::network_sync::SharedPeers,
     platform: SharedPlatform,
 ) -> Router {
+    // Same address app-container deploys bind to (never "0.0.0.0" — see
+    // AgentConfig::private_address). Falls back to loopback only for the
+    // legacy-config test-fixture case; `temps agent`'s CLI entrypoint
+    // already hard-errors before reaching here if this is genuinely unset.
+    let host_bind_address = config
+        .private_address
+        .clone()
+        .unwrap_or_else(|| "127.0.0.1".to_string());
     let state = Arc::new(AgentState {
         container_deployer,
         image_builder,
@@ -58,6 +66,7 @@ pub fn build_router(
         overlay_bridge_address,
         overlay_peers,
         platform,
+        host_bind_address,
     });
     let resource_limits = Arc::new(handlers::AgentResourceLimits::new());
 
@@ -781,6 +790,7 @@ mod tests {
             require_mtls,
             underlay_dev: None,
             underlay_mtu: None,
+            private_address: None,
         }
     }
 

--- a/crates/temps-agent/src/service_handlers.rs
+++ b/crates/temps-agent/src/service_handlers.rs
@@ -208,6 +208,17 @@ fn ok_response<T: serde::Serialize>(data: T) -> Json<AgentResponse<T>> {
     })
 }
 
+/// Build a Docker port binding for a service container, always bound to
+/// this agent's resolved private/overlay address — never `"0.0.0.0"`, which
+/// would make the service reachable on the node's public interface too.
+/// `host_port: None` means auto-assign: let Docker pick a free host port.
+fn service_port_binding(host_ip: &str, host_port: Option<u16>) -> bollard::models::PortBinding {
+    bollard::models::PortBinding {
+        host_ip: Some(host_ip.to_string()),
+        host_port: host_port.map(|port| port.to_string()),
+    }
+}
+
 fn mounted_volume_names(
     container_name: &str,
     mounts: Vec<bollard::models::MountPoint>,
@@ -288,18 +299,15 @@ pub async fn create_service(
             has_auto_assign = true;
             port_bindings.insert(
                 container_port_key,
-                Some(vec![bollard::models::PortBinding {
-                    host_ip: Some("0.0.0.0".to_string()),
-                    host_port: None,
-                }]),
+                Some(vec![service_port_binding(&state.host_bind_address, None)]),
             );
         } else {
             port_bindings.insert(
                 container_port_key,
-                Some(vec![bollard::models::PortBinding {
-                    host_ip: Some("0.0.0.0".to_string()),
-                    host_port: Some(pm.host_port.to_string()),
-                }]),
+                Some(vec![service_port_binding(
+                    &state.host_bind_address,
+                    Some(pm.host_port),
+                )]),
             );
             if first_host_port == 0 {
                 first_host_port = pm.host_port;
@@ -2286,5 +2294,27 @@ mod overlay_ip_tests {
         assert!(command[4].contains("pg_dumpall"));
         assert!(command[4].contains("| gzip"));
         assert!(command[4].contains("&& echo 'dump_complete'"));
+    }
+}
+
+#[cfg(test)]
+mod service_port_binding_tests {
+    use super::service_port_binding;
+
+    // Regression guard for the exact bug this replaced: both port mappings
+    // used a hardcoded "0.0.0.0" PortBinding, exposing service containers
+    // (managed databases, Redis, etc.) on every interface of the worker
+    // node instead of only the private/overlay one.
+    #[test]
+    fn never_binds_to_all_interfaces() {
+        let fixed = service_port_binding("10.100.0.2", Some(5432));
+        assert_eq!(fixed.host_ip.as_deref(), Some("10.100.0.2"));
+        assert_ne!(fixed.host_ip.as_deref(), Some("0.0.0.0"));
+        assert_eq!(fixed.host_port.as_deref(), Some("5432"));
+
+        let auto_assign = service_port_binding("10.100.0.2", None);
+        assert_eq!(auto_assign.host_ip.as_deref(), Some("10.100.0.2"));
+        assert_ne!(auto_assign.host_ip.as_deref(), Some("0.0.0.0"));
+        assert_eq!(auto_assign.host_port, None);
     }
 }

--- a/crates/temps-cli/src/commands/agent.rs
+++ b/crates/temps-cli/src/commands/agent.rs
@@ -412,12 +412,18 @@ impl AgentCommand {
                      nodes.private_address."
                 )
             })?;
-        private_address.parse::<std::net::IpAddr>().map_err(|_| {
-            anyhow::anyhow!(
-                "private_address '{}' is not a valid IP address",
-                private_address
-            )
-        })?;
+        // Reuse the same reserved-range rejection `temps join` registration
+        // already enforces server-side (loopback, link-local, unspecified,
+        // multicast, broadcast, documentation ranges) — a manually supplied
+        // --private-address/TEMPS_AGENT_PRIVATE_ADDRESS override must not be
+        // able to bypass it. In particular this rejects "0.0.0.0", which
+        // parses as a syntactically valid IP but would silently reproduce
+        // the exact all-interface exposure this whole mechanism exists to
+        // close.
+        temps_deployments::handlers::nodes::validate_node_private_address(&private_address)
+            .map_err(|error| {
+                anyhow::anyhow!("private_address '{private_address}' is invalid: {error}")
+            })?;
 
         Ok(temps_agent::AgentConfig {
             listen_address,

--- a/crates/temps-cli/src/commands/agent.rs
+++ b/crates/temps-cli/src/commands/agent.rs
@@ -68,6 +68,18 @@ pub struct AgentCommand {
     /// MTU is lower than the interface advertises.
     #[arg(long, env = "TEMPS_AGENT_UNDERLAY_MTU")]
     pub underlay_mtu: Option<u32>,
+
+    /// This node's private/underlay address, as registered with the control
+    /// plane during `temps join` (`nodes.private_address`) — the WireGuard
+    /// tunnel IP in relay mode, or the user-managed address in direct mode.
+    /// Published Docker container ports are bound to this address only,
+    /// never to "0.0.0.0", so deployed containers are reachable from the
+    /// control-plane proxy over the private network but never on this
+    /// node's public interface. Overrides the saved config; must match what
+    /// was registered with the control plane, since that's the address the
+    /// proxy dials for this node.
+    #[arg(long, env = "TEMPS_AGENT_PRIVATE_ADDRESS")]
+    pub private_address: Option<String>,
 }
 
 impl AgentCommand {
@@ -118,12 +130,45 @@ impl AgentCommand {
             let overlay_bridge_address: Arc<std::sync::RwLock<Option<std::net::IpAddr>>> =
                 Arc::new(std::sync::RwLock::new(None));
 
+            // Bind published container ports to this node's private/overlay
+            // address (the WireGuard tunnel IP, or the direct-mode address)
+            // rather than 0.0.0.0, so deployed app containers are reachable
+            // only from the control-plane proxy over the private network —
+            // never on the worker's public interface. `nodes.private_address`
+            // is what the proxy already dials for cross-node routing (see
+            // `resolve_node_private_address` in temps-routes), so this is
+            // just narrowing the bind to match, not changing the routing path.
+            // `resolve_config` guarantees this is set (and is a valid IP) —
+            // legacy `agent.json` files predating this field fail fast at
+            // startup instead of silently reproducing the 0.0.0.0 exposure.
+            let host_bind_address = config.private_address.clone().ok_or_else(|| {
+                anyhow::anyhow!("private_address missing from resolved agent config")
+            })?;
+
+            // Registration deliberately allows a direct-mode node's private
+            // address to be a public IP (WireGuard-less direct networking) —
+            // see `validate_node_private_address` in temps-deployments. That
+            // means this bind can still land on a publicly reachable
+            // interface; warn so the operator knows to firewall it rather
+            // than discovering it via a port scan.
+            if let Ok(std::net::IpAddr::V4(v4)) = host_bind_address.parse::<std::net::IpAddr>() {
+                if !v4.is_private() {
+                    tracing::warn!(
+                        address = %host_bind_address,
+                        "this node's private_address is not an RFC 1918 private IP; \
+                         deployed container ports will be reachable on this address from \
+                         any network that can route to it. If this node has no WireGuard \
+                         underlay, restrict access with a host firewall."
+                    );
+                }
+            }
+
             let mut runtime_builder = temps_deployer::docker::DockerRuntime::new(
                 Arc::new(docker.clone()),
                 true,
                 network_name,
             )
-            .with_host_bind_address("0.0.0.0".to_string())
+            .with_host_bind_address(host_bind_address)
             .with_overlay_dns_slot(overlay_bridge_address.clone());
             if !overlay_network.is_empty() {
                 runtime_builder = runtime_builder
@@ -347,6 +392,33 @@ impl AgentCommand {
             .underlay_mtu
             .or_else(|| saved.as_ref().and_then(|c| c.underlay_mtu));
 
+        // Written by `temps join` (both direct and relay mode always set
+        // it) or overridden explicitly via --private-address/env for
+        // deployments that don't persist agent.json. Required: this is the
+        // address published container ports are bound to, so an agent
+        // without it would otherwise fall back to something insecure.
+        // Legacy `agent.json` files saved before this field existed must be
+        // regenerated with `temps join` before the agent will start.
+        let private_address = self
+            .private_address
+            .clone()
+            .or_else(|| saved.as_ref().and_then(|c| c.private_address.clone()))
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Missing private_address. This agent.json predates the fix that binds \
+                     published container ports to this node's private address instead of \
+                     0.0.0.0 (all interfaces). Re-run 'temps join' to update it, or pass \
+                     --private-address <ip> matching this node's registered \
+                     nodes.private_address."
+                )
+            })?;
+        private_address.parse::<std::net::IpAddr>().map_err(|_| {
+            anyhow::anyhow!(
+                "private_address '{}' is not a valid IP address",
+                private_address
+            )
+        })?;
+
         Ok(temps_agent::AgentConfig {
             listen_address,
             token,
@@ -364,6 +436,7 @@ impl AgentCommand {
             require_mtls,
             underlay_dev,
             underlay_mtu,
+            private_address: Some(private_address),
         })
     }
 

--- a/crates/temps-cli/src/commands/agent.rs
+++ b/crates/temps-cli/src/commands/agent.rs
@@ -420,10 +420,18 @@ impl AgentCommand {
         // parses as a syntactically valid IP but would silently reproduce
         // the exact all-interface exposure this whole mechanism exists to
         // close.
-        temps_deployments::handlers::nodes::validate_node_private_address(&private_address)
-            .map_err(|error| {
-                anyhow::anyhow!("private_address '{private_address}' is invalid: {error}")
-            })?;
+        //
+        // Also normalizes to a bare IP: registration tolerates a "host:port"
+        // shape for `nodes.private_address` (e.g. a scheme+port agent URL),
+        // but Docker's `PortBinding.host_ip` needs a bare address — passing
+        // a port-suffixed string straight through would fail every
+        // subsequent container creation on this node.
+        let private_address =
+            temps_deployments::handlers::nodes::validate_node_private_address(&private_address)
+                .map_err(|error| {
+                    anyhow::anyhow!("private_address '{private_address}' is invalid: {error}")
+                })?
+                .to_string();
 
         Ok(temps_agent::AgentConfig {
             listen_address,

--- a/crates/temps-cli/src/commands/join.rs
+++ b/crates/temps-cli/src/commands/join.rs
@@ -347,6 +347,27 @@ impl JoinCommand {
         let prior_token =
             prior_token_for_reenrollment(saved_config.as_ref(), node_name, self.target.as_str());
 
+        // SocketAddr's own Display brackets IPv6 automatically
+        // ("[fc00::1]:3100") -- a bare "{ip}:{port}" is unparsable as a URL
+        // authority for an IPv6 private address, since nothing marks where
+        // the address ends and the port begins. `private_address` is
+        // already a validated bare IP at this point (see above), so this
+        // only falls back to the unbracketed form if the configured
+        // `--agent-address` port isn't itself numeric.
+        let agent_port = self
+            .agent_address
+            .split(':')
+            .next_back()
+            .unwrap_or("3100")
+            .trim();
+        let agent_url_host = match (
+            private_address.parse::<std::net::IpAddr>(),
+            agent_port.parse::<u16>(),
+        ) {
+            (Ok(ip), Ok(port)) => std::net::SocketAddr::new(ip, port).to_string(),
+            _ => format!("{}:{}", private_address, agent_port),
+        };
+
         let register_body = serde_json::json!({
             "name": node_name,
             "token": agent_token,
@@ -355,7 +376,7 @@ impl JoinCommand {
             // The control plane may still accept an old CSR-less HTTP worker
             // during migration, but a newly enrolled worker must never be
             // persisted as plaintext.
-            "address": format!("https://{}:{}", private_address.trim(), self.agent_address.split(':').next_back().unwrap_or("3100").trim()),
+            "address": format!("https://{}", agent_url_host),
             "private_address": private_address,
             "labels": labels,
             "architecture": platform,

--- a/crates/temps-cli/src/commands/join.rs
+++ b/crates/temps-cli/src/commands/join.rs
@@ -106,6 +106,33 @@ fn prior_token_for_reenrollment(
     (saved.node_name == node_name && same_control_plane).then(|| saved.token.clone())
 }
 
+/// Extract the port `temps agent` will listen on from `--agent-address`.
+/// Uses `SocketAddr::from_str` rather than a manual `.split(':').next_back()`
+/// so a bracketed IPv6 address with no port (e.g. "[::1]") doesn't glue the
+/// closing bracket onto the extracted "port" -- falls back to the default
+/// agent port only when `agent_address` isn't a parsable socket address at
+/// all.
+fn agent_listen_port(agent_address: &str) -> u16 {
+    agent_address
+        .parse::<std::net::SocketAddr>()
+        .map(|addr| addr.port())
+        .unwrap_or(3100)
+}
+
+/// Build a "host:port" URL authority, bracketing IPv6 the way
+/// `SocketAddr`'s `Display` does ("[fc00::1]:3100") -- a bare
+/// "{ip}:{port}" is unparsable for IPv6 since nothing marks where the
+/// address ends and the port begins. Falls back to the unbracketed form
+/// only if `ip` isn't itself a parsable IP address (shouldn't happen for a
+/// validated `private_address`, but this must never produce a *worse*
+/// address than the naive concatenation it replaces).
+fn socket_authority(ip: &str, port: u16) -> String {
+    match ip.parse::<std::net::IpAddr>() {
+        Ok(ip) => std::net::SocketAddr::new(ip, port).to_string(),
+        Err(_) => format!("{ip}:{port}"),
+    }
+}
+
 /// Generate a per-node keypair + CSR. The private key never leaves this host.
 /// `ip` is the address the control plane will connect to (the node's
 /// private/WG IP) and MUST be a SAN, or the CP's server-cert hostname check
@@ -347,26 +374,8 @@ impl JoinCommand {
         let prior_token =
             prior_token_for_reenrollment(saved_config.as_ref(), node_name, self.target.as_str());
 
-        // SocketAddr's own Display brackets IPv6 automatically
-        // ("[fc00::1]:3100") -- a bare "{ip}:{port}" is unparsable as a URL
-        // authority for an IPv6 private address, since nothing marks where
-        // the address ends and the port begins. `private_address` is
-        // already a validated bare IP at this point (see above), so this
-        // only falls back to the unbracketed form if the configured
-        // `--agent-address` port isn't itself numeric.
-        let agent_port = self
-            .agent_address
-            .split(':')
-            .next_back()
-            .unwrap_or("3100")
-            .trim();
-        let agent_url_host = match (
-            private_address.parse::<std::net::IpAddr>(),
-            agent_port.parse::<u16>(),
-        ) {
-            (Ok(ip), Ok(port)) => std::net::SocketAddr::new(ip, port).to_string(),
-            _ => format!("{}:{}", private_address, agent_port),
-        };
+        let agent_port = agent_listen_port(&self.agent_address);
+        let agent_url_host = socket_authority(private_address, agent_port);
 
         let register_body = serde_json::json!({
             "name": node_name,
@@ -713,7 +722,35 @@ async fn detect_public_endpoint(wg_port: u16) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::prior_token_for_reenrollment;
+    use super::{agent_listen_port, prior_token_for_reenrollment, socket_authority};
+
+    #[test]
+    fn agent_listen_port_reads_ipv4_socket_addr() {
+        assert_eq!(agent_listen_port("127.0.0.1:3100"), 3100);
+    }
+
+    #[test]
+    fn agent_listen_port_reads_bracketed_ipv6_socket_addr() {
+        assert_eq!(agent_listen_port("[::1]:8080"), 8080);
+    }
+
+    #[test]
+    fn agent_listen_port_falls_back_when_bracketed_ipv6_has_no_port() {
+        // Regression guard: a naive `.split(':').next_back()` on "[::1]"
+        // (no port) would glue the closing bracket onto the extracted
+        // "port" instead of recognizing there isn't one.
+        assert_eq!(agent_listen_port("[::1]"), 3100);
+    }
+
+    #[test]
+    fn socket_authority_brackets_ipv6() {
+        assert_eq!(socket_authority("fc00::1", 3100), "[fc00::1]:3100");
+    }
+
+    #[test]
+    fn socket_authority_leaves_ipv4_unbracketed() {
+        assert_eq!(socket_authority("10.0.5.20", 3100), "10.0.5.20:3100");
+    }
 
     fn saved_config() -> temps_agent::AgentConfig {
         temps_agent::AgentConfig {

--- a/crates/temps-cli/src/commands/join.rs
+++ b/crates/temps-cli/src/commands/join.rs
@@ -392,6 +392,7 @@ impl JoinCommand {
             require_mtls: register_response.mtls_required,
             underlay_dev: self.underlay_dev.clone(),
             underlay_mtu: self.underlay_mtu,
+            private_address: Some(private_address.trim().to_string()),
         };
         self.save_agent_config(&config)?;
 
@@ -574,6 +575,7 @@ impl JoinCommand {
             require_mtls: register_response.mtls_required,
             underlay_dev: self.underlay_dev.clone(),
             underlay_mtu: self.underlay_mtu,
+            private_address: Some(relay_response.assigned_ip.clone()),
         };
         self.save_agent_config(&config)?;
 
@@ -692,6 +694,7 @@ mod tests {
             require_mtls: false,
             underlay_dev: None,
             underlay_mtu: None,
+            private_address: Some("10.100.0.7".to_string()),
         }
     }
 

--- a/crates/temps-cli/src/commands/join.rs
+++ b/crates/temps-cli/src/commands/join.rs
@@ -305,6 +305,21 @@ impl JoinCommand {
         labels: &serde_json::Value,
         platform: Option<&str>,
     ) -> anyhow::Result<()> {
+        // Reject dangerous ranges up front, and normalize to a bare IP: the
+        // "address" field built below appends its own port
+        // (`https://{private_address}:{agent_port}`), and the control plane
+        // does the same when constructing proxy backend addresses from the
+        // stored `nodes.private_address` -- a port-suffixed value here would
+        // corrupt both, independent of the server's own validation.
+        let private_address = temps_deployments::handlers::nodes::validate_node_private_address(
+            private_address.trim(),
+        )
+        .map(|ip| ip.to_string())
+        .map_err(|error| {
+            anyhow::anyhow!("--private-address '{private_address}' is invalid: {error}")
+        })?;
+        let private_address = private_address.as_str();
+
         println!(
             "Using direct mode with private address: {}",
             private_address

--- a/crates/temps-deployer/src/docker.rs
+++ b/crates/temps-deployer/src/docker.rs
@@ -666,7 +666,9 @@ pub struct DockerRuntime {
     docker: Arc<Docker>,
     use_buildkit: bool,
     network_name: String,
-    /// Address to bind host ports to (e.g. "127.0.0.1" for local, "0.0.0.0" for remote agents)
+    /// Address to bind host ports to: "127.0.0.1" for the control plane's
+    /// own local containers, or a worker agent's private/overlay address
+    /// (never "0.0.0.0" — see [`Self::with_host_bind_address`]).
     host_bind_address: String,
     /// Optional secondary network for multi-host overlay (e.g. "temps-overlay").
     /// When set, every container is additionally connected to this network
@@ -1187,7 +1189,11 @@ impl DockerRuntime {
     }
 
     /// Set the host bind address for container port mappings.
-    /// Use "0.0.0.0" on agent nodes so containers are reachable from the private network.
+    /// On agent (worker) nodes, pass the node's private/overlay address
+    /// (`AgentConfig::private_address`) so published container ports are
+    /// reachable from the control-plane proxy over the private network but
+    /// never on the node's public interface. Never pass "0.0.0.0" — Docker
+    /// treats it as "bind every interface", including any public one.
     pub fn with_host_bind_address(mut self, address: String) -> Self {
         self.host_bind_address = address;
         self

--- a/crates/temps-deployments/src/handlers/nodes.rs
+++ b/crates/temps-deployments/src/handlers/nodes.rs
@@ -642,7 +642,14 @@ impl std::fmt::Display for NodeAddressError {
 /// Workers that use public IPs with a WireGuard underlay are intentionally
 /// allowed — the goal is to block dangerous special-purpose ranges, not enforce
 /// private-only addressing.
-fn validate_node_private_address(addr: &str) -> Result<(), NodeAddressError> {
+///
+/// `pub`: also called from `temps-cli`'s `temps agent --private-address`/
+/// `TEMPS_AGENT_PRIVATE_ADDRESS` override resolution, so a manually supplied
+/// address gets the identical rejection of dangerous ranges (in particular
+/// `0.0.0.0`, which would otherwise silently reproduce the all-interface
+/// container-port exposure this whole registration check exists to prevent)
+/// that a `temps join`-registered address already gets server-side.
+pub fn validate_node_private_address(addr: &str) -> Result<(), NodeAddressError> {
     use std::net::IpAddr;
 
     // Strip an optional port suffix (handles both "10.0.5.20" and "10.0.5.20:8443").

--- a/crates/temps-deployments/src/handlers/nodes.rs
+++ b/crates/temps-deployments/src/handlers/nodes.rs
@@ -649,7 +649,14 @@ impl std::fmt::Display for NodeAddressError {
 /// `0.0.0.0`, which would otherwise silently reproduce the all-interface
 /// container-port exposure this whole registration check exists to prevent)
 /// that a `temps join`-registered address already gets server-side.
-pub fn validate_node_private_address(addr: &str) -> Result<(), NodeAddressError> {
+///
+/// Returns the bare `IpAddr` with any port suffix stripped (registration
+/// tolerates `host:port`/`[ipv6]:port`, matching `node_address_host`'s
+/// scheme+port stripping below, but a caller that binds Docker container
+/// ports to this address — see `temps-agent` — needs the bare host: passing
+/// a `host:port` string straight to Docker's `PortBinding.host_ip` is not a
+/// valid IP and fails every container creation).
+pub fn validate_node_private_address(addr: &str) -> Result<std::net::IpAddr, NodeAddressError> {
     use std::net::IpAddr;
 
     // Strip an optional port suffix (handles both "10.0.5.20" and "10.0.5.20:8443").
@@ -751,7 +758,7 @@ pub fn validate_node_private_address(addr: &str) -> Result<(), NodeAddressError>
         }
     }
 
-    Ok(())
+    Ok(ip)
 }
 
 /// Extract the host from a validated node agent URL or private address for use
@@ -3878,6 +3885,20 @@ mod tests {
             validate_node_private_address("10.0.5.20:8443").is_ok(),
             "10.0.5.20:8443 must be accepted (RFC-1918 with port)"
         );
+    }
+
+    #[test]
+    fn test_validate_node_private_address_strips_port_from_returned_ip() {
+        // Regression guard: a caller that binds Docker container ports to
+        // this address (temps-agent) needs the bare host, since Docker's
+        // PortBinding.host_ip is not a valid IP with a port suffix attached
+        // -- every container creation would fail if the raw "host:port"
+        // input were forwarded unchanged instead of the parsed IpAddr.
+        let ip = validate_node_private_address("10.0.5.20:8443").expect("accepted with port");
+        assert_eq!(ip.to_string(), "10.0.5.20");
+
+        let ip = validate_node_private_address("[fc00::1]:8443").expect("accepted with port");
+        assert_eq!(ip.to_string(), "fc00::1");
     }
 
     #[test]

--- a/crates/temps-deployments/src/handlers/nodes.rs
+++ b/crates/temps-deployments/src/handlers/nodes.rs
@@ -666,15 +666,19 @@ pub fn validate_node_private_address(addr: &str) -> Result<std::net::IpAddr, Nod
         // Bracketed IPv6 — either "[::1]" or "[::1]:port"
         stripped.split(']').next().unwrap_or(addr)
     } else {
-        // Plain IPv4 or bare IPv6: split on last ':' to strip port, but only
-        // if what remains before the ':' parses as an IP (so we don't strip
-        // the last group of a bare IPv6 address like "fc00::1").
-        if let Some((before, _after)) = addr.rsplit_once(':') {
-            if before.parse::<IpAddr>().is_ok() {
-                before
-            } else {
-                addr
-            }
+        // Disambiguate by colon count, not by "does the prefix also happen
+        // to parse as an IP" -- that heuristic is unsound for unbracketed
+        // IPv6: plenty of valid bare addresses (e.g. "2001:db8::1:2") have a
+        // last hextet that looks like a "port" AND a prefix that is itself
+        // an independently valid IPv6 address, so it would silently
+        // truncate them to the wrong host. RFC 3986 requires brackets for
+        // an IPv6 host:port, so an unbracketed address is unambiguous by
+        // colon count alone: any bare IPv6 address needs at least two
+        // colons (minimum form "::"), so exactly one colon can only mean
+        // IPv4:port.
+        if addr.matches(':').count() == 1 {
+            addr.rsplit_once(':')
+                .map_or(addr, |(before, _after)| before)
         } else {
             addr
         }
@@ -3983,6 +3987,21 @@ mod tests {
             validate_node_private_address("fc00::1").is_ok(),
             "fc00::1 must be accepted (unique-local IPv6)"
         );
+    }
+
+    #[test]
+    fn test_validate_node_private_address_never_truncates_bare_ipv6_with_ambiguous_prefix() {
+        // Regression guard: "2001:db8::1:2"'s prefix before the last colon
+        // ("2001:db8::1") is itself a valid, DIFFERENT IPv6 address, so a
+        // naive "does the prefix parse as an IP" port-stripping heuristic
+        // would wrongly truncate this bare address down to that prefix,
+        // silently changing which host gets used. Any multi-colon
+        // unbracketed address must be preserved whole.
+        let ip = validate_node_private_address("2001:db8::1:2").expect("valid bare IPv6 address");
+        assert_eq!(ip.to_string(), "2001:db8::1:2");
+
+        let ip = validate_node_private_address("fc00::1:2").expect("valid bare IPv6 address");
+        assert_eq!(ip.to_string(), "fc00::1:2");
     }
 
     #[test]

--- a/crates/temps-deployments/src/handlers/nodes.rs
+++ b/crates/temps-deployments/src/handlers/nodes.rs
@@ -1047,17 +1047,24 @@ async fn register_node(
 
     // ── Address validation (SSRF guard) ──────────────────────────────────────
     // Reject private_address values in reserved/dangerous ranges before they
-    // can be persisted and later used to build health-check URLs.
-    validate_node_private_address(request.private_address.trim()).map_err(|e| {
-        warn!(
-            "Node registration rejected: invalid private_address '{}': {}",
-            request.private_address.trim(),
-            e
-        );
-        problemdetails::new(StatusCode::BAD_REQUEST)
-            .with_title("Invalid Node Address")
-            .with_detail(e.to_string())
-    })?;
+    // can be persisted and later used to build health-check URLs. Store the
+    // normalized bare IP, not the raw request value: route_table.rs's
+    // build_container_backend_addr appends its own port to whatever is
+    // stored here (`format!("{private_addr}:{port}")`), so a port-suffixed
+    // value persisted verbatim would corrupt every proxy backend address
+    // built for this node.
+    let private_address = validate_node_private_address(request.private_address.trim())
+        .map_err(|e| {
+            warn!(
+                "Node registration rejected: invalid private_address '{}': {}",
+                request.private_address.trim(),
+                e
+            );
+            problemdetails::new(StatusCode::BAD_REQUEST)
+                .with_title("Invalid Node Address")
+                .with_detail(e.to_string())
+        })?
+        .to_string();
 
     // The `address` field is also user-supplied (used as the deployer agent URL).
     // Extract the host portion and apply the same check.
@@ -1126,7 +1133,7 @@ async fn register_node(
         // CSR SANs are discarded by sign_node_csr so one worker cannot mint a
         // certificate valid for another cluster identity.
         let mut allowed_sans = vec![request.name.trim().to_string()];
-        for address in [&registered_address, request.private_address.trim()] {
+        for address in [&registered_address, &private_address] {
             let host = node_address_host(address);
             if !host.is_empty() && !allowed_sans.contains(&host) {
                 allowed_sans.push(host);
@@ -1149,7 +1156,7 @@ async fn register_node(
         token_hash,
         token_encrypted: Some(token_encrypted),
         address: registered_address,
-        private_address: request.private_address.trim().to_string(),
+        private_address,
         public_endpoint: request.public_endpoint,
         wg_public_key: request.wg_public_key,
         role: request.role.unwrap_or_else(|| "worker".to_string()),

--- a/crates/temps-routes/src/route_table.rs
+++ b/crates/temps-routes/src/route_table.rs
@@ -218,9 +218,19 @@ fn build_container_backend_addr(
     runtime_context: &RuntimeContext,
 ) -> String {
     if let Some(private_addr) = node_private_address {
-        // Remote node: use the node's private/WireGuard IP with host_port
+        // Remote node: use the node's private/WireGuard IP with host_port.
+        // `SocketAddr`'s own Display brackets IPv6 automatically
+        // ("[fc00::1]:5432") -- a bare `format!("{ip}:{port}")` produces an
+        // unparsable authority for any IPv6 private address, since nothing
+        // marks where the address ends and the port begins.
         let port = host_port.unwrap_or(container_port);
-        format!("{}:{}", private_addr, port)
+        match private_addr.parse::<std::net::IpAddr>() {
+            Ok(ip) => std::net::SocketAddr::new(ip, port as u16).to_string(),
+            // nodes.private_address is validated as a bare IP at
+            // registration; this only defends a pre-existing row from
+            // before that validation existed.
+            Err(_) => format!("{}:{}", private_addr, port),
+        }
     } else {
         let endpoint = runtime_context.resolve_service_endpoint(
             container_name,
@@ -2941,6 +2951,22 @@ mod tests {
             &RuntimeContext::host(),
         );
         assert_eq!(addr, "10.100.0.5:3000");
+    }
+
+    #[test]
+    fn test_build_container_backend_addr_remote_brackets_ipv6() {
+        // Regression guard: a bare "{ip}:{port}" is unparsable for an IPv6
+        // node's private address -- nothing marks where the address ends
+        // and the port begins. The proxy must dial "[fc00::1]:8080", not
+        // "fc00::1:8080" (which parses as a different, wrong IPv6 address).
+        let addr = build_container_backend_addr(
+            "my-app",
+            3000,
+            Some(8080),
+            Some("fc00::1"),
+            &RuntimeContext::host(),
+        );
+        assert_eq!(addr, "[fc00::1]:8080");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Every container a worker node's `temps agent` published — both app deploys (via `DockerRuntime`) and services created directly through the agent's HTTP API (managed databases, Redis, etc., via `service_handlers`) — bound its host port to `0.0.0.0`, all interfaces, including any public one. That bypasses the control-plane proxy (auth, TLS termination, routing) entirely: anyone who can reach the node's public IP directly could hit the raw container port.
- `temps join` already registers a node's private/overlay address (`nodes.private_address` — the WireGuard tunnel IP in relay mode, the operator-supplied address in direct mode) and now saves it into `agent.json`. `temps agent` requires it at startup (hard error with a recovery path if a legacy `agent.json` predates the field) and binds both app and service containers to it instead of `0.0.0.0`. Direct-mode nodes that register a non-RFC1918 address get a startup warning recommending a host firewall, since that mode intentionally allows a public IP with no WireGuard underlay.
- This is the agent-side half of the fail-closed check already living in `deploy_image.rs`, which refuses to retain or route an app container unless it can confirm the worker actually bound it to the private address — every deployment to an agent node has been failing against that check until this fix ships.

## Test plan

- [x] `cargo check --lib -p temps-agent -p temps-cli -p temps-deployer` — clean
- [x] `cargo test -p temps-agent --lib` — 106 passed (includes new regression test)
- [x] `cargo test -p temps-cli --lib -- commands::agent:: commands::join::` — 6 passed
- [x] `cargo test -p temps-deployer --lib -- docker::` — 79 passed
- [x] `$(command -v cargo) clippy -p temps-agent -p temps-cli -p temps-deployer --lib --tests -- -D warnings` — clean
- [x] `cargo fmt --check` on all touched crates — clean
- [x] Security-reviewed in two passes (core `DockerRuntime`/`temps join`/`temps agent` fix, then the `service_handlers.rs` extension for service containers) — no blocking findings; added a unit test (`service_port_binding_tests::never_binds_to_all_interfaces`) guarding against the exact hardcoded-`0.0.0.0` regression this fixes