### PR TITLE
fix(web): map catalog-only preset slugs before requesting managed env vars

### DIFF
--- a/web/src/components/project/ProvidedEnvironmentVariables.test.ts
+++ b/web/src/components/project/ProvidedEnvironmentVariables.test.ts
@@ -18,6 +18,20 @@ describe('ProvidedEnvironmentVariables', () => {
     expect(normalizeCreationPreset('')).toBe('dockerfile')
   })
 
+  test('maps catalog-only slugs to a preset the backend recognizes', () => {
+    // `nixpacks-node` and `nixpacks-static` are grouped catalog slugs from
+    // `PresetInfo::catalog_slug()` (crates/temps-presets) — they aren't in
+    // `Preset::from_str`'s vocabulary and must be aliased down, or
+    // `/deployments/managed-environment-variables` 400s with "Unknown
+    // Deployment Preset".
+    expect(normalizeCreationPreset('nixpacks-node')).toBe('nodejs')
+    expect(normalizeCreationPreset('nixpacks-static')).toBe('static')
+    expect(normalizeCreationPreset('nixpacks-node::apps/web')).toBe('nodejs')
+    // Other nixpacks-prefixed or bare presets are untouched.
+    expect(normalizeCreationPreset('nixpacks')).toBe('nixpacks')
+    expect(normalizeCreationPreset('nixpacks-python')).toBe('nixpacks-python')
+  })
+
   test('groups backend variables in a stable user-facing order', () => {
     const variables: ManagedEnvironmentVariable[] = [
       {

--- a/web/src/lib/provided-environment-variables.test.ts
+++ b/web/src/lib/provided-environment-variables.test.ts
@@ -11,7 +11,7 @@ import {
   normalizeCreationPreset,
 } from '@/lib/provided-environment-variables'
 
-describe('ProvidedEnvironmentVariables', () => {
+describe('provided-environment-variables', () => {
   test('normalizes repository presets and keeps only the preset slug', () => {
     expect(normalizeCreationPreset('NextJS::apps/web')).toBe('nextjs')
     expect(normalizeCreationPreset('custom')).toBe('static')

--- a/web/src/lib/provided-environment-variables.ts
+++ b/web/src/lib/provided-environment-variables.ts
@@ -18,9 +18,22 @@ const SOURCE_ORDER: ManagedEnvironmentVariableSource[] = [
   'temps',
 ]
 
+/// Catalog-only slugs produced by `PresetInfo::catalog_slug()`
+/// (`crates/temps-presets`) that group several frameworks under one buildable
+/// entry. They aren't in the backend's `Preset::from_str` vocabulary, so they
+/// must be mapped to the closest preset it does recognize before being sent
+/// to `/deployments/managed-environment-variables`.
+const CATALOG_ONLY_PRESET_ALIASES: Record<string, string> = {
+  'nixpacks-node': 'nodejs',
+  'nixpacks-static': 'static',
+}
+
 export function normalizeCreationPreset(preset: string): string {
   const [name] = preset.split('::')
   const normalized = name.trim().toLowerCase() || 'dockerfile'
+  if (normalized in CATALOG_ONLY_PRESET_ALIASES) {
+    return CATALOG_ONLY_PRESET_ALIASES[normalized]
+  }
   return normalized === 'custom' ? 'static' : normalized
 }
 


### PR DESCRIPTION
## Summary
- `PresetInfo::catalog_slug()` (`crates/temps-presets`) collapses several Node.js-family frameworks (Astro, Nuxt, Remix, SvelteKit, SolidStart, Angular, Vue, plain Node.js) into the synthetic catalog slug `nixpacks-node`, and the static preset into `nixpacks-static`. These are UI/catalog-only groupings — they were never added to the backend's `Preset::from_str` vocabulary (`crates/temps-entities/src/preset.rs`), which only understands framework-level slugs like `nodejs` and `static`.
- Any project stored with one of these catalog slugs hit `GET /deployments/managed-environment-variables?preset=nixpacks-node`, which 400s with "Unknown Deployment Preset" — silently dropping the platform-provided environment variable suggestions (Sentry DSN, OTel, Temps platform vars) shown during project setup.
- `normalizeCreationPreset` (`web/src/lib/provided-environment-variables.ts`) already existed specifically to reconcile the stored preset value with what this endpoint accepts (it already handles the `preset::subdirectory` and `custom` cases) — extended it to alias the two catalog-only slugs to their backend-recognized equivalents.

## Test plan
- [x] `bun test src/components/project/ProvidedEnvironmentVariables.test.ts` — 6 pass, added coverage for `nixpacks-node` → `nodejs`, `nixpacks-static` → `static`, plus the `preset::subdirectory` form and a negative case confirming unrelated slugs are untouched
- [x] `bun run eslint --fix` on both changed files — clean
- [ ] Manual verification: open project creation/settings for a repo whose detected preset is `nixpacks-node` and confirm the "Provided environment variables" panel loads instead of erroring