### PR TITLE
fix(cloud): human-readable source label for control-plane backups

### DIFF
--- a/crates/temps-cloud/src/backup_mirror.rs
+++ b/crates/temps-cloud/src/backup_mirror.rs
@@ -1017,7 +1017,8 @@ async fn mirror_native_backup(
 /// Cloud. Factored out of `mirror_native_backup` so [`mirror_control_plane_backup`]
 /// can reuse the same declare/upload/complete sequence without duplicating
 /// it -- `source` is the only thing that differs (a `service_type/name` label
-/// for customer services, `control_plane/{name}` for the control plane).
+/// for customer services, the static `control_plane/control-plane` for the
+/// control plane, which is singular per instance).
 #[allow(clippy::too_many_arguments)]
 async fn declare_and_complete_native_snapshot(
     link: &CloudLink,
@@ -1156,7 +1157,7 @@ async fn mirror_control_plane_backup(
         instance_id,
         &source_config,
         &client,
-        format!("control_plane/{}", backup.name),
+        "control_plane/control-plane".to_string(),
         BackupEngine::Postgres,
         BackupFormat::PgDumpPlain,
         BackupCompression::Gzip,


### PR DESCRIPTION
## Summary
- `mirror_control_plane_backup` labelled every mirrored control-plane backup as `control_plane/Backup <uuid>` in Temps Cloud's Source column, since it reused `backup.name` (an auto-generated `"Backup {uuid}"` string with no `external_services` row to draw a friendlier name from).
- There's exactly one control plane per instance, so the UUID added no disambiguating value — the `Created` timestamp and the deterministic `cloud_backup_id` already do that job.
- Replaced with the static label `control_plane/control-plane`, matching what the existing `temps-app-backups` test fixture already expects.

## Test plan
- [x] `cargo check --lib -p temps-cloud`
- [x] `cargo fmt` / `cargo clippy -p temps-cloud --lib --tests -- -D warnings`
- [x] security-auditor review: no findings (display-only string, `backup_id`/UUID-v5 remains the identity/dedup key, unaffected)