### PR TITLE
feat(cloud-protocol): report the source database's actual Docker image

### DIFF
--- a/crates/temps-cloud-protocol/src/messages.rs
+++ b/crates/temps-cloud-protocol/src/messages.rs
@@ -328,6 +328,25 @@ pub struct NativeSnapshotRequest {
     pub compression: BackupCompression,
     pub identity: NativeSnapshotIdentity,
     pub objects: Vec<NativeSnapshotObjectDeclaration>,
+    /// The Docker image (repository:tag) the source database actually runs
+    /// on, when the instance can determine it -- e.g. the control plane's
+    /// own database, or a customer external service's configured
+    /// `docker_image`. Lets a downstream restore script use the exact same
+    /// image instead of guessing a generic one from `engine`/`format` alone,
+    /// which cannot distinguish a plain Postgres image from an
+    /// extension-bearing one (TimescaleDB, pgvector, ...) sharing the same
+    /// engine and format. `None` when the source image can't be determined
+    /// (e.g. an externally managed database Temps didn't deploy) -- the
+    /// consumer must keep a sensible generic fallback for that case.
+    ///
+    /// This value is reported by the instance and is not trusted input: a
+    /// consumer that runs `source_image` (e.g. `docker run`/`docker pull`)
+    /// MUST validate it against an allowlist first, the same way this repo's
+    /// own `TEMPS_ALLOWED_POSTGRES_DOCKER_IMAGES` gates which images an
+    /// instance may pull -- never interpolate it into a shell command
+    /// unvalidated.
+    #[serde(default)]
+    pub source_image: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1041,6 +1060,7 @@ mod tests {
                 bytes: 1_024,
                 checksum_sha256: "ab".repeat(32),
             }],
+            source_image: None,
         };
 
         let value = serde_json::to_value(request).unwrap();

--- a/crates/temps-cloud/src/backup_mirror.rs
+++ b/crates/temps-cloud/src/backup_mirror.rs
@@ -1009,6 +1009,9 @@ async fn mirror_native_backup(
         identity,
         &root,
         &selected,
+        // Customer external-service source image threading is deferred --
+        // the recovery script falls back to a generic image for this path.
+        None,
     )
     .await
 }
@@ -1034,6 +1037,7 @@ async fn declare_and_complete_native_snapshot(
     identity: NativeSnapshotIdentity,
     root: &str,
     selected: &[SourceObject],
+    source_image: Option<String>,
 ) -> Result<(), StageError> {
     let mut declarations = Vec::with_capacity(selected.len());
     for object in selected {
@@ -1084,6 +1088,7 @@ async fn declare_and_complete_native_snapshot(
         compression,
         identity,
         objects: declarations.clone(),
+        source_image,
     };
     let snapshot = link
         .declare_native_snapshot(&request)
@@ -1150,6 +1155,10 @@ async fn mirror_control_plane_backup(
             "control_plane backup {location_key} is incomplete or lacks {metadata_key}"
         )));
     }
+    let source_image = format!(
+        "gotempsh/timescaledb-walg:pg{}",
+        control_plane_postgres_major(resources).await?
+    );
     declare_and_complete_native_snapshot(
         link,
         resources,
@@ -1166,6 +1175,7 @@ async fn mirror_control_plane_backup(
         },
         &root,
         &selected,
+        Some(source_image),
     )
     .await
 }
@@ -1989,35 +1999,44 @@ async fn load_postgres_identity(
             major,
         ))
     } else {
-        let major = if let Some(major) = resources.control_plane_postgres_major {
-            major
-        } else {
-            let row = resources
-                .db
-                .query_one(Statement::from_string(
-                    resources.db.get_database_backend(),
-                    "SELECT current_setting('server_version') AS server_version".to_string(),
-                ))
-                .await
-                .map_err(|error| StageError::Retry(error.to_string()))?
-                .ok_or_else(|| {
-                    StageError::Retry("PostgreSQL did not return server_version".into())
-                })?;
-            let version: String = row
-                .try_get("", "server_version")
-                .map_err(|error| StageError::Retry(error.to_string()))?;
-            let major = parse_postgres_major(Some(&version)).ok_or_else(|| {
-                StageError::Unsupported(format!("unsupported PostgreSQL version {version}"))
-            })?;
-            resources.control_plane_postgres_major = Some(major);
-            major
-        };
+        let major = control_plane_postgres_major(resources).await?;
         Ok((
             "postgres/control-plane".into(),
             BackupEngine::Postgres,
             major,
         ))
     }
+}
+
+/// The control plane's own PostgreSQL major version, cached on
+/// [`SweepResources`] after the first query since it cannot change within a
+/// sweep. Shared by [`load_postgres_identity`]'s control-plane branch (a real
+/// WAL-G repository backup routed through the Postgres/TimescaleDB WAL-G
+/// path) and [`mirror_control_plane_backup`] (the control plane's own
+/// pg_dump-shaped backup, which never has an `external_services` row).
+async fn control_plane_postgres_major(
+    resources: &mut SweepResources<'_>,
+) -> Result<u16, StageError> {
+    if let Some(major) = resources.control_plane_postgres_major {
+        return Ok(major);
+    }
+    let row = resources
+        .db
+        .query_one(Statement::from_string(
+            resources.db.get_database_backend(),
+            "SELECT current_setting('server_version') AS server_version".to_string(),
+        ))
+        .await
+        .map_err(|error| StageError::Retry(error.to_string()))?
+        .ok_or_else(|| StageError::Retry("PostgreSQL did not return server_version".into()))?;
+    let version: String = row
+        .try_get("", "server_version")
+        .map_err(|error| StageError::Retry(error.to_string()))?;
+    let major = parse_postgres_major(Some(&version)).ok_or_else(|| {
+        StageError::Unsupported(format!("unsupported PostgreSQL version {version}"))
+    })?;
+    resources.control_plane_postgres_major = Some(major);
+    Ok(major)
 }
 
 fn s3_client(


### PR DESCRIPTION
## Summary
- Add `source_image: Option<String>` to `NativeSnapshotRequest` so an instance can report the Docker image its source database actually runs on, when known.
- Populate it for the control-plane's own backup path (`gotempsh/timescaledb-walg:pg{major}`, derived from the control plane's own Postgres major version -- not user input). Customer external-service backups keep reporting `None` for now; threading their configured `docker_image` through is deferred to a follow-up.
- Extract `control_plane_postgres_major` as a shared helper (previously inlined only in `load_postgres_identity`), now also used by `mirror_control_plane_backup`.

## Why
Cloud generates a downloadable restore script for pg_dump-shaped backups and previously had to *guess* which Docker image to restore into from `engine`/`format` strings alone. That guess broke in production for control-plane backups: they're TimescaleDB-backed, but `engine` is always reported as plain `"postgres"`, so the script picked a plain Postgres image (missing the extension) and the wrong data-directory mount path. Reporting the real image removes the guesswork at the source instead of adding another string heuristic downstream.

## Security
Reviewed by `security-auditor`: approved with a non-blocking note that `source_image` is instance-reported, untrusted input, and any future consumer that executes it (`docker run`/`docker pull`) must validate it against an allowlist first -- the same pattern as this repo's own `TEMPS_ALLOWED_POSTGRES_DOCKER_IMAGES`. Added that requirement explicitly to the field's doc comment.

## Test plan
- [x] `cargo check --lib -p temps-cloud-protocol -p temps-cloud`
- [x] `cargo test --lib -p temps-cloud-protocol -p temps-cloud` (102 passed)
- [x] `cargo fmt` (scoped to the two changed files)
- [x] `cargo clippy -p temps-cloud-protocol -p temps-cloud --all-targets -- -D warnings` (clean)
- [x] `python3 scripts/source_attribution.py check`