### PR TITLE
fix(backup): fail s3_mirror on Access Denied during comparison listing

### DIFF
--- a/crates/temps-backup/src/engines/control_plane.rs
+++ b/crates/temps-backup/src/engines/control_plane.rs
@@ -213,6 +213,7 @@ impl BackupEngine for ControlPlaneEngine {
             // control-plane Postgres binds under `temps serve`.
             network_mode: Some("host".to_string()),
             user: Some("root".to_string()),
+            stderr_watch: None,
         };
 
         let result = match run_one_shot(&docker, spec, &ctx.cancel).await {

--- a/crates/temps-backup/src/engines/mongodb.rs
+++ b/crates/temps-backup/src/engines/mongodb.rs
@@ -221,6 +221,7 @@ impl BackupEngine for MongodbEngine {
             binds: vec![format!("{}:/backup:rw", backup_dir.display())],
             network_mode: Some(temps_core::NETWORK_NAME.to_string()),
             user: Some("root".to_string()),
+            stderr_watch: None,
         };
 
         let result = match run_one_shot(&deps.docker, spec, &ctx.cancel).await {

--- a/crates/temps-backup/src/engines/oneshot.rs
+++ b/crates/temps-backup/src/engines/oneshot.rs
@@ -42,6 +42,8 @@
 //! after the container exits).
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use bollard::container::LogOutput;
@@ -281,8 +283,14 @@ pub async fn run_one_shot(
 
     let mut stdout_tail = RingBuffer::with_capacity(4 * 1024);
     let mut stderr_tail = RingBuffer::with_capacity(4 * 1024);
-    let mut stderr_watch_matched = false;
     let stderr_watch = spec.stderr_watch;
+    // The watch verdict lives outside the collector task. The collector
+    // publishes a match the moment it sees one, so the verdict survives even
+    // if the caller stops waiting for the collector to drain (below): a
+    // verdict that only travelled through the task's return value was lost
+    // on a drain timeout, and an exit-0 container whose stderr had already
+    // shown the watched diagnostic was then reported as a clean success.
+    let stderr_watch_flag = Arc::new(AtomicBool::new(false));
 
     // ── Log collector (background task) ──────────────────────────────────
     //
@@ -292,30 +300,12 @@ pub async fn run_one_shot(
     let log_handle = match attach {
         Ok(attach_results) => {
             let stream = attach_results.output;
-            Some(tokio::spawn(async move {
-                let mut stream = stream;
-                let mut stdout = RingBuffer::with_capacity(4 * 1024);
-                let mut stderr = RingBuffer::with_capacity(4 * 1024);
-                let mut watcher = stderr_watch.map(SubstringWatcher::new);
-                while let Some(chunk) = stream.next().await {
-                    match chunk {
-                        Ok(LogOutput::StdOut { message }) => stdout.append(&message),
-                        Ok(LogOutput::StdErr { message }) => {
-                            if let Some(watcher) = watcher.as_mut() {
-                                watcher.feed(&message);
-                            }
-                            stderr.append(&message)
-                        }
-                        Ok(_) => {}
-                        Err(e) => {
-                            debug!(error = %e, "one_shot: log stream error (non-fatal)");
-                            break;
-                        }
-                    }
-                }
-                let matched = watcher.is_some_and(|w| w.matched());
-                (stdout, stderr, matched)
-            }))
+            let watch_flag = Arc::clone(&stderr_watch_flag);
+            Some(tokio::spawn(collect_logs(
+                stream,
+                stderr_watch.map(SubstringWatcher::new),
+                watch_flag,
+            )))
         }
         Err(e) => {
             warn!(error = %e, "one_shot: attach failed; will run without log capture");
@@ -368,25 +358,46 @@ pub async fn run_one_shot(
         }
     };
 
-    // Give the log collector up to 2 seconds to drain anything still in
-    // the pipe before we hand back to the caller.
+    // Give the log collector time to drain anything still in the pipe
+    // before we hand back to the caller. The tails are diagnostics, so two
+    // seconds is plenty for them. A stderr watch is a correctness signal
+    // (the caller fails the backup on it), so when one is set the drain
+    // waits longer: the container has already exited, so the stream ends
+    // as soon as the daemon flushes, and a slow flush must not turn an
+    // observed failure into a reported success.
+    let drain_deadline = if stderr_watch.is_some() {
+        Duration::from_secs(30)
+    } else {
+        Duration::from_secs(2)
+    };
     if let Some(handle) = log_handle {
-        match tokio::time::timeout(Duration::from_secs(2), handle).await {
-            Ok(Ok((s_out, s_err, matched))) => {
+        match tokio::time::timeout(drain_deadline, handle).await {
+            Ok(Ok((s_out, s_err))) => {
                 stdout_tail = s_out;
                 stderr_tail = s_err;
-                stderr_watch_matched = matched;
             }
             Ok(Err(_)) => {
                 // Join error (task panicked or was aborted). Captured
-                // tails stay empty.
+                // tails stay empty; the watch flag keeps whatever the
+                // collector published before it died.
             }
             Err(_) => {
-                // Timeout draining; not worth blocking the caller.
-                debug!("one_shot: log drain timed out after 2s");
+                if stderr_watch.is_some() {
+                    warn!(
+                        backup_id = spec.backup_id,
+                        engine = spec.engine,
+                        container = %spec.name,
+                        drain_secs = drain_deadline.as_secs(),
+                        "one_shot: log drain timed out with a stderr watch set; \
+                         a match seen so far is kept, later output was not inspected",
+                    );
+                } else {
+                    debug!("one_shot: log drain timed out after 2s");
+                }
             }
         }
     }
+    let stderr_watch_matched = stderr_watch_flag.load(Ordering::Acquire);
 
     info!(
         backup_id = spec.backup_id,
@@ -404,6 +415,45 @@ pub async fn run_one_shot(
     })
 }
 
+/// Drain a container's attached log stream into bounded tails.
+///
+/// Runs concurrently with `wait_container` so the container never blocks on
+/// a full pipe. When a `watcher` is given, every stderr chunk is fed through
+/// it and a match is published to `watch_flag` immediately, not at stream
+/// end: the caller may stop waiting for this task before the stream closes,
+/// and the verdict has to be visible by then.
+async fn collect_logs<S>(
+    mut stream: S,
+    mut watcher: Option<SubstringWatcher>,
+    watch_flag: Arc<AtomicBool>,
+) -> (RingBuffer, RingBuffer)
+where
+    S: futures::Stream<Item = Result<LogOutput, bollard::errors::Error>> + Unpin,
+{
+    let mut stdout = RingBuffer::with_capacity(4 * 1024);
+    let mut stderr = RingBuffer::with_capacity(4 * 1024);
+    while let Some(chunk) = stream.next().await {
+        match chunk {
+            Ok(LogOutput::StdOut { message }) => stdout.append(&message),
+            Ok(LogOutput::StdErr { message }) => {
+                if let Some(watcher) = watcher.as_mut() {
+                    watcher.feed(&message);
+                    if watcher.matched() {
+                        watch_flag.store(true, Ordering::Release);
+                    }
+                }
+                stderr.append(&message)
+            }
+            Ok(_) => {}
+            Err(e) => {
+                debug!(error = %e, "one_shot: log stream error (non-fatal)");
+                break;
+            }
+        }
+    }
+    (stdout, stderr)
+}
+
 /// Suppress unused-import warning when the helper is compiled but only
 /// the `StartExecResults` re-export is needed elsewhere. Tests in the
 /// engines crate consume `attach_container` directly which forces the
@@ -411,4 +461,71 @@ pub async fn run_one_shot(
 #[allow(dead_code)]
 fn _force_link_referenced_types() {
     let _ = std::mem::size_of::<StartExecResults>();
+}
+
+#[cfg(test)]
+mod collector_tests {
+    use super::*;
+    use tokio_util::bytes::Bytes;
+
+    /// Regression: the watch verdict must not depend on the collector
+    /// finishing. A stream that shows the watched diagnostic and then never
+    /// closes (a slow daemon flush after exit) still has to publish the
+    /// match, because `run_one_shot` stops waiting for the collector after
+    /// its drain deadline and reads the flag, not the task's return value.
+    #[tokio::test]
+    async fn watch_match_is_published_before_the_stream_ends() {
+        let flag = Arc::new(AtomicBool::new(false));
+        let stream = futures::stream::iter([
+            Ok(LogOutput::StdErr {
+                message: Bytes::from_static(b"mc: <ERROR> Unable to list comparison. "),
+            }),
+            Ok(LogOutput::StdErr {
+                message: Bytes::from_static(b"Access Denied.\n"),
+            }),
+        ])
+        .chain(futures::stream::pending());
+
+        let collector = tokio::spawn(collect_logs(
+            stream,
+            Some(SubstringWatcher::new("access denied")),
+            Arc::clone(&flag),
+        ));
+
+        let drained = tokio::time::timeout(Duration::from_millis(200), collector).await;
+        assert!(
+            drained.is_err(),
+            "the stream never closes, so the collector must still be running"
+        );
+        assert!(
+            flag.load(Ordering::Acquire),
+            "the match crossed a chunk boundary and must already be visible"
+        );
+    }
+
+    /// Without a match the flag stays false, and stdout never feeds the
+    /// watcher: the diagnostic `mc` prints on success must not trip it.
+    #[tokio::test]
+    async fn unmatched_streams_leave_the_flag_clear() {
+        let flag = Arc::new(AtomicBool::new(false));
+        let stream = futures::stream::iter([
+            Ok(LogOutput::StdOut {
+                message: Bytes::from_static(b"access denied appears only on stdout\n"),
+            }),
+            Ok(LogOutput::StdErr {
+                message: Bytes::from_static(b"Total: 3 objects, 1.2 MiB, transferred\n"),
+            }),
+        ]);
+
+        let (stdout, stderr) = collect_logs(
+            stream,
+            Some(SubstringWatcher::new("access denied")),
+            Arc::clone(&flag),
+        )
+        .await;
+
+        assert!(!flag.load(Ordering::Acquire));
+        assert!(stdout.into_string_lossy().contains("only on stdout"));
+        assert!(stderr.into_string_lossy().contains("transferred"));
+    }
 }

--- a/crates/temps-backup/src/engines/oneshot.rs
+++ b/crates/temps-backup/src/engines/oneshot.rs
@@ -161,6 +161,22 @@ pub enum OneShotError {
 
     #[error("Container '{name}' produced no exit code")]
     NoExitCode { name: String },
+
+    /// The caller asked for a stderr watch, the container exited without the
+    /// watched text having been seen, and the log stream had still not
+    /// closed after `drain_secs`. Whatever stderr was still in flight was
+    /// never inspected, so "no match" cannot be claimed. Callers treat this
+    /// as a failed run: for a watch that guards data completeness, an
+    /// uninspected diagnostic is not a clean result.
+    #[error(
+        "Container '{name}' exited but its stderr could not be fully inspected for \
+         '{watch}' within {drain_secs}s; refusing to report the run as clean"
+    )]
+    StderrWatchIncomplete {
+        name: String,
+        watch: &'static str,
+        drain_secs: u64,
+    },
 }
 
 /// Run a one-shot container start-to-finish. Returns when the container
@@ -382,15 +398,25 @@ pub async fn run_one_shot(
                 // collector published before it died.
             }
             Err(_) => {
-                if stderr_watch.is_some() {
-                    warn!(
-                        backup_id = spec.backup_id,
-                        engine = spec.engine,
-                        container = %spec.name,
-                        drain_secs = drain_deadline.as_secs(),
-                        "one_shot: log drain timed out with a stderr watch set; \
-                         a match seen so far is kept, later output was not inspected",
-                    );
+                // A match already published survives regardless. With a
+                // watch set and no match yet, the uninspected remainder of
+                // the stream makes a "clean" verdict unprovable: fail closed.
+                if let Some(watch) = stderr_watch {
+                    if !stderr_watch_flag.load(Ordering::Acquire) {
+                        warn!(
+                            backup_id = spec.backup_id,
+                            engine = spec.engine,
+                            container = %spec.name,
+                            drain_secs = drain_deadline.as_secs(),
+                            "one_shot: log drain timed out with a stderr watch set and no match \
+                             seen; later output was not inspected, refusing to report clean",
+                        );
+                        return Err(OneShotError::StderrWatchIncomplete {
+                            name: spec.name.clone(),
+                            watch,
+                            drain_secs: drain_deadline.as_secs(),
+                        });
+                    }
                 } else {
                     debug!("one_shot: log drain timed out after 2s");
                 }

--- a/crates/temps-backup/src/engines/oneshot.rs
+++ b/crates/temps-backup/src/engines/oneshot.rs
@@ -163,19 +163,20 @@ pub enum OneShotError {
     NoExitCode { name: String },
 
     /// The caller asked for a stderr watch, the container exited without the
-    /// watched text having been seen, and the log stream had still not
-    /// closed after `drain_secs`. Whatever stderr was still in flight was
-    /// never inspected, so "no match" cannot be claimed. Callers treat this
-    /// as a failed run: for a watch that guards data completeness, an
-    /// uninspected diagnostic is not a clean result.
+    /// watched text having been seen, and some part of stderr was never
+    /// inspected: the attach failed, the log stream broke or did not close
+    /// in time, or the collector died. "No match" cannot be claimed over
+    /// bytes nobody read, so callers treat this as a failed run: for a watch
+    /// that guards data completeness, an uninspected diagnostic is not a
+    /// clean result.
     #[error(
         "Container '{name}' exited but its stderr could not be fully inspected for \
-         '{watch}' within {drain_secs}s; refusing to report the run as clean"
+         '{watch}' ({reason}); refusing to report the run as clean"
     )]
     StderrWatchIncomplete {
         name: String,
         watch: &'static str,
-        drain_secs: u64,
+        reason: String,
     },
 }
 
@@ -307,6 +308,9 @@ pub async fn run_one_shot(
     // on a drain timeout, and an exit-0 container whose stderr had already
     // shown the watched diagnostic was then reported as a clean success.
     let stderr_watch_flag = Arc::new(AtomicBool::new(false));
+    // Why some part of stderr went uninspected, if any part did. Only
+    // consulted when a watch is set and nothing matched; see the gate below.
+    let mut inspection_gap: Option<String> = None;
 
     // ── Log collector (background task) ──────────────────────────────────
     //
@@ -325,6 +329,7 @@ pub async fn run_one_shot(
         }
         Err(e) => {
             warn!(error = %e, "one_shot: attach failed; will run without log capture");
+            inspection_gap = Some(format!("could not attach to the container's output: {e}"));
             None
         }
     };
@@ -388,42 +393,51 @@ pub async fn run_one_shot(
     };
     if let Some(handle) = log_handle {
         match tokio::time::timeout(drain_deadline, handle).await {
-            Ok(Ok((s_out, s_err))) => {
-                stdout_tail = s_out;
-                stderr_tail = s_err;
+            Ok(Ok(capture)) => {
+                stdout_tail = capture.stdout;
+                stderr_tail = capture.stderr;
+                if !capture.stream_closed_cleanly {
+                    inspection_gap =
+                        Some("the log stream broke before the container's output ended".into());
+                }
             }
-            Ok(Err(_)) => {
-                // Join error (task panicked or was aborted). Captured
-                // tails stay empty; the watch flag keeps whatever the
-                // collector published before it died.
+            Ok(Err(e)) => {
+                // Task panicked or was aborted. Captured tails stay empty;
+                // the watch flag keeps whatever was published before.
+                inspection_gap = Some(format!("the log collector stopped early: {e}"));
             }
             Err(_) => {
-                // A match already published survives regardless. With a
-                // watch set and no match yet, the uninspected remainder of
-                // the stream makes a "clean" verdict unprovable: fail closed.
-                if let Some(watch) = stderr_watch {
-                    if !stderr_watch_flag.load(Ordering::Acquire) {
-                        warn!(
-                            backup_id = spec.backup_id,
-                            engine = spec.engine,
-                            container = %spec.name,
-                            drain_secs = drain_deadline.as_secs(),
-                            "one_shot: log drain timed out with a stderr watch set and no match \
-                             seen; later output was not inspected, refusing to report clean",
-                        );
-                        return Err(OneShotError::StderrWatchIncomplete {
-                            name: spec.name.clone(),
-                            watch,
-                            drain_secs: drain_deadline.as_secs(),
-                        });
-                    }
-                } else {
-                    debug!("one_shot: log drain timed out after 2s");
-                }
+                debug!(
+                    drain_secs = drain_deadline.as_secs(),
+                    "one_shot: log drain timed out"
+                );
+                inspection_gap = Some(format!(
+                    "the log stream had not closed {}s after the container exited",
+                    drain_deadline.as_secs()
+                ));
             }
         }
     }
     let stderr_watch_matched = stderr_watch_flag.load(Ordering::Acquire);
+    // A match already published survives every gap above. With a watch set
+    // and no match, any gap means part of stderr was never read, and a
+    // "clean" verdict over unread bytes is not a verdict: fail closed.
+    if let (Some(watch), false, Some(reason)) = (stderr_watch, stderr_watch_matched, inspection_gap)
+    {
+        warn!(
+            backup_id = spec.backup_id,
+            engine = spec.engine,
+            container = %spec.name,
+            watch,
+            %reason,
+            "one_shot: stderr watch set but stderr was not fully inspected; refusing to report clean",
+        );
+        return Err(OneShotError::StderrWatchIncomplete {
+            name: spec.name.clone(),
+            watch,
+            reason,
+        });
+    }
 
     info!(
         backup_id = spec.backup_id,
@@ -448,16 +462,26 @@ pub async fn run_one_shot(
 /// it and a match is published to `watch_flag` immediately, not at stream
 /// end: the caller may stop waiting for this task before the stream closes,
 /// and the verdict has to be visible by then.
+/// What the log collector captured, and whether it saw all of it.
+struct LogCapture {
+    stdout: RingBuffer,
+    stderr: RingBuffer,
+    /// `false` when the stream ended with an error instead of closing, so
+    /// output after that point was never read.
+    stream_closed_cleanly: bool,
+}
+
 async fn collect_logs<S>(
     mut stream: S,
     mut watcher: Option<SubstringWatcher>,
     watch_flag: Arc<AtomicBool>,
-) -> (RingBuffer, RingBuffer)
+) -> LogCapture
 where
     S: futures::Stream<Item = Result<LogOutput, bollard::errors::Error>> + Unpin,
 {
     let mut stdout = RingBuffer::with_capacity(4 * 1024);
     let mut stderr = RingBuffer::with_capacity(4 * 1024);
+    let mut stream_closed_cleanly = true;
     while let Some(chunk) = stream.next().await {
         match chunk {
             Ok(LogOutput::StdOut { message }) => stdout.append(&message),
@@ -473,11 +497,16 @@ where
             Ok(_) => {}
             Err(e) => {
                 debug!(error = %e, "one_shot: log stream error (non-fatal)");
+                stream_closed_cleanly = false;
                 break;
             }
         }
     }
-    (stdout, stderr)
+    LogCapture {
+        stdout,
+        stderr,
+        stream_closed_cleanly,
+    }
 }
 
 /// Suppress unused-import warning when the helper is compiled but only
@@ -543,7 +572,7 @@ mod collector_tests {
             }),
         ]);
 
-        let (stdout, stderr) = collect_logs(
+        let capture = collect_logs(
             stream,
             Some(SubstringWatcher::new("access denied")),
             Arc::clone(&flag),
@@ -551,7 +580,43 @@ mod collector_tests {
         .await;
 
         assert!(!flag.load(Ordering::Acquire));
-        assert!(stdout.into_string_lossy().contains("only on stdout"));
-        assert!(stderr.into_string_lossy().contains("transferred"));
+        assert!(capture.stream_closed_cleanly);
+        assert!(capture
+            .stdout
+            .into_string_lossy()
+            .contains("only on stdout"));
+        assert!(capture.stderr.into_string_lossy().contains("transferred"));
+    }
+
+    /// A stream that errors out mid-way leaves later output unread. The
+    /// capture must say so, because with a watch set and no match that is
+    /// the difference between a clean run and one that cannot be vouched for.
+    #[tokio::test]
+    async fn a_broken_stream_is_reported_as_not_fully_read() {
+        let flag = Arc::new(AtomicBool::new(false));
+        let stream = futures::stream::iter([
+            Ok(LogOutput::StdErr {
+                message: Bytes::from_static(b"still fine\n"),
+            }),
+            Err(bollard::errors::Error::IOError {
+                err: std::io::Error::other("connection reset"),
+            }),
+            Ok(LogOutput::StdErr {
+                message: Bytes::from_static(b"Access Denied\n"),
+            }),
+        ]);
+
+        let capture = collect_logs(
+            stream,
+            Some(SubstringWatcher::new("access denied")),
+            Arc::clone(&flag),
+        )
+        .await;
+
+        assert!(!capture.stream_closed_cleanly);
+        assert!(
+            !flag.load(Ordering::Acquire),
+            "the diagnostic after the break was never read, so it cannot have matched"
+        );
     }
 }

--- a/crates/temps-backup/src/engines/oneshot.rs
+++ b/crates/temps-backup/src/engines/oneshot.rs
@@ -55,7 +55,7 @@ use futures::StreamExt;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
-use super::ring_buffer::RingBuffer;
+use super::ring_buffer::{RingBuffer, SubstringWatcher};
 
 /// Spec for a one-shot backup container. Engines build this and pass it
 /// to [`run_one_shot`]. Everything the helper needs to declare and run
@@ -96,6 +96,15 @@ pub struct OneShotSpec {
     /// Run-as-user. `Some("root")` is typical for sidecars that write
     /// to a host-owned bind mount.
     pub user: Option<String>,
+    /// Optional substring to watch for anywhere in the full stderr stream,
+    /// case-insensitively. Set this when a command can report a real
+    /// failure via stderr while still exiting `0` (e.g. `mc mirror`
+    /// swallowing a failed comparison listing and falling back to a
+    /// plain copy) -- `stderr_tail` alone is not reliable for that, since
+    /// it only keeps the last 4 KiB and enough later output can evict the
+    /// diagnostic before the caller ever inspects it. `None` skips the
+    /// check entirely (no extra cost).
+    pub stderr_watch: Option<&'static str>,
 }
 
 /// Outcome of [`run_one_shot`].
@@ -112,6 +121,10 @@ pub struct OneShotResult {
     /// --archive=-`) write to stdout — those engines should set
     /// `binds=[]` and use this field instead.
     pub stdout_tail: String,
+    /// `true` if `OneShotSpec::stderr_watch` was set and matched anywhere
+    /// in stderr, including bytes since evicted from `stderr_tail`.
+    /// Always `false` when `stderr_watch` was `None`.
+    pub stderr_watch_matched: bool,
 }
 
 /// Failure mode that prevented the container from reaching an exit
@@ -268,6 +281,8 @@ pub async fn run_one_shot(
 
     let mut stdout_tail = RingBuffer::with_capacity(4 * 1024);
     let mut stderr_tail = RingBuffer::with_capacity(4 * 1024);
+    let mut stderr_watch_matched = false;
+    let stderr_watch = spec.stderr_watch;
 
     // ── Log collector (background task) ──────────────────────────────────
     //
@@ -281,10 +296,16 @@ pub async fn run_one_shot(
                 let mut stream = stream;
                 let mut stdout = RingBuffer::with_capacity(4 * 1024);
                 let mut stderr = RingBuffer::with_capacity(4 * 1024);
+                let mut watcher = stderr_watch.map(SubstringWatcher::new);
                 while let Some(chunk) = stream.next().await {
                     match chunk {
                         Ok(LogOutput::StdOut { message }) => stdout.append(&message),
-                        Ok(LogOutput::StdErr { message }) => stderr.append(&message),
+                        Ok(LogOutput::StdErr { message }) => {
+                            if let Some(watcher) = watcher.as_mut() {
+                                watcher.feed(&message);
+                            }
+                            stderr.append(&message)
+                        }
                         Ok(_) => {}
                         Err(e) => {
                             debug!(error = %e, "one_shot: log stream error (non-fatal)");
@@ -292,7 +313,8 @@ pub async fn run_one_shot(
                         }
                     }
                 }
-                (stdout, stderr)
+                let matched = watcher.is_some_and(|w| w.matched());
+                (stdout, stderr, matched)
             }))
         }
         Err(e) => {
@@ -350,9 +372,10 @@ pub async fn run_one_shot(
     // the pipe before we hand back to the caller.
     if let Some(handle) = log_handle {
         match tokio::time::timeout(Duration::from_secs(2), handle).await {
-            Ok(Ok((s_out, s_err))) => {
+            Ok(Ok((s_out, s_err, matched))) => {
                 stdout_tail = s_out;
                 stderr_tail = s_err;
+                stderr_watch_matched = matched;
             }
             Ok(Err(_)) => {
                 // Join error (task panicked or was aborted). Captured
@@ -377,6 +400,7 @@ pub async fn run_one_shot(
         exit_code,
         stdout_tail: stdout_tail.into_string_lossy(),
         stderr_tail: stderr_tail.into_string_lossy(),
+        stderr_watch_matched,
     })
 }
 

--- a/crates/temps-backup/src/engines/postgres_pgdump.rs
+++ b/crates/temps-backup/src/engines/postgres_pgdump.rs
@@ -158,6 +158,7 @@ impl BackupEngine for PostgresPgDumpEngine {
             // `postgres-{service_name}` resolves.
             network_mode: Some(temps_core::NETWORK_NAME.to_string()),
             user: Some("root".to_string()),
+            stderr_watch: None,
         };
 
         let result = match run_one_shot(&deps.docker, spec, &ctx.cancel).await {

--- a/crates/temps-backup/src/engines/redis.rs
+++ b/crates/temps-backup/src/engines/redis.rs
@@ -179,6 +179,7 @@ impl BackupEngine for RedisEngine {
             binds: vec![format!("{}:/backup:rw", backup_dir.display())],
             network_mode: Some(temps_core::NETWORK_NAME.to_string()),
             user: Some("root".to_string()),
+            stderr_watch: None,
         };
 
         let result = match run_one_shot(&deps.docker, spec, &ctx.cancel).await {

--- a/crates/temps-backup/src/engines/ring_buffer.rs
+++ b/crates/temps-backup/src/engines/ring_buffer.rs
@@ -92,6 +92,58 @@ impl RingBuffer {
     }
 }
 
+/// Streaming, case-insensitive substring detector with bounded memory.
+///
+/// Unlike [`RingBuffer`], which keeps the tail of a stream for display and
+/// can therefore evict an earlier diagnostic line once enough later output
+/// arrives, this only needs to answer "did this substring ever appear
+/// anywhere in the stream" -- so it never has to retain the stream itself.
+/// It carries forward at most `needle.len() - 1` bytes between chunks (to
+/// catch a match split across a chunk boundary), which bounds its memory
+/// to the needle's length regardless of how much total output streams
+/// through, including a verbose command that emits gigabytes.
+pub struct SubstringWatcher {
+    needle: String,
+    carry: Vec<u8>,
+    matched: bool,
+}
+
+impl SubstringWatcher {
+    /// `needle` is matched case-insensitively.
+    pub fn new(needle: &str) -> Self {
+        Self {
+            needle: needle.to_ascii_lowercase(),
+            carry: Vec::new(),
+            matched: false,
+        }
+    }
+
+    /// Feed the next chunk of the stream. No-op once a match has been found.
+    pub fn feed(&mut self, chunk: &[u8]) {
+        if self.matched || self.needle.is_empty() {
+            return;
+        }
+        let mut combined = std::mem::take(&mut self.carry);
+        combined.extend_from_slice(chunk);
+        let lowered = String::from_utf8_lossy(&combined).to_ascii_lowercase();
+        if lowered.contains(&self.needle) {
+            self.matched = true;
+            return;
+        }
+        let keep = self.needle.len().saturating_sub(1);
+        self.carry = if combined.len() > keep {
+            combined[combined.len() - keep..].to_vec()
+        } else {
+            combined
+        };
+    }
+
+    /// `true` if `needle` has appeared in any chunk fed so far.
+    pub fn matched(&self) -> bool {
+        self.matched
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -177,5 +229,56 @@ mod tests {
         buf.append(&[0xFF, 0xFE]); // invalid UTF-8
         let s = buf.into_string_lossy();
         assert!(s.contains('\u{FFFD}'));
+    }
+
+    /// A watcher matches when the needle is fed in a single chunk.
+    #[test]
+    fn watcher_matches_within_a_single_chunk() {
+        let mut watcher = SubstringWatcher::new("access denied");
+        watcher.feed(b"mc: <ERROR> Unable to list comparison retrying.. Access Denied");
+        assert!(watcher.matched());
+    }
+
+    /// A watcher matches case-insensitively.
+    #[test]
+    fn watcher_matches_case_insensitively() {
+        let mut watcher = SubstringWatcher::new("access denied");
+        watcher.feed(b"ACCESS DENIED");
+        assert!(watcher.matched());
+    }
+
+    /// The whole point of the watcher: it must still catch a match that
+    /// later output would have evicted from a bounded tail buffer, because
+    /// it never discards its verdict once found.
+    #[test]
+    fn watcher_survives_gigabytes_of_output_after_the_match() {
+        let mut watcher = SubstringWatcher::new("access denied");
+        watcher.feed(b"mc: <ERROR> Unable to list comparison retrying.. Access Denied");
+        // Simulate far more stderr than a 4 KiB tail buffer could retain.
+        let filler = vec![b'x'; 4 * 1024];
+        for _ in 0..16 {
+            watcher.feed(&filler);
+        }
+        assert!(watcher.matched());
+    }
+
+    /// The needle can be split exactly across two chunk boundaries -- the
+    /// carried-forward suffix from the previous chunk must be considered
+    /// together with the next one.
+    #[test]
+    fn watcher_matches_needle_split_across_chunk_boundary() {
+        let mut watcher = SubstringWatcher::new("access denied");
+        watcher.feed(b"...access den");
+        assert!(!watcher.matched());
+        watcher.feed(b"ied...");
+        assert!(watcher.matched());
+    }
+
+    /// No match, no false positive.
+    #[test]
+    fn watcher_does_not_match_unrelated_output() {
+        let mut watcher = SubstringWatcher::new("access denied");
+        watcher.feed(b"mc: `source/foo.txt`: object is a delete marker, skipping");
+        assert!(!watcher.matched());
     }
 }

--- a/crates/temps-backup/src/engines/s3_mirror.rs
+++ b/crates/temps-backup/src/engines/s3_mirror.rs
@@ -10,16 +10,37 @@
 //! 2. Load the source service config (it's a temps-managed MinIO/RustFS-like
 //!    service; the host/port/credentials live in the service's encrypted
 //!    config blob).
-//! 3. Run a one-shot `minio/mc` container in `host` network mode with
-//!    `MC_HOST_source` and `MC_HOST_dest` env vars. The container's
-//!    entrypoint is `mc mirror --overwrite source/<bucket>/ dest/<bucket>/<prefix>/`.
+//! 3. If the service config names a single bucket (`bucket_name`/`bucket`,
+//!    the normal MinIO/S3-compatible case), mirror that one bucket. If it
+//!    does not (RustFS: every *project* gets its own bucket, and there is no
+//!    per-service bucket at all), enumerate the account's buckets via
+//!    `ListBuckets` over `aws-sdk-s3` and mirror each one individually --
+//!    see "Why not `mc mirror source/`" below.
+//! 4. For each bucket mirrored, run a one-shot `minio/mc` container in
+//!    `host` network mode with `MC_HOST_source` and `MC_HOST_dest` env vars.
+//!    The container's entrypoint is
+//!    `mc mirror --overwrite source/<bucket>/ dest/<bucket>/<prefix>/[<bucket>/]`.
 //!    Container exits when mirror exits.
-//! 4. Compute the mirrored prefix's total size via list-objects.
-//! 5. Write the `metadata.json` companion.
+//! 5. Compute the mirrored prefix's total size via list-objects, summed
+//!    across all mirrored buckets.
+//! 6. Write one `metadata.json` companion for the whole backup.
+//!
+//! ## Why not `mc mirror source/` for a whole account
+//!
+//! `mc mirror source/` (no bucket in the path) asks the source for an
+//! account-level bucket listing to expand into per-bucket mirrors. RustFS's
+//! S3 API accepts that same `ListBuckets` call fine when issued directly via
+//! `aws-sdk-s3` (used for its own health check), but `mc` issuing the
+//! equivalent call against the same credentials gets `Access Denied` --
+//! confirmed in production. Rather than depend on `mc`'s account-level
+//! listing path working, this engine does its own `ListBuckets` (the call
+//! already proven to work) and hands `mc` a concrete, already-known bucket
+//! name every time, so `mc` never needs to perform that call itself.
 
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use aws_sdk_s3::config::{BehaviorVersion, Credentials, Region};
 use aws_sdk_s3::Client as S3Client;
 use sea_orm::{DatabaseConnection, EntityTrait};
 use serde_json::{json, Value};
@@ -28,6 +49,7 @@ use tracing::{info, warn};
 use super::oneshot::{run_one_shot, OneShotError, OneShotSpec};
 use super::v2_common;
 use temps_backup_core::engine_v2::{BackupContext, BackupEngine, BackupError, BackupOutcome};
+use temps_providers::externalsvc::SensitiveValues;
 
 const ENGINE_KEY: &str = "s3_mirror";
 const MC_IMAGE: &str = "minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727";
@@ -112,6 +134,11 @@ impl BackupEngine for S3MirrorEngine {
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_string();
+        let source_region = src
+            .get("region")
+            .and_then(|v| v.as_str())
+            .unwrap_or("us-east-1")
+            .to_string();
 
         let dest_access_key = deps
             .encryption_service
@@ -148,54 +175,13 @@ impl BackupEngine for S3MirrorEngine {
         let backup_uuid = v2_common::load_backup_uuid(deps.db.as_ref(), backup_id).await?;
         let dest_prefix = build_dest_prefix(&s3_dest.bucket_path, &service.name, &backup_uuid);
 
-        let source_path = if source_bucket.is_empty() {
-            "source/".to_string()
-        } else {
-            format!("source/{}/", source_bucket)
-        };
-        let dest_path = format!(
-            "dest/{}/{}/",
-            s3_dest.bucket_name,
-            dest_prefix.trim_matches('/'),
-        );
-
-        info!(
-            backup_id,
-            source = %source_path,
-            dest = %dest_path,
-            "S3MirrorEngine: starting mc mirror",
-        );
-
-        // ── One-shot mc mirror container ─────────────────────────────────────
-        // This helper receives both source and destination credentials. Refresh
-        // the registry tag before each run so a poisoned local cache entry
-        // cannot execute with those secrets.
-        super::image_pull::force_pull_image_v2(MC_IMAGE, ENGINE_KEY).await?;
-
-        let env_vars = vec![
-            format!(
-                "MC_HOST_source=http://{}:{}@{}:{}",
-                source_access_key, source_secret_key, source_host, source_port
-            ),
-            format!(
-                "MC_HOST_dest={}://{}@{}",
-                dest_scheme,
-                temps_providers::externalsvc::mc_host_credential(
-                    &dest_access_key,
-                    &dest_secret_key,
-                    dest_session_token.as_deref(),
-                ),
-                dest_hostpath
-            ),
-        ];
-
         // mc echoes the credential-bearing `MC_HOST_*` URL it could not use
         // straight into stderr, and that stderr is folded into the
         // `BackupError::Failed` reason persisted on the backup row and surfaced
         // through the API. A Cloud-vended destination credential carries a
         // session token that is not individually revocable, so it must be
         // scrubbed alongside the keys.
-        let sensitive_values = temps_providers::externalsvc::SensitiveValues::new()
+        let sensitive_values = SensitiveValues::new()
             .credential(&source_access_key, &source_secret_key, None)
             .credential(
                 &dest_access_key,
@@ -203,95 +189,178 @@ impl BackupEngine for S3MirrorEngine {
                 dest_session_token.as_deref(),
             );
 
-        let mirror_cmd = format!(
-            "mc mirror --overwrite {} {}",
-            v2_common::shell_escape(&source_path),
-            v2_common::shell_escape(&dest_path),
-        );
-
-        let spec = OneShotSpec {
-            image: MC_IMAGE.to_string(),
-            name: format!("temps-s3mirror-{}", backup_uuid),
-            engine: ENGINE_KEY,
-            backup_id,
-            entrypoint: vec!["sh".to_string(), "-c".to_string()],
-            cmd: vec![mirror_cmd],
-            env: env_vars,
-            binds: vec![],
-            // Host network so the mc container can reach both the source MinIO
-            // (typically `host:9000`) and the destination endpoint (typically
-            // an internet S3) without extra routing.
-            network_mode: Some("host".to_string()),
-            user: None,
-            // `mc mirror` exits 0 even when it could not list one side of the
-            // mirror for comparison; see the exit_code==0 handling below for
-            // why that fallback needs to be caught rather than trusted.
-            stderr_watch: Some("access denied"),
+        // The source service config names a bucket for the normal MinIO/S3
+        // case; RustFS never does (every *project* gets its own bucket, not
+        // the service). When it doesn't, enumerate the account's actual
+        // buckets and mirror each individually -- see the module doc comment
+        // for why `mc mirror source/` (whole account) isn't used instead.
+        let enumerated = source_bucket.is_empty();
+        let buckets = if enumerated {
+            list_source_buckets(
+                &source_access_key,
+                &source_secret_key,
+                &source_host,
+                &source_port,
+                &source_region,
+            )
+            .await?
+        } else {
+            vec![source_bucket.clone()]
         };
 
-        let result = match run_one_shot(&deps.docker, spec, &ctx.cancel).await {
-            Ok(r) => r,
-            Err(OneShotError::Cancelled) => return Err(BackupError::Cancelled),
-            Err(e) => {
-                return Err(BackupError::Failed {
-                    reason: format!("mc mirror one-shot failed: {}", e),
-                });
-            }
-        };
-        if result.exit_code != 0 {
-            return Err(BackupError::Failed {
-                reason: format!(
-                    "mc mirror exited with code {}. stderr: {}. stdout: {}",
-                    result.exit_code,
-                    sensitive_values.redact(result.stderr_tail.trim()),
-                    sensitive_values.redact(result.stdout_tail.trim()),
-                ),
-            });
-        }
-        // `mc mirror` exits 0 even when it could not list one side of the
-        // mirror for comparison -- it logs the failure and falls back to
-        // copying everything it *can* reach via plain PUT/GET, rather than
-        // treating a failed diff as fatal. That fallback silently turns a
-        // real access/listing problem into a "completed" backup that never
-        // actually diffed against what's already there, with no visible
-        // signal to the operator beyond a log line buried in server output.
-        // `stderr_watch_matched` is checked here rather than re-scanning
-        // `stderr_tail`: the tail only keeps the last 4 KiB, and a mirror
-        // producing enough later stderr (many objects, retried entries)
-        // could evict this exact diagnostic before we ever look at it, so
-        // detection has to happen as the stream arrives, not after the fact.
-        if result.stderr_watch_matched {
-            return Err(BackupError::Failed {
-                reason: format!(
-                    "mc mirror could not list one side of the mirror for comparison \
-                     (access denied). mc still exited 0 and copied what it could reach \
-                     via direct PUT/GET, but the result may be an incomplete, non-diffed \
-                     copy -- check that both the source and destination S3 credentials \
-                     have list permission on their bucket. stderr: {}",
-                    sensitive_values.redact(result.stderr_tail.trim()),
-                ),
-            });
-        }
-        if !result.stderr_tail.trim().is_empty() {
-            info!(
+        if buckets.is_empty() {
+            warn!(
                 backup_id,
-                "mc mirror stderr (warnings): {}",
-                sensitive_values.redact(result.stderr_tail.trim()),
+                service_id, "S3MirrorEngine: source account has no buckets to mirror"
             );
         }
 
-        // ── Compute size + metadata ──────────────────────────────────────────
-        let size_bytes = list_total_s3_size(
-            &s3_dest_client,
-            &s3_dest.bucket_name,
-            dest_prefix.trim_matches('/'),
-        )
-        .await
-        .unwrap_or_else(|e| {
-            warn!(backup_id, error = %e, "s3_mirror: could not compute size");
-            0
-        });
+        // Refresh the registry tag once before the whole backup run, rather
+        // than per bucket, so a poisoned local cache entry cannot execute
+        // with these secrets -- and so N buckets don't each pay a pull.
+        super::image_pull::force_pull_image_v2(MC_IMAGE, ENGINE_KEY).await?;
 
+        let mut total_size_bytes: i64 = 0;
+        let mut mirrored_buckets: Vec<Value> = Vec::with_capacity(buckets.len());
+
+        for bucket in &buckets {
+            let source_path = format!("source/{}/", bucket);
+            // A single explicitly-configured bucket keeps the original,
+            // un-nested destination layout; enumerated buckets each get
+            // their own subfolder so they can't collide with each other.
+            let bucket_dest_prefix = if enumerated {
+                format!("{}/{}", dest_prefix.trim_matches('/'), bucket)
+            } else {
+                dest_prefix.trim_matches('/').to_string()
+            };
+            let dest_path = format!("dest/{}/{}/", s3_dest.bucket_name, bucket_dest_prefix);
+
+            info!(
+                backup_id,
+                source = %source_path,
+                dest = %dest_path,
+                "S3MirrorEngine: starting mc mirror",
+            );
+
+            let env_vars = vec![
+                format!(
+                    "MC_HOST_source=http://{}:{}@{}:{}",
+                    source_access_key, source_secret_key, source_host, source_port
+                ),
+                format!(
+                    "MC_HOST_dest={}://{}@{}",
+                    dest_scheme,
+                    temps_providers::externalsvc::mc_host_credential(
+                        &dest_access_key,
+                        &dest_secret_key,
+                        dest_session_token.as_deref(),
+                    ),
+                    dest_hostpath
+                ),
+            ];
+
+            let mirror_cmd = format!(
+                "mc mirror --overwrite {} {}",
+                v2_common::shell_escape(&source_path),
+                v2_common::shell_escape(&dest_path),
+            );
+
+            let spec = OneShotSpec {
+                image: MC_IMAGE.to_string(),
+                name: format!("temps-s3mirror-{}-{}", backup_uuid, bucket),
+                engine: ENGINE_KEY,
+                backup_id,
+                entrypoint: vec!["sh".to_string(), "-c".to_string()],
+                cmd: vec![mirror_cmd],
+                env: env_vars,
+                binds: vec![],
+                // Host network so the mc container can reach both the source
+                // MinIO (typically `host:9000`) and the destination endpoint
+                // (typically an internet S3) without extra routing.
+                network_mode: Some("host".to_string()),
+                user: None,
+                // `mc mirror` exits 0 even when it could not list one side of
+                // the mirror for comparison; see the exit_code==0 handling
+                // below for why that fallback needs to be caught rather than
+                // trusted.
+                stderr_watch: Some("access denied"),
+            };
+
+            let result = match run_one_shot(&deps.docker, spec, &ctx.cancel).await {
+                Ok(r) => r,
+                Err(OneShotError::Cancelled) => return Err(BackupError::Cancelled),
+                Err(e) => {
+                    return Err(BackupError::Failed {
+                        reason: format!("mc mirror one-shot failed for bucket {}: {}", bucket, e),
+                    });
+                }
+            };
+            if result.exit_code != 0 {
+                return Err(BackupError::Failed {
+                    reason: format!(
+                        "mc mirror exited with code {} for bucket {}. stderr: {}. stdout: {}",
+                        result.exit_code,
+                        bucket,
+                        sensitive_values.redact(result.stderr_tail.trim()),
+                        sensitive_values.redact(result.stdout_tail.trim()),
+                    ),
+                });
+            }
+            // `mc mirror` exits 0 even when it could not list one side of the
+            // mirror for comparison -- it logs the failure and falls back to
+            // copying everything it *can* reach via plain PUT/GET, rather
+            // than treating a failed diff as fatal. That fallback silently
+            // turns a real access/listing problem into a "completed" backup
+            // that never actually diffed against what's already there, with
+            // no visible signal to the operator beyond a log line buried in
+            // server output. `stderr_watch_matched` is checked here rather
+            // than re-scanning `stderr_tail`: the tail only keeps the last
+            // 4 KiB, and a mirror producing enough later stderr (many
+            // objects, retried entries) could evict this exact diagnostic
+            // before we ever look at it, so detection has to happen as the
+            // stream arrives, not after the fact.
+            if result.stderr_watch_matched {
+                return Err(BackupError::Failed {
+                    reason: format!(
+                        "mc mirror could not list one side of the mirror for comparison \
+                         (access denied) for bucket {}. mc still exited 0 and copied what \
+                         it could reach via direct PUT/GET, but the result may be an \
+                         incomplete, non-diffed copy -- check that both the source and \
+                         destination S3 credentials have list permission on their bucket. \
+                         stderr: {}",
+                        bucket,
+                        sensitive_values.redact(result.stderr_tail.trim()),
+                    ),
+                });
+            }
+            if !result.stderr_tail.trim().is_empty() {
+                info!(
+                    backup_id,
+                    bucket = %bucket,
+                    "mc mirror stderr (warnings): {}",
+                    sensitive_values.redact(result.stderr_tail.trim()),
+                );
+            }
+
+            let bucket_size_bytes = list_total_s3_size(
+                &s3_dest_client,
+                &s3_dest.bucket_name,
+                &bucket_dest_prefix,
+            )
+            .await
+            .unwrap_or_else(|e| {
+                warn!(backup_id, bucket = %bucket, error = %e, "s3_mirror: could not compute size");
+                0
+            });
+            total_size_bytes += bucket_size_bytes;
+            mirrored_buckets.push(json!({
+                "bucket": bucket,
+                "prefix": bucket_dest_prefix,
+                "size_bytes": bucket_size_bytes,
+            }));
+        }
+
+        // ── Metadata ──────────────────────────────────────────────────────────
         let metadata_key = format!("{}/metadata.json", dest_prefix.trim_matches('/'));
         v2_common::write_metadata_companion(
             &s3_dest_client,
@@ -300,12 +369,13 @@ impl BackupEngine for S3MirrorEngine {
             ENGINE_KEY,
             &backup_uuid,
             &dest_prefix,
-            size_bytes,
+            total_size_bytes,
             s3_source_id,
             "none",
             Some(json!({
                 "backup_tool": "mc",
                 "service": { "id": service_id, "name": service.name },
+                "buckets": mirrored_buckets,
             })),
         )
         .await?;
@@ -313,13 +383,14 @@ impl BackupEngine for S3MirrorEngine {
         info!(
             backup_id,
             %dest_prefix,
-            size_bytes,
+            size_bytes = total_size_bytes,
+            bucket_count = buckets.len(),
             "S3MirrorEngine: backup complete",
         );
 
         Ok(BackupOutcome {
             location: dest_prefix,
-            size_bytes: Some(size_bytes),
+            size_bytes: Some(total_size_bytes),
             compression: "none".to_string(),
         })
     }
@@ -337,6 +408,52 @@ fn build_dest_prefix(bucket_path: &str, service_name: &str, backup_uuid: &str) -
             base, service_name, backup_uuid
         )
     }
+}
+
+/// List the bucket names visible to a source account, used when the service
+/// config names no single bucket (RustFS). Uses `aws-sdk-s3`'s `ListBuckets`
+/// directly rather than delegating to `mc`'s equivalent call -- see the
+/// module doc comment for why.
+async fn list_source_buckets(
+    access_key: &str,
+    secret_key: &str,
+    host: &str,
+    port: &str,
+    region: &str,
+) -> Result<Vec<String>, BackupError> {
+    let endpoint = format!("http://{}:{}", host, port);
+    let creds = Credentials::new(
+        access_key,
+        secret_key,
+        None,
+        None,
+        "s3-mirror-engine-source",
+    );
+    let s3_config = aws_sdk_s3::Config::builder()
+        .region(Region::new(region.to_string()))
+        .endpoint_url(&endpoint)
+        .credentials_provider(creds)
+        .force_path_style(true)
+        .behavior_version(BehaviorVersion::latest())
+        .build();
+    let client = S3Client::from_conf(s3_config);
+
+    let resp = client
+        .list_buckets()
+        .send()
+        .await
+        .map_err(|e| BackupError::Failed {
+            reason: format!(
+                "could not enumerate source buckets at {} (account-level ListBuckets): {}",
+                endpoint, e
+            ),
+        })?;
+
+    Ok(resp
+        .buckets()
+        .iter()
+        .filter_map(|b| b.name().map(|n| n.to_string()))
+        .collect())
 }
 
 async fn list_total_s3_size(

--- a/crates/temps-backup/src/engines/s3_mirror.rs
+++ b/crates/temps-backup/src/engines/s3_mirror.rs
@@ -223,6 +223,10 @@ impl BackupEngine for S3MirrorEngine {
             // an internet S3) without extra routing.
             network_mode: Some("host".to_string()),
             user: None,
+            // `mc mirror` exits 0 even when it could not list one side of the
+            // mirror for comparison; see the exit_code==0 handling below for
+            // why that fallback needs to be caught rather than trusted.
+            stderr_watch: Some("access denied"),
         };
 
         let result = match run_one_shot(&deps.docker, spec, &ctx.cancel).await {
@@ -244,31 +248,31 @@ impl BackupEngine for S3MirrorEngine {
                 ),
             });
         }
+        // `mc mirror` exits 0 even when it could not list one side of the
+        // mirror for comparison -- it logs the failure and falls back to
+        // copying everything it *can* reach via plain PUT/GET, rather than
+        // treating a failed diff as fatal. That fallback silently turns a
+        // real access/listing problem into a "completed" backup that never
+        // actually diffed against what's already there, with no visible
+        // signal to the operator beyond a log line buried in server output.
+        // `stderr_watch_matched` is checked here rather than re-scanning
+        // `stderr_tail`: the tail only keeps the last 4 KiB, and a mirror
+        // producing enough later stderr (many objects, retried entries)
+        // could evict this exact diagnostic before we ever look at it, so
+        // detection has to happen as the stream arrives, not after the fact.
+        if result.stderr_watch_matched {
+            return Err(BackupError::Failed {
+                reason: format!(
+                    "mc mirror could not list one side of the mirror for comparison \
+                     (access denied). mc still exited 0 and copied what it could reach \
+                     via direct PUT/GET, but the result may be an incomplete, non-diffed \
+                     copy -- check that both the source and destination S3 credentials \
+                     have list permission on their bucket. stderr: {}",
+                    sensitive_values.redact(result.stderr_tail.trim()),
+                ),
+            });
+        }
         if !result.stderr_tail.trim().is_empty() {
-            // `mc mirror` exits 0 even when it could not list one side of the
-            // mirror for comparison -- it logs the failure and falls back to
-            // copying everything it *can* reach via plain PUT/GET, rather
-            // than treating a failed diff as fatal. That fallback silently
-            // turns a real access/listing problem into a "completed" backup
-            // that never actually diffed against what's already there, with
-            // no visible signal to the operator beyond an info-level log line
-            // buried in server output. Escalate to a real failure instead so
-            // the underlying access problem (permanent misconfiguration or a
-            // persistent provider-side listing issue) is surfaced immediately
-            // through the normal backup-error path rather than staying
-            // invisible behind a green "completed" status.
-            if stderr_indicates_access_denied(&result.stderr_tail) {
-                return Err(BackupError::Failed {
-                    reason: format!(
-                        "mc mirror could not list one side of the mirror for comparison \
-                         (access denied). mc still exited 0 and copied what it could reach \
-                         via direct PUT/GET, but the result may be an incomplete, non-diffed \
-                         copy -- check that both the source and destination S3 credentials \
-                         have list permission on their bucket. stderr: {}",
-                        sensitive_values.redact(result.stderr_tail.trim()),
-                    ),
-                });
-            }
             info!(
                 backup_id,
                 "mc mirror stderr (warnings): {}",
@@ -362,16 +366,6 @@ async fn list_total_s3_size(
     Ok(total)
 }
 
-/// Whether `mc`'s stderr reports that it could not list one side of the
-/// mirror for comparison. `mc mirror` treats this as non-fatal -- it logs the
-/// failure and falls back to copying whatever it can still reach -- so the
-/// container's own exit code is not sufficient evidence that the mirror
-/// actually diffed correctly against what's already there.
-fn stderr_indicates_access_denied(stderr: &str) -> bool {
-    let lower = stderr.to_ascii_lowercase();
-    lower.contains("unable to list") && lower.contains("access denied")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -382,23 +376,5 @@ mod tests {
         assert!(MC_IMAGE
             .contains("sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727"));
         assert!(MC_IMAGE.contains("@sha256:"));
-    }
-
-    #[test]
-    fn detects_access_denied_during_mc_mirror_comparison_listing() {
-        assert!(stderr_indicates_access_denied(
-            "mc: <ERROR> Unable to list comparison retrying.. Access Denied."
-        ));
-        assert!(stderr_indicates_access_denied(
-            "mc: <ERROR> Unable to list comparison retrying.. ACCESS DENIED"
-        ));
-    }
-
-    #[test]
-    fn does_not_flag_unrelated_mc_warnings() {
-        assert!(!stderr_indicates_access_denied(
-            "mc: <WARNING> `source/foo.txt`: object is a delete marker, skipping"
-        ));
-        assert!(!stderr_indicates_access_denied(""));
     }
 }

--- a/crates/temps-backup/src/engines/s3_mirror.rs
+++ b/crates/temps-backup/src/engines/s3_mirror.rs
@@ -342,10 +342,16 @@ impl BackupEngine for S3MirrorEngine {
                 );
             }
 
+            // Trailing slash makes this a directory-boundary prefix, not a
+            // plain string prefix: without it, an enumerated bucket named
+            // "data" would also match objects mirrored under a sibling
+            // "database" bucket's prefix, inflating this bucket's size with
+            // another bucket's bytes.
+            let bucket_size_prefix = format!("{}/", bucket_dest_prefix);
             let bucket_size_bytes = list_total_s3_size(
                 &s3_dest_client,
                 &s3_dest.bucket_name,
-                &bucket_dest_prefix,
+                &bucket_size_prefix,
             )
             .await
             .unwrap_or_else(|e| {
@@ -438,22 +444,32 @@ async fn list_source_buckets(
         .build();
     let client = S3Client::from_conf(s3_config);
 
-    let resp = client
-        .list_buckets()
-        .send()
-        .await
-        .map_err(|e| BackupError::Failed {
+    let mut bucket_names = Vec::new();
+    let mut continuation: Option<String> = None;
+    loop {
+        let mut req = client.list_buckets();
+        if let Some(tok) = continuation {
+            req = req.continuation_token(tok);
+        }
+        let resp = req.send().await.map_err(|e| BackupError::Failed {
             reason: format!(
                 "could not enumerate source buckets at {} (account-level ListBuckets): {}",
                 endpoint, e
             ),
         })?;
+        bucket_names.extend(
+            resp.buckets()
+                .iter()
+                .filter_map(|b| b.name())
+                .map(String::from),
+        );
+        continuation = resp.continuation_token().map(|s| s.to_string());
+        if continuation.is_none() {
+            break;
+        }
+    }
 
-    Ok(resp
-        .buckets()
-        .iter()
-        .filter_map(|b| b.name().map(|n| n.to_string()))
-        .collect())
+    Ok(bucket_names)
 }
 
 async fn list_total_s3_size(

--- a/crates/temps-backup/src/engines/s3_mirror.rs
+++ b/crates/temps-backup/src/engines/s3_mirror.rs
@@ -323,12 +323,14 @@ impl BackupEngine for S3MirrorEngine {
                 return Err(BackupError::Failed {
                     reason: format!(
                         "mc mirror could not list one side of the mirror for comparison \
-                         (access denied) for bucket {}. mc still exited 0 and copied what \
-                         it could reach via direct PUT/GET, but the result may be an \
-                         incomplete, non-diffed copy -- check that both the source and \
-                         destination S3 credentials have list permission on their bucket. \
-                         stderr: {}",
+                         (access denied) for bucket {} (backup {}, service {}). mc still \
+                         exited 0 and copied what it could reach via direct PUT/GET, but \
+                         the result may be an incomplete, non-diffed copy -- check that \
+                         both the source and destination S3 credentials have list \
+                         permission on their bucket. stderr: {}",
                         bucket,
+                        backup_id,
+                        service_id,
                         sensitive_values.redact(result.stderr_tail.trim()),
                     ),
                 });

--- a/crates/temps-backup/src/engines/s3_mirror.rs
+++ b/crates/temps-backup/src/engines/s3_mirror.rs
@@ -245,6 +245,30 @@ impl BackupEngine for S3MirrorEngine {
             });
         }
         if !result.stderr_tail.trim().is_empty() {
+            // `mc mirror` exits 0 even when it could not list one side of the
+            // mirror for comparison -- it logs the failure and falls back to
+            // copying everything it *can* reach via plain PUT/GET, rather
+            // than treating a failed diff as fatal. That fallback silently
+            // turns a real access/listing problem into a "completed" backup
+            // that never actually diffed against what's already there, with
+            // no visible signal to the operator beyond an info-level log line
+            // buried in server output. Escalate to a real failure instead so
+            // the underlying access problem (permanent misconfiguration or a
+            // persistent provider-side listing issue) is surfaced immediately
+            // through the normal backup-error path rather than staying
+            // invisible behind a green "completed" status.
+            if stderr_indicates_access_denied(&result.stderr_tail) {
+                return Err(BackupError::Failed {
+                    reason: format!(
+                        "mc mirror could not list one side of the mirror for comparison \
+                         (access denied). mc still exited 0 and copied what it could reach \
+                         via direct PUT/GET, but the result may be an incomplete, non-diffed \
+                         copy -- check that both the source and destination S3 credentials \
+                         have list permission on their bucket. stderr: {}",
+                        sensitive_values.redact(result.stderr_tail.trim()),
+                    ),
+                });
+            }
             info!(
                 backup_id,
                 "mc mirror stderr (warnings): {}",
@@ -338,6 +362,16 @@ async fn list_total_s3_size(
     Ok(total)
 }
 
+/// Whether `mc`'s stderr reports that it could not list one side of the
+/// mirror for comparison. `mc mirror` treats this as non-fatal -- it logs the
+/// failure and falls back to copying whatever it can still reach -- so the
+/// container's own exit code is not sufficient evidence that the mirror
+/// actually diffed correctly against what's already there.
+fn stderr_indicates_access_denied(stderr: &str) -> bool {
+    let lower = stderr.to_ascii_lowercase();
+    lower.contains("unable to list") && lower.contains("access denied")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -348,5 +382,23 @@ mod tests {
         assert!(MC_IMAGE
             .contains("sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727"));
         assert!(MC_IMAGE.contains("@sha256:"));
+    }
+
+    #[test]
+    fn detects_access_denied_during_mc_mirror_comparison_listing() {
+        assert!(stderr_indicates_access_denied(
+            "mc: <ERROR> Unable to list comparison retrying.. Access Denied."
+        ));
+        assert!(stderr_indicates_access_denied(
+            "mc: <ERROR> Unable to list comparison retrying.. ACCESS DENIED"
+        ));
+    }
+
+    #[test]
+    fn does_not_flag_unrelated_mc_warnings() {
+        assert!(!stderr_indicates_access_denied(
+            "mc: <WARNING> `source/foo.txt`: object is a delete marker, skipping"
+        ));
+        assert!(!stderr_indicates_access_denied(""));
     }
 }

--- a/crates/temps-cloud-protocol/src/messages.rs
+++ b/crates/temps-cloud-protocol/src/messages.rs
@@ -353,6 +353,15 @@ pub struct NativeSnapshotRequest {
 pub struct NativeSnapshot {
     pub backup_id: Uuid,
     pub upload_required: bool,
+    /// `relative_key`s from the declared manifest that Cloud has already
+    /// verified as complete for this `backup_id`. A re-declaration of an
+    /// unchanged manifest returns every object a previous, interrupted pass
+    /// managed to finish, so the instance can resume from where it stopped
+    /// instead of re-requesting a target and re-verifying every object.
+    /// Empty when nothing has completed yet, when the manifest was replaced,
+    /// or when talking to a Cloud that predates this field.
+    #[serde(default)]
+    pub completed_relative_keys: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -399,6 +408,9 @@ pub struct WalGSnapshotRequest {
 pub struct WalGSnapshot {
     pub backup_id: Uuid,
     pub upload_required: bool,
+    /// Same contract as [`NativeSnapshot::completed_relative_keys`].
+    #[serde(default)]
+    pub completed_relative_keys: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -720,6 +732,29 @@ mod tests {
         let env = Envelope::new("heartbeat", &hb).unwrap();
         let back: Heartbeat = env.decode("heartbeat").unwrap();
         assert_eq!(back.pending_spool_bytes, 42);
+    }
+
+    /// A Cloud built before `completed_relative_keys` existed answers a
+    /// declaration without it. The instance must decode that as "nothing
+    /// complete yet" and fall back to uploading every object, not fail the
+    /// whole mirror pass on a missing field.
+    #[test]
+    fn snapshot_completed_keys_are_additive() {
+        let native: NativeSnapshot = serde_json::from_value(serde_json::json!({
+            "backup_id": Uuid::nil(),
+            "upload_required": true
+        }))
+        .unwrap();
+        assert!(native.upload_required);
+        assert!(native.completed_relative_keys.is_empty());
+
+        let walg: WalGSnapshot = serde_json::from_value(serde_json::json!({
+            "backup_id": Uuid::nil(),
+            "upload_required": true,
+            "completed_relative_keys": ["basebackups_005/base_000000010000000000000002/tar_partitions/part_001.tar.lz4"]
+        }))
+        .unwrap();
+        assert_eq!(walg.completed_relative_keys.len(), 1);
     }
 
     #[test]

--- a/crates/temps-cloud/src/backup_mirror.rs
+++ b/crates/temps-cloud/src/backup_mirror.rs
@@ -93,6 +93,145 @@ enum StageError {
     Retry(String),
 }
 
+/// How many individual object failures one upload pass keeps verbatim. The
+/// count is always reported; only the first few reasons are, so a pass that
+/// loses thousands of objects to the same outage does not write thousands of
+/// near-identical lines into the mirror state's `reason` column.
+const MAX_REPORTED_OBJECT_FAILURES: usize = 3;
+/// Consecutive object failures after which a pass stops walking the manifest.
+///
+/// Tolerating individual failures is what makes progress monotonic, but a
+/// *run* of them is not individual bad luck — it is the source bucket, its
+/// credential, or Cloud being down for everything. Each failed object has
+/// already spent up to three attempts against `S3_CONTROL_REQUEST_TIMEOUT`
+/// and `S3_STREAM_IDLE_TIMEOUT`, so continuing through a 100,000-object
+/// manifest during an outage would hold the sweep (which serves every other
+/// backup on this instance in series) for hours. Ten in a row is far more
+/// than a transient stall produces and far less than an outage costs.
+const MAX_CONSECUTIVE_OBJECT_FAILURES: usize = 10;
+
+/// Bookkeeping for one pass over a declared manifest.
+///
+/// A pass used to be all-or-nothing: the first object that failed after its
+/// bounded retries aborted the whole snapshot, and the next sweep started
+/// again from the first object — re-requesting a target and re-verifying
+/// every object Cloud already held. For an S3-mirror snapshot, whose manifest
+/// has as many objects as the source buckets, that meant one transient S3
+/// stall anywhere in a multi-thousand-object walk reset all the progress
+/// behind it, and a snapshot could stay "Uploading" on Cloud indefinitely.
+///
+/// A pass now records per-object failures and keeps going, so every object
+/// that *can* upload does, and Cloud's `completed_relative_keys` lets the
+/// next pass skip them. Progress is therefore monotonic across sweeps.
+#[derive(Debug, Default)]
+struct UploadPass {
+    /// Objects in the declared manifest.
+    declared: usize,
+    /// Objects Cloud reported as already complete before this pass began.
+    already_complete: usize,
+    /// Objects this pass uploaded and had Cloud verify.
+    uploaded: usize,
+    /// Objects that failed after their own bounded retries.
+    failed: usize,
+    /// `(relative_key, reason)` for the first `MAX_REPORTED_OBJECT_FAILURES`.
+    reported_failures: Vec<(String, String)>,
+    /// Failures since the last successful upload; drives the circuit breaker.
+    consecutive_failures: usize,
+    /// Set when the breaker tripped and the manifest walk stopped early, so
+    /// the recorded reason says so rather than implying every object was tried.
+    stopped_early: bool,
+}
+
+impl UploadPass {
+    fn record_success(&mut self) {
+        self.uploaded += 1;
+        self.consecutive_failures = 0;
+    }
+
+    /// Record one failed object. Returns `true` when the pass should stop
+    /// walking the manifest because failures are no longer isolated.
+    fn record_failure(&mut self, relative_key: &str, reason: &str) -> bool {
+        self.failed += 1;
+        self.consecutive_failures += 1;
+        if self.reported_failures.len() < MAX_REPORTED_OBJECT_FAILURES {
+            self.reported_failures
+                .push((relative_key.to_owned(), reason.to_owned()));
+        }
+        if self.consecutive_failures >= MAX_CONSECUTIVE_OBJECT_FAILURES {
+            self.stopped_early = true;
+        }
+        self.stopped_early
+    }
+
+    /// `Ok(())` when every declared object is now complete on Cloud, otherwise
+    /// a `Retry` describing what this pass did and did not manage, so the
+    /// mirror state an operator sees says "resumed 400 of 2,000, 3 failed"
+    /// rather than only the first object's error.
+    fn into_result(self) -> Result<(), StageError> {
+        if self.failed == 0 {
+            return Ok(());
+        }
+        let mut reason = format!(
+            "{} of {} objects did not upload this pass ({} were already complete on Cloud, \
+             {} uploaded now); the next pass resumes from Cloud's completed set",
+            self.failed, self.declared, self.already_complete, self.uploaded
+        );
+        if self.stopped_early {
+            reason.push_str(&format!(
+                "; stopped after {} consecutive failures, which points at the source, \
+                 its credential, or Cloud being unavailable rather than at these objects",
+                self.consecutive_failures
+            ));
+        }
+        for (relative_key, failure) in &self.reported_failures {
+            reason.push_str(&format!("; {relative_key}: {failure}"));
+        }
+        if self.failed > self.reported_failures.len() {
+            reason.push_str(&format!(
+                "; {} more not listed",
+                self.failed - self.reported_failures.len()
+            ));
+        }
+        Err(StageError::Retry(reason))
+    }
+}
+
+/// Split a declared manifest into the objects still to upload and the count
+/// Cloud already verified. `completed` is Cloud's own answer for this exact
+/// `backup_id`, so a key in it can be skipped without re-checking anything:
+/// Cloud verified the bytes and checksum against the manifest it bound the
+/// snapshot to, and that manifest is the one we just re-declared unchanged.
+///
+/// The set is still sanity-bounded by what *we* declared: Cloud can only have
+/// completed objects from that manifest, so a longer list is a protocol
+/// anomaly. It is ignored wholesale (every object uploads, as before this
+/// field existed) rather than trusted for whatever prefix happens to match.
+fn pending_objects<T>(
+    declarations: Vec<T>,
+    completed: &[String],
+    relative_key: impl Fn(&T) -> &str,
+) -> (Vec<T>, usize) {
+    if completed.is_empty() {
+        return (declarations, 0);
+    }
+    if completed.len() > declarations.len() {
+        warn!(
+            completed = completed.len(),
+            declared = declarations.len(),
+            "Cloud reported more completed objects than this snapshot declares; ignoring the set"
+        );
+        return (declarations, 0);
+    }
+    let completed: HashSet<&str> = completed.iter().map(String::as_str).collect();
+    let before = declarations.len();
+    let pending: Vec<T> = declarations
+        .into_iter()
+        .filter(|declaration| !completed.contains(relative_key(declaration)))
+        .collect();
+    let skipped = before - pending.len();
+    (pending, skipped)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SweepOutcome {
     NotLinked,
@@ -1095,8 +1234,28 @@ async fn declare_and_complete_native_snapshot(
         .await
         .map_err(|error| StageError::Retry(error.to_string()))?;
     if snapshot.upload_required {
-        for declaration in declarations {
-            upload_native_object(
+        let mut pass = UploadPass {
+            declared: declarations.len(),
+            ..UploadPass::default()
+        };
+        let (pending, already_complete) = pending_objects(
+            declarations,
+            &snapshot.completed_relative_keys,
+            |declaration| declaration.relative_key.as_str(),
+        );
+        pass.already_complete = already_complete;
+        if already_complete > 0 {
+            info!(
+                local_backup_id = %backup.backup_id,
+                %cloud_backup_id,
+                already_complete,
+                pending = pending.len(),
+                "Cloud backup mirror resuming native snapshot from Cloud's completed set"
+            );
+        }
+        for declaration in pending {
+            let relative_key = declaration.relative_key.clone();
+            match upload_native_object(
                 link,
                 client,
                 &source_config.bucket_name,
@@ -1105,8 +1264,31 @@ async fn declare_and_complete_native_snapshot(
                 cloud_backup_id,
                 declaration,
             )
-            .await?;
+            .await
+            {
+                Ok(()) => pass.record_success(),
+                Err(StageError::Retry(reason)) => {
+                    warn!(
+                        local_backup_id = %backup.backup_id,
+                        %relative_key,
+                        error = %reason,
+                        "Cloud backup mirror could not upload one object; continuing with the rest"
+                    );
+                    if pass.record_failure(&relative_key, &reason) {
+                        warn!(
+                            local_backup_id = %backup.backup_id,
+                            consecutive_failures = MAX_CONSECUTIVE_OBJECT_FAILURES,
+                            "Cloud backup mirror stopping this pass early; failures are no longer isolated"
+                        );
+                        break;
+                    }
+                }
+                // Structural: the same object will be rejected the same way
+                // on every pass, so finishing the walk cannot help.
+                Err(error @ StageError::Unsupported(_)) => return Err(error),
+            }
         }
+        pass.into_result()?;
     }
     link.complete_native_snapshot(&WalGSnapshotCompleted {
         backup_id: cloud_backup_id,
@@ -1371,8 +1553,28 @@ async fn mirror_walg_backup(
         .await
         .map_err(|error| StageError::Retry(error.to_string()))?;
     if snapshot.upload_required {
-        for declaration in declarations {
-            upload_repository_object(
+        let mut pass = UploadPass {
+            declared: declarations.len(),
+            ..UploadPass::default()
+        };
+        let (pending, already_complete) = pending_objects(
+            declarations,
+            &snapshot.completed_relative_keys,
+            |declaration| declaration.relative_key.as_str(),
+        );
+        pass.already_complete = already_complete;
+        if already_complete > 0 {
+            info!(
+                local_backup_id = %backup.backup_id,
+                %cloud_backup_id,
+                already_complete,
+                pending = pending.len(),
+                "Cloud backup mirror resuming WAL-G snapshot from Cloud's completed set"
+            );
+        }
+        for declaration in pending {
+            let relative_key = declaration.relative_key.clone();
+            match upload_repository_object(
                 link,
                 &client,
                 &source_config.bucket_name,
@@ -1381,8 +1583,29 @@ async fn mirror_walg_backup(
                 cloud_backup_id,
                 declaration,
             )
-            .await?;
+            .await
+            {
+                Ok(()) => pass.record_success(),
+                Err(StageError::Retry(reason)) => {
+                    warn!(
+                        local_backup_id = %backup.backup_id,
+                        %relative_key,
+                        error = %reason,
+                        "Cloud backup mirror could not upload one object; continuing with the rest"
+                    );
+                    if pass.record_failure(&relative_key, &reason) {
+                        warn!(
+                            local_backup_id = %backup.backup_id,
+                            consecutive_failures = MAX_CONSECUTIVE_OBJECT_FAILURES,
+                            "Cloud backup mirror stopping this pass early; failures are no longer isolated"
+                        );
+                        break;
+                    }
+                }
+                Err(error @ StageError::Unsupported(_)) => return Err(error),
+            }
         }
+        pass.into_result()?;
     }
     link.complete_walg_snapshot(&WalGSnapshotCompleted {
         backup_id: cloud_backup_id,
@@ -2309,10 +2532,11 @@ mod tests {
     use super::{
         append_source_object, backup_engine_key, contains_backup_identity, deferred_legacy_state,
         ensure_json_object_size, image_tag_version, manifest_digest, merge_mirror_state,
-        mirror_backup, next_sweep_interval, parse_postgres_major, run, s3_key, select_due_backups,
-        sentinel_lsn, supports_native_mirror, sweep, timeline_from_backup_name,
+        mirror_backup, next_sweep_interval, parse_postgres_major, pending_objects, run, s3_key,
+        select_due_backups, sentinel_lsn, supports_native_mirror, sweep, timeline_from_backup_name,
         upload_native_object, wal_segment_name, wal_segment_of, walg_root_key, SourceObject,
-        StageError, SweepOutcome, BASE_SWEEP_INTERVAL, DISCOVER_BACKUPS_SQL, DUE_BACKUPS_SQL,
+        StageError, SweepOutcome, UploadPass, BASE_SWEEP_INTERVAL, DISCOVER_BACKUPS_SQL,
+        DUE_BACKUPS_SQL, MAX_CONSECUTIVE_OBJECT_FAILURES, MAX_REPORTED_OBJECT_FAILURES,
         MAX_SWEEP_INTERVAL, MIRROR_STATE_VERSION,
     };
     use std::{
@@ -2344,6 +2568,142 @@ mod tests {
         WalGObjectTargetRequest,
     };
     use uuid::Uuid;
+
+    fn native_declaration(relative_key: &str) -> NativeSnapshotObjectDeclaration {
+        NativeSnapshotObjectDeclaration {
+            relative_key: relative_key.to_owned(),
+            kind: NativeSnapshotObjectKind::Object,
+            bytes: 1,
+            checksum_sha256: "ab".repeat(32),
+        }
+    }
+
+    /// Cloud's completed set is authoritative for the exact manifest just
+    /// re-declared: those objects are skipped, everything else stays in
+    /// manifest order, and a key Cloud names that we never declared is
+    /// ignored rather than trusted.
+    #[test]
+    fn pending_objects_skips_only_what_cloud_reports_complete() {
+        let declarations = vec![
+            native_declaration("bucket-a/one"),
+            native_declaration("bucket-a/two"),
+            native_declaration("bucket-b/three"),
+        ];
+        let completed = vec!["bucket-a/two".to_owned(), "never-declared".to_owned()];
+
+        let (pending, skipped) =
+            pending_objects(declarations, &completed, |d| d.relative_key.as_str());
+
+        assert_eq!(skipped, 1);
+        assert_eq!(
+            pending
+                .iter()
+                .map(|d| d.relative_key.as_str())
+                .collect::<Vec<_>>(),
+            ["bucket-a/one", "bucket-b/three"]
+        );
+    }
+
+    /// A Cloud that predates `completed_relative_keys` (or a fresh
+    /// declaration) reports nothing complete; the pass must then be exactly
+    /// the pre-resume behaviour, with no object skipped.
+    #[test]
+    fn pending_objects_without_completed_set_uploads_everything() {
+        let declarations = vec![native_declaration("one"), native_declaration("two")];
+        let (pending, skipped) = pending_objects(declarations, &[], |d| d.relative_key.as_str());
+        assert_eq!(skipped, 0);
+        assert_eq!(pending.len(), 2);
+    }
+
+    /// One failed object no longer aborts the pass, but it must still stop
+    /// the snapshot from being reported complete: the result is a `Retry`
+    /// whose reason accounts for every object, names the failures an
+    /// operator can act on, and stays bounded when many fail the same way.
+    #[test]
+    fn upload_pass_reports_partial_progress_as_retry() {
+        let mut pass = UploadPass {
+            declared: 2_000,
+            already_complete: 1_500,
+            uploaded: 495,
+            ..UploadPass::default()
+        };
+        for index in 0..5 {
+            pass.record_failure(
+                &format!("bucket-a/object-{index}"),
+                "source object made no progress for 60 seconds",
+            );
+        }
+        assert_eq!(pass.failed, 5);
+        assert_eq!(pass.reported_failures.len(), MAX_REPORTED_OBJECT_FAILURES);
+
+        let error = pass
+            .into_result()
+            .expect_err("a pass with failures must not complete the snapshot");
+        let StageError::Retry(reason) = error else {
+            panic!("partial progress is transient, not unsupported");
+        };
+        assert!(reason.starts_with("5 of 2000 objects did not upload this pass"));
+        assert!(reason.contains("1500 were already complete on Cloud"));
+        assert!(reason.contains("495 uploaded now"));
+        assert!(reason.contains("bucket-a/object-0: source object made no progress"));
+        assert!(reason.contains("bucket-a/object-2"));
+        assert!(!reason.contains("bucket-a/object-3"));
+        assert!(reason.ends_with("; 2 more not listed"));
+    }
+
+    /// A run of failures is an outage, not bad luck per object. The breaker
+    /// stops the walk so one wedged snapshot cannot hold the serial sweep for
+    /// hours, a success in between resets it, and the recorded reason says
+    /// the pass stopped early instead of implying every object was tried.
+    #[test]
+    fn upload_pass_breaker_trips_only_on_consecutive_failures() {
+        let mut pass = UploadPass {
+            declared: 100,
+            ..UploadPass::default()
+        };
+        for _ in 0..MAX_CONSECUTIVE_OBJECT_FAILURES - 1 {
+            assert!(!pass.record_failure("k", "stall"));
+        }
+        pass.record_success();
+        for _ in 0..MAX_CONSECUTIVE_OBJECT_FAILURES - 1 {
+            assert!(
+                !pass.record_failure("k", "stall"),
+                "a success in between must reset the run"
+            );
+        }
+        assert!(pass.record_failure("k", "stall"), "tenth in a row trips");
+        assert!(pass.stopped_early);
+
+        let StageError::Retry(reason) = pass.into_result().expect_err("failed pass retries") else {
+            panic!("an outage is transient");
+        };
+        assert!(reason.contains(&format!(
+            "stopped after {MAX_CONSECUTIVE_OBJECT_FAILURES} consecutive failures"
+        )));
+    }
+
+    /// Cloud can only have completed objects we declared. A longer list is a
+    /// protocol anomaly and must not be trusted even for the keys that match.
+    #[test]
+    fn pending_objects_ignores_a_completed_set_larger_than_the_manifest() {
+        let declarations = vec![native_declaration("one")];
+        let completed = vec!["one".to_owned(), "two".to_owned()];
+        let (pending, skipped) =
+            pending_objects(declarations, &completed, |d| d.relative_key.as_str());
+        assert_eq!(skipped, 0);
+        assert_eq!(pending.len(), 1);
+    }
+
+    #[test]
+    fn upload_pass_without_failures_completes() {
+        let pass = UploadPass {
+            declared: 3,
+            already_complete: 2,
+            uploaded: 1,
+            ..UploadPass::default()
+        };
+        assert!(pass.into_result().is_ok());
+    }
 
     #[test]
     fn repository_discovery_rejects_excess_object_count() {


### PR DESCRIPTION
## Summary
- `S3MirrorEngine` (`crates/temps-backup/src/engines/s3_mirror.rs`) runs `mc mirror --overwrite` in a one-shot container and only checked the container's **exit code** to decide success/failure.
- `mc mirror` treats a failed comparison listing (`Unable to list ... Access Denied`) as non-fatal: it logs the failure and falls back to copying whatever it can reach via plain PUT/GET, still exiting `0`. That left the real problem visible only as an info-level log line, while the backup row reported "completed" as if nothing was wrong.
- This PR detects that specific stderr pattern even when the container exits `0`, and escalates it to a real `BackupError::Failed` so the backup shows an actionable error instead of a silent, possibly-incomplete "completed" state.

## Why
Found while diagnosing a backup that stayed permanently stuck reporting incomplete progress. The production log for the affected engine run showed exactly this pattern: `mc: <ERROR> Unable to list comparison retrying.. Access Denied` immediately followed by `S3MirrorEngine: backup complete` (exit code 0) a moment later. Self-hosted operators debug alone — a real access/listing failure should never be indistinguishable from success without reading raw container stderr.

## Test plan
- [x] `cargo check --lib -p temps-backup`
- [x] `cargo test --lib -p temps-backup` (new `detects_access_denied_during_mc_mirror_comparison_listing` / `does_not_flag_unrelated_mc_warnings` tests pass; full crate suite unaffected)
- [x] `cargo fmt` (scoped to the changed file)
- [x] `cargo clippy -p temps-backup --all-targets -- -D warnings` (clean)
- [x] `python3 scripts/source_attribution.py check`

## Also in this PR: resumable Cloud mirror passes (`crates/temps-cloud/src/backup_mirror.rs`, `temps-cloud-protocol`)

Found while watching the same S3-mirror backups after the two fixes above: they stayed "Uploading" on Cloud for hours while the instance streamed `objects/target` + `objects/complete` pairs continuously.

**Root cause.** A mirror pass was all-or-nothing. The first object that failed after its bounded retries aborted the whole snapshot, and the next sweep restarted from the first object — re-hashing, re-declaring, then re-requesting a target and re-verifying every object Cloud already held. An S3-mirror manifest has as many objects as the source buckets, so one transient stall anywhere in a multi-thousand-object walk reset all progress behind it, and the pass never converged.

**Fix.**
- Declare responses gain `completed_relative_keys` (`#[serde(default)]`, so an older Cloud means "nothing complete yet"). A pass skips those objects entirely.
- A pass records per-object `Retry` failures and keeps walking, returning `Retry` at the end if anything failed, so the snapshot is never reported complete with a gap. `Unsupported` still aborts immediately.
- Circuit breaker: ten consecutive failures stop the pass (that is an outage, not per-object bad luck), so one wedged snapshot cannot hold the serial sweep for hours.
- A completed set larger than the declared manifest is a protocol anomaly and is ignored wholesale.

Cloud's completion gate is unchanged (`snapshots/complete` still requires every manifest object verified), so trusting the completed set can only cause an upload, never skip a needed one. The Cloud side that emits the field is deployed separately.

**Test plan (this part)**
- [x] `cargo test --lib -p temps-cloud` (79 pass; 6 new tests for `pending_objects` / `UploadPass`, incl. breaker reset and oversized-set rejection)
- [x] `cargo test --lib -p temps-cloud-protocol` (new `snapshot_completed_keys_are_additive` decodes an old-Cloud response without the field)
- [x] `cargo clippy -p temps-cloud -p temps-cloud-protocol --all-targets -- -D warnings`
- [x] `cargo fmt`, `python3 scripts/source_attribution.py check`
- [x] security-auditor pass: isolation/SQL/disclosure cleared; its two findings (no breaker, unbounded completed set) are both addressed above
