### PR TITLE
feat(cloud): catalog managed-source native snapshots in place

### DIFF
--- a/crates/temps-cloud-protocol/src/messages.rs
+++ b/crates/temps-cloud-protocol/src/messages.rs
@@ -347,6 +347,17 @@ pub struct NativeSnapshotRequest {
     /// unvalidated.
     #[serde(default)]
     pub source_image: Option<String>,
+    /// Key prefix in the Cloud-managed bucket under which the backup engine
+    /// already wrote every object in `objects` (their keys are
+    /// `<in_place_root>/<relative_key>`). Set only for sources the cloud
+    /// manages (`s3_sources.managed_by_cloud`), whose bucket *is* the
+    /// tenant's cloud backup bucket: it tells Cloud to catalog the objects
+    /// where they sit rather than asking the instance to upload a second
+    /// copy into Cloud's own layout in the same bucket. A Cloud that predates
+    /// the field ignores it and answers `upload_required: true`, so the
+    /// instance falls back to the copy path unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub in_place_root: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1096,6 +1107,7 @@ mod tests {
                 checksum_sha256: "ab".repeat(32),
             }],
             source_image: None,
+            in_place_root: None,
         };
 
         let value = serde_json::to_value(request).unwrap();
@@ -1103,6 +1115,40 @@ mod tests {
         assert_eq!(value["format"], "mongo_dump_archive");
         assert_eq!(value["identity"]["kind"], "mongo_db_stream");
         assert_eq!(value["objects"][0]["kind"], "data");
+        // Absent by default so an older Cloud sees the exact request it
+        // always did; present verbatim when the sweep sets it.
+        assert!(value.get("in_place_root").is_none());
+    }
+
+    #[test]
+    fn native_snapshot_in_place_root_round_trips_and_defaults() {
+        let mut request = NativeSnapshotRequest {
+            backup_id: Uuid::new_v4(),
+            instance_id: Uuid::new_v4(),
+            source: "s3/object-store".into(),
+            engine: BackupEngine::RustFs,
+            format: BackupFormat::ObjectSet,
+            compression: BackupCompression::None,
+            identity: NativeSnapshotIdentity::ObjectSet {
+                snapshot_name: "backup-7".into(),
+            },
+            objects: vec![],
+            source_image: None,
+            in_place_root: Some("external_services/s3/object-store/2026-09-11/backup-7".into()),
+        };
+        let value = serde_json::to_value(&request).unwrap();
+        assert_eq!(
+            value["in_place_root"],
+            "external_services/s3/object-store/2026-09-11/backup-7"
+        );
+        let decoded: NativeSnapshotRequest = serde_json::from_value(value).unwrap();
+        assert_eq!(decoded, request);
+
+        request.in_place_root = None;
+        let mut without = serde_json::to_value(&request).unwrap();
+        without.as_object_mut().unwrap().remove("in_place_root");
+        let decoded: NativeSnapshotRequest = serde_json::from_value(without).unwrap();
+        assert_eq!(decoded.in_place_root, None);
     }
 
     #[test]

--- a/crates/temps-cloud/src/backup_mirror.rs
+++ b/crates/temps-cloud/src/backup_mirror.rs
@@ -1218,6 +1218,16 @@ async fn declare_and_complete_native_snapshot(
             .ok_or_else(|| StageError::Retry("Cloud link lost its tenant identity".into()))?,
         format!("{instance_id}:{}", backup.backup_id).as_bytes(),
     );
+    // A managed source's bucket is the tenant's cloud backup bucket, so the
+    // objects the engine wrote under `root` already are the offsite copy.
+    // Tell Cloud where they are and let it catalog them in place rather than
+    // reading every object back and uploading it a second time into Cloud's
+    // own layout in the same bucket. A Cloud that predates the field answers
+    // `upload_required: true` and the copy path below runs unchanged.
+    let in_place_root = source_config
+        .managed_by_cloud
+        .then(|| root.trim_matches('/').to_string())
+        .filter(|root| !root.is_empty());
     let request = NativeSnapshotRequest {
         backup_id: cloud_backup_id,
         instance_id,
@@ -1228,11 +1238,20 @@ async fn declare_and_complete_native_snapshot(
         identity,
         objects: declarations.clone(),
         source_image,
+        in_place_root,
     };
     let snapshot = link
         .declare_native_snapshot(&request)
         .await
         .map_err(|error| StageError::Retry(error.to_string()))?;
+    if !snapshot.upload_required && request.in_place_root.is_some() {
+        info!(
+            local_backup_id = %backup.backup_id,
+            %cloud_backup_id,
+            objects = declarations.len(),
+            "Cloud cataloged the snapshot in place; no second copy uploaded"
+        );
+    }
     if snapshot.upload_required {
         let mut pass = UploadPass {
             declared: declarations.len(),
@@ -4396,6 +4415,166 @@ mod tests {
             "expected exactly the dump object and metadata.json to be read and checksummed, \
              proving the decoy object was excluded and both real objects were reached"
         );
+    }
+
+    struct InPlaceCloudStub {
+        declared: Mutex<Option<serde_json::Value>>,
+        target_calls: AtomicUsize,
+        completions: AtomicUsize,
+    }
+
+    async fn in_place_declare_stub(
+        State(state): State<Arc<InPlaceCloudStub>>,
+        Json(request): Json<serde_json::Value>,
+    ) -> (StatusCode, Json<serde_json::Value>) {
+        let backup_id = request["backup_id"].clone();
+        let declared = request["objects"]
+            .as_array()
+            .map(Vec::len)
+            .unwrap_or_default();
+        *state.declared.lock().expect("declared lock") = Some(request);
+        (
+            StatusCode::CREATED,
+            Json(serde_json::json!({
+                "backup_id": backup_id,
+                "upload_required": false,
+                "declared_objects": declared,
+                "completed_relative_keys": [],
+            })),
+        )
+    }
+
+    async fn in_place_target_stub(
+        State(state): State<Arc<InPlaceCloudStub>>,
+    ) -> (StatusCode, Json<serde_json::Value>) {
+        state.target_calls.fetch_add(1, Ordering::SeqCst);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"detail": "in-place snapshots never request targets"})),
+        )
+    }
+
+    async fn in_place_complete_stub(
+        State(state): State<Arc<InPlaceCloudStub>>,
+    ) -> (StatusCode, Json<serde_json::Value>) {
+        state.completions.fetch_add(1, Ordering::SeqCst);
+        (
+            StatusCode::OK,
+            Json(serde_json::json!({"state": "complete"})),
+        )
+    }
+
+    /// A managed source's bucket is the tenant's cloud bucket, so the sweep
+    /// declares the engine's own root and Cloud catalogs the objects where
+    /// they already are. Against a stub Cloud that answers
+    /// `upload_required: false`, the whole native flow must complete with
+    /// zero object targets and zero re-uploads.
+    #[tokio::test]
+    async fn managed_native_snapshots_are_declared_in_place_and_never_re_uploaded() {
+        let Some((origin, state)) = spawn_repository_stub(HashMap::new()).await else {
+            return;
+        };
+        let cloud_listener = match tokio::net::TcpListener::bind("127.0.0.1:0").await {
+            Ok(listener) => listener,
+            Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
+                eprintln!("sandbox denied TCP bind; skipping in-place catalog test");
+                return;
+            }
+            Err(error) => panic!("bind Cloud stub: {error}"),
+        };
+        let cloud_origin = format!(
+            "http://{}",
+            cloud_listener.local_addr().expect("Cloud stub address")
+        );
+        let cloud = Arc::new(InPlaceCloudStub {
+            declared: Mutex::new(None),
+            target_calls: AtomicUsize::new(0),
+            completions: AtomicUsize::new(0),
+        });
+        let app = Router::new()
+            .route("/v1/backups/native/snapshots", post(in_place_declare_stub))
+            .route(
+                "/v1/backups/native/objects/target",
+                post(in_place_target_stub),
+            )
+            .route(
+                "/v1/backups/native/snapshots/complete",
+                post(in_place_complete_stub),
+            )
+            .with_state(cloud.clone());
+        tokio::spawn(async move {
+            axum::serve(cloud_listener, app)
+                .await
+                .expect("serve Cloud stub");
+        });
+
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("in-memory SQLite connects");
+        let (encryption, backup) = seed_redis_fallback_backup(&db, &origin).await;
+        let (dump_key, metadata_key) = redis_fallback_repository_keys(&backup);
+        let expected_root = dump_key
+            .rsplit_once('/')
+            .expect("dump key has a parent")
+            .0
+            .to_string();
+        {
+            let mut objects = state.objects.lock().expect("repository stub objects lock");
+            objects.insert(dump_key, b"redis-rdb-dump-bytes".to_vec());
+            objects.insert(metadata_key, b"{\"redis_version\":\"7.4\"}".to_vec());
+        }
+
+        let temp = tempfile::tempdir().expect("cloud-link state dir");
+        let state_dir = temp.path().join("cloud-link");
+        std::fs::create_dir_all(&state_dir).expect("cloud-link state dir");
+        let instance_id = Uuid::new_v4();
+        std::fs::write(
+            state_dir.join("state.json"),
+            serde_json::json!({
+                "instance_id": instance_id,
+                "base_url": cloud_origin,
+                "allow_loopback_development": true,
+                "token": "test-instance-token",
+                "tenant_id": Uuid::new_v4(),
+                "account_email": "backup-owner@example.invalid",
+            })
+            .to_string(),
+        )
+        .expect("write Cloud link state");
+        let link = Arc::new(CloudLink::load_for_loopback_development(
+            temp.path().to_path_buf(),
+            "test-agent",
+        ));
+        link.set_feature_switches(CloudFeatureSwitches {
+            telemetry: false,
+            backups: true,
+            notifications: false,
+        })
+        .expect("enable backup mirroring");
+        let mut resources =
+            super::SweepResources::load(&db, &encryption, std::slice::from_ref(&backup))
+                .await
+                .expect("resources load");
+
+        expect_stage_ok(
+            mirror_backup(&link, &mut resources, &backup, instance_id).await,
+            "in-place native mirror completes",
+        );
+
+        let declared = cloud
+            .declared
+            .lock()
+            .expect("declared lock")
+            .clone()
+            .expect("the sweep declared the snapshot");
+        assert_eq!(declared["in_place_root"], expected_root);
+        assert_eq!(declared["objects"].as_array().map(Vec::len), Some(2));
+        assert_eq!(
+            cloud.target_calls.load(Ordering::SeqCst),
+            0,
+            "an in-place snapshot must never ask for an upload target"
+        );
+        assert_eq!(cloud.completions.load(Ordering::SeqCst), 1);
     }
 
     /// The `mirror_native_backup` fallback branch treats a dump with no

--- a/crates/temps-cloud/src/backup_mirror.rs
+++ b/crates/temps-cloud/src/backup_mirror.rs
@@ -14,7 +14,7 @@ use sea_orm::{
     TransactionTrait,
 };
 use sha2::{Digest, Sha256};
-use temps_cloud_client::CloudLink;
+use temps_cloud_client::{CloudError, CloudLink};
 use temps_cloud_protocol::{
     BackupCompression, BackupEngine, BackupFormat, NativeSnapshotIdentity,
     NativeSnapshotObjectDeclaration, NativeSnapshotObjectKind, NativeSnapshotRequest,
@@ -1228,7 +1228,7 @@ async fn declare_and_complete_native_snapshot(
         .managed_by_cloud
         .then(|| root.trim_matches('/').to_string())
         .filter(|root| !root.is_empty());
-    let request = NativeSnapshotRequest {
+    let mut request = NativeSnapshotRequest {
         backup_id: cloud_backup_id,
         instance_id,
         source,
@@ -1240,10 +1240,27 @@ async fn declare_and_complete_native_snapshot(
         source_image,
         in_place_root,
     };
-    let snapshot = link
-        .declare_native_snapshot(&request)
-        .await
-        .map_err(|error| StageError::Retry(error.to_string()))?;
+    let snapshot = match link.declare_native_snapshot(&request).await {
+        Ok(snapshot) => snapshot,
+        // Cloud understood the in-place request and refused it (a root it
+        // will not accept, a bucket that disagrees with the manifest). That
+        // is a verdict on this layout, not a transient fault: retrying the
+        // same declaration would loop forever. Fall back to the copy path,
+        // which is what Cloud always accepted, and say why.
+        Err(CloudError::Rejected { detail }) if request.in_place_root.is_some() => {
+            warn!(
+                local_backup_id = %backup.backup_id,
+                %cloud_backup_id,
+                %detail,
+                "Cloud declined to catalog the snapshot in place; mirroring a copy instead"
+            );
+            request.in_place_root = None;
+            link.declare_native_snapshot(&request)
+                .await
+                .map_err(|error| StageError::Retry(error.to_string()))?
+        }
+        Err(error) => return Err(StageError::Retry(error.to_string())),
+    };
     if !snapshot.upload_required && request.in_place_root.is_some() {
         info!(
             local_backup_id = %backup.backup_id,
@@ -4418,7 +4435,11 @@ mod tests {
     }
 
     struct InPlaceCloudStub {
-        declared: Mutex<Option<serde_json::Value>>,
+        /// Every declaration body received, in order.
+        declared: Mutex<Vec<serde_json::Value>>,
+        /// Refuse declarations that carry `in_place_root` with a 400, the
+        /// way Cloud does for a root it will not catalog.
+        reject_in_place: bool,
         target_calls: AtomicUsize,
         completions: AtomicUsize,
     }
@@ -4432,12 +4453,21 @@ mod tests {
             .as_array()
             .map(Vec::len)
             .unwrap_or_default();
-        *state.declared.lock().expect("declared lock") = Some(request);
+        let in_place = request.get("in_place_root").is_some();
+        state.declared.lock().expect("declared lock").push(request);
+        if in_place && state.reject_in_place {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "detail": "in_place_root must lie under this tenant's managed backup path"
+                })),
+            );
+        }
         (
             StatusCode::CREATED,
             Json(serde_json::json!({
                 "backup_id": backup_id,
-                "upload_required": false,
+                "upload_required": !in_place,
                 "declared_objects": declared,
                 "completed_relative_keys": [],
             })),
@@ -4487,7 +4517,8 @@ mod tests {
             cloud_listener.local_addr().expect("Cloud stub address")
         );
         let cloud = Arc::new(InPlaceCloudStub {
-            declared: Mutex::new(None),
+            declared: Mutex::new(Vec::new()),
+            reject_in_place: false,
             target_calls: AtomicUsize::new(0),
             completions: AtomicUsize::new(0),
         });
@@ -4561,20 +4592,133 @@ mod tests {
             "in-place native mirror completes",
         );
 
-        let declared = cloud
-            .declared
-            .lock()
-            .expect("declared lock")
-            .clone()
-            .expect("the sweep declared the snapshot");
-        assert_eq!(declared["in_place_root"], expected_root);
-        assert_eq!(declared["objects"].as_array().map(Vec::len), Some(2));
+        let declared = cloud.declared.lock().expect("declared lock").clone();
+        assert_eq!(declared.len(), 1, "one declaration, accepted first time");
+        assert_eq!(declared[0]["in_place_root"], expected_root);
+        assert_eq!(declared[0]["objects"].as_array().map(Vec::len), Some(2));
         assert_eq!(
             cloud.target_calls.load(Ordering::SeqCst),
             0,
             "an in-place snapshot must never ask for an upload target"
         );
         assert_eq!(cloud.completions.load(Ordering::SeqCst), 1);
+    }
+
+    /// Cloud answering 400 to an in-place declaration is a verdict on the
+    /// layout, not a transient fault. The sweep must not retry it forever:
+    /// it re-declares without the root and takes the copy path, which is
+    /// what Cloud always accepted. The stub's target endpoint returns 500,
+    /// so reaching it is the proof that the fallback happened, and the
+    /// resulting error is `Retry`, exactly as for any copy-path hiccup.
+    #[tokio::test]
+    async fn a_rejected_in_place_declaration_falls_back_to_the_copy_path() {
+        let Some((origin, state)) = spawn_repository_stub(HashMap::new()).await else {
+            return;
+        };
+        let cloud_listener = match tokio::net::TcpListener::bind("127.0.0.1:0").await {
+            Ok(listener) => listener,
+            Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
+                eprintln!("sandbox denied TCP bind; skipping in-place fallback test");
+                return;
+            }
+            Err(error) => panic!("bind Cloud stub: {error}"),
+        };
+        let cloud_origin = format!(
+            "http://{}",
+            cloud_listener.local_addr().expect("Cloud stub address")
+        );
+        let cloud = Arc::new(InPlaceCloudStub {
+            declared: Mutex::new(Vec::new()),
+            reject_in_place: true,
+            target_calls: AtomicUsize::new(0),
+            completions: AtomicUsize::new(0),
+        });
+        let app = Router::new()
+            .route("/v1/backups/native/snapshots", post(in_place_declare_stub))
+            .route(
+                "/v1/backups/native/objects/target",
+                post(in_place_target_stub),
+            )
+            .route(
+                "/v1/backups/native/snapshots/complete",
+                post(in_place_complete_stub),
+            )
+            .with_state(cloud.clone());
+        tokio::spawn(async move {
+            axum::serve(cloud_listener, app)
+                .await
+                .expect("serve Cloud stub");
+        });
+
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("in-memory SQLite connects");
+        let (encryption, backup) = seed_redis_fallback_backup(&db, &origin).await;
+        let (dump_key, metadata_key) = redis_fallback_repository_keys(&backup);
+        {
+            let mut objects = state.objects.lock().expect("repository stub objects lock");
+            objects.insert(dump_key, b"redis-rdb-dump-bytes".to_vec());
+            objects.insert(metadata_key, b"{\"redis_version\":\"7.4\"}".to_vec());
+        }
+
+        let temp = tempfile::tempdir().expect("cloud-link state dir");
+        let state_dir = temp.path().join("cloud-link");
+        std::fs::create_dir_all(&state_dir).expect("cloud-link state dir");
+        let instance_id = Uuid::new_v4();
+        std::fs::write(
+            state_dir.join("state.json"),
+            serde_json::json!({
+                "instance_id": instance_id,
+                "base_url": cloud_origin,
+                "allow_loopback_development": true,
+                "token": "test-instance-token",
+                "tenant_id": Uuid::new_v4(),
+                "account_email": "backup-owner@example.invalid",
+            })
+            .to_string(),
+        )
+        .expect("write Cloud link state");
+        let link = Arc::new(CloudLink::load_for_loopback_development(
+            temp.path().to_path_buf(),
+            "test-agent",
+        ));
+        link.set_feature_switches(CloudFeatureSwitches {
+            telemetry: false,
+            backups: true,
+            notifications: false,
+        })
+        .expect("enable backup mirroring");
+        let mut resources =
+            super::SweepResources::load(&db, &encryption, std::slice::from_ref(&backup))
+                .await
+                .expect("resources load");
+
+        let error = mirror_backup(&link, &mut resources, &backup, instance_id)
+            .await
+            .expect_err("the copy path hits the stub's failing target endpoint");
+        match error {
+            StageError::Retry(_) => {}
+            StageError::Unsupported(reason) => {
+                panic!("a copy-path target failure is transient, not Unsupported: {reason}")
+            }
+        }
+
+        let declared = cloud.declared.lock().expect("declared lock").clone();
+        assert_eq!(
+            declared.len(),
+            2,
+            "in-place attempt, then the copy-path re-declaration"
+        );
+        assert!(declared[0].get("in_place_root").is_some());
+        assert!(
+            declared[1].get("in_place_root").is_none(),
+            "the fallback must not carry the rejected root"
+        );
+        assert!(
+            cloud.target_calls.load(Ordering::SeqCst) > 0,
+            "the copy path asked for an upload target"
+        );
+        assert_eq!(cloud.completions.load(Ordering::SeqCst), 0);
     }
 
     /// The `mirror_native_backup` fallback branch treats a dump with no

--- a/crates/temps-cloud/src/backup_mirror.rs
+++ b/crates/temps-cloud/src/backup_mirror.rs
@@ -1155,6 +1155,31 @@ async fn mirror_native_backup(
     .await
 }
 
+/// The root Cloud may catalog in place for this snapshot, if any.
+///
+/// A managed source's bucket is the tenant's cloud backup bucket, so the
+/// objects the engine wrote under `root` already are the offsite copy. Telling
+/// Cloud where they are lets it catalog them in place rather than have the
+/// sweep read every object back and upload it a second time into Cloud's own
+/// layout in the same bucket. A Cloud that predates the field answers
+/// `upload_required: true` and the copy path runs unchanged.
+///
+/// Only snapshot-exclusive layouts qualify: an object set or a logical dump
+/// lives under a root that belongs to this backup alone. A WAL-G stream
+/// snapshot (Redis/MongoDB `/walg`, MariaDB physical) selects its objects out
+/// of a repository shared by every backup of that service, and WAL-G's own
+/// retention later deletes from it, so cataloging those objects in place would
+/// leave Cloud pointing at files that disappear. They keep the copy path.
+fn in_place_root_for(
+    managed_by_cloud: bool,
+    compression: BackupCompression,
+    root: &str,
+) -> Option<String> {
+    (managed_by_cloud && compression != BackupCompression::WalGNative)
+        .then(|| root.trim_matches('/').to_string())
+        .filter(|root| !root.is_empty())
+}
+
 /// Declare, upload (if required), and complete a native snapshot against
 /// Cloud. Factored out of `mirror_native_backup` so [`mirror_control_plane_backup`]
 /// can reuse the same declare/upload/complete sequence without duplicating
@@ -1218,16 +1243,7 @@ async fn declare_and_complete_native_snapshot(
             .ok_or_else(|| StageError::Retry("Cloud link lost its tenant identity".into()))?,
         format!("{instance_id}:{}", backup.backup_id).as_bytes(),
     );
-    // A managed source's bucket is the tenant's cloud backup bucket, so the
-    // objects the engine wrote under `root` already are the offsite copy.
-    // Tell Cloud where they are and let it catalog them in place rather than
-    // reading every object back and uploading it a second time into Cloud's
-    // own layout in the same bucket. A Cloud that predates the field answers
-    // `upload_required: true` and the copy path below runs unchanged.
-    let in_place_root = source_config
-        .managed_by_cloud
-        .then(|| root.trim_matches('/').to_string())
-        .filter(|root| !root.is_empty());
+    let in_place_root = in_place_root_for(source_config.managed_by_cloud, compression, root);
     let mut request = NativeSnapshotRequest {
         backup_id: cloud_backup_id,
         instance_id,
@@ -2600,7 +2616,8 @@ mod tests {
     use sha2::{Digest, Sha256};
     use temps_cloud_client::{BackendUrl, CloudFeatureSwitches, CloudLink};
     use temps_cloud_protocol::{
-        NativeSnapshotObjectDeclaration, NativeSnapshotObjectKind, WalGObjectCompleted,
+        BackupCompression, NativeSnapshot, NativeSnapshotObjectDeclaration,
+        NativeSnapshotObjectKind, NativeSnapshotRequest, WalGObjectCompleted,
         WalGObjectTargetRequest,
     };
     use uuid::Uuid;
@@ -4434,9 +4451,24 @@ mod tests {
         );
     }
 
+    #[test]
+    fn only_snapshot_exclusive_layouts_on_managed_sources_catalog_in_place() {
+        let root = "/t/managed-backups/external_services/s3/store/2026-09-11/backup-7/";
+        assert_eq!(
+            super::in_place_root_for(true, BackupCompression::None, root).as_deref(),
+            Some("t/managed-backups/external_services/s3/store/2026-09-11/backup-7")
+        );
+        assert!(super::in_place_root_for(true, BackupCompression::Gzip, root).is_some());
+        // Shared WAL-G repositories are rotated by WAL-G retention: copy.
+        assert!(super::in_place_root_for(true, BackupCompression::WalGNative, root).is_none());
+        // Operator-owned sources are not the cloud bucket: copy.
+        assert!(super::in_place_root_for(false, BackupCompression::None, root).is_none());
+        assert!(super::in_place_root_for(true, BackupCompression::None, "/").is_none());
+    }
+
     struct InPlaceCloudStub {
-        /// Every declaration body received, in order.
-        declared: Mutex<Vec<serde_json::Value>>,
+        /// Every declaration received, in order.
+        declared: Mutex<Vec<NativeSnapshotRequest>>,
         /// Refuse declarations that carry `in_place_root` with a 400, the
         /// way Cloud does for a root it will not catalog.
         reject_in_place: bool,
@@ -4444,54 +4476,57 @@ mod tests {
         completions: AtomicUsize,
     }
 
+    /// Cloud's problem body for a refused request.
+    #[derive(serde::Serialize)]
+    struct StubRejection {
+        detail: &'static str,
+    }
+
+    /// Cloud's acknowledgement of a completed snapshot.
+    #[derive(serde::Serialize)]
+    struct StubCompletion {
+        state: &'static str,
+    }
+
     async fn in_place_declare_stub(
         State(state): State<Arc<InPlaceCloudStub>>,
-        Json(request): Json<serde_json::Value>,
-    ) -> (StatusCode, Json<serde_json::Value>) {
-        let backup_id = request["backup_id"].clone();
-        let declared = request["objects"]
-            .as_array()
-            .map(Vec::len)
-            .unwrap_or_default();
-        let in_place = request.get("in_place_root").is_some();
+        Json(request): Json<NativeSnapshotRequest>,
+    ) -> Result<(StatusCode, Json<NativeSnapshot>), (StatusCode, Json<StubRejection>)> {
+        let in_place = request.in_place_root.is_some();
+        let response = NativeSnapshot {
+            backup_id: request.backup_id,
+            upload_required: !in_place,
+            completed_relative_keys: Vec::new(),
+        };
         state.declared.lock().expect("declared lock").push(request);
         if in_place && state.reject_in_place {
-            return (
+            return Err((
                 StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({
-                    "detail": "in_place_root must lie under this tenant's managed backup path"
-                })),
-            );
+                Json(StubRejection {
+                    detail: "in_place_root must lie under this tenant's managed backup path",
+                }),
+            ));
         }
-        (
-            StatusCode::CREATED,
-            Json(serde_json::json!({
-                "backup_id": backup_id,
-                "upload_required": !in_place,
-                "declared_objects": declared,
-                "completed_relative_keys": [],
-            })),
-        )
+        Ok((StatusCode::CREATED, Json(response)))
     }
 
     async fn in_place_target_stub(
         State(state): State<Arc<InPlaceCloudStub>>,
-    ) -> (StatusCode, Json<serde_json::Value>) {
+    ) -> (StatusCode, Json<StubRejection>) {
         state.target_calls.fetch_add(1, Ordering::SeqCst);
         (
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({"detail": "in-place snapshots never request targets"})),
+            Json(StubRejection {
+                detail: "in-place snapshots never request targets",
+            }),
         )
     }
 
     async fn in_place_complete_stub(
         State(state): State<Arc<InPlaceCloudStub>>,
-    ) -> (StatusCode, Json<serde_json::Value>) {
+    ) -> (StatusCode, Json<StubCompletion>) {
         state.completions.fetch_add(1, Ordering::SeqCst);
-        (
-            StatusCode::OK,
-            Json(serde_json::json!({"state": "complete"})),
-        )
+        (StatusCode::OK, Json(StubCompletion { state: "complete" }))
     }
 
     /// A managed source's bucket is the tenant's cloud bucket, so the sweep
@@ -4594,8 +4629,11 @@ mod tests {
 
         let declared = cloud.declared.lock().expect("declared lock").clone();
         assert_eq!(declared.len(), 1, "one declaration, accepted first time");
-        assert_eq!(declared[0]["in_place_root"], expected_root);
-        assert_eq!(declared[0]["objects"].as_array().map(Vec::len), Some(2));
+        assert_eq!(
+            declared[0].in_place_root.as_deref(),
+            Some(expected_root.as_str())
+        );
+        assert_eq!(declared[0].objects.len(), 2);
         assert_eq!(
             cloud.target_calls.load(Ordering::SeqCst),
             0,
@@ -4709,9 +4747,9 @@ mod tests {
             2,
             "in-place attempt, then the copy-path re-declaration"
         );
-        assert!(declared[0].get("in_place_root").is_some());
+        assert!(declared[0].in_place_root.is_some());
         assert!(
-            declared[1].get("in_place_root").is_none(),
+            declared[1].in_place_root.is_none(),
             "the fallback must not carry the rejected root"
         );
         assert!(


### PR DESCRIPTION
## Why

A Cloud-managed backup source (`s3_sources.managed_by_cloud`) is the tenant's own cloud bucket. The backup engines already write every object there directly. The mirror sweep then re-read each object, requested a presigned URL from Cloud per object and uploaded it a second time into Cloud's catalog layout in the **same bucket**. For an S3 mirror of N objects that meant:

- 2× storage for every snapshot, permanently (Cloud never expired its copy)
- every byte crossing the instance's link three times (engine write, checksum read, re-upload)
- two Cloud round trips per object plus a full read, which is why large object sets sat in "Uploading" for hours and why a single rejected presigned PUT could wedge a snapshot indefinitely

Cloud-side counterpart is ADR 0028 in the Cloud repo: the declaration may carry the engine's root, Cloud lists that prefix once, checks every declared object is present at its declared size, records the rows complete and answers `upload_required: false`.

## What

- `temps-cloud-protocol`: `NativeSnapshotRequest.in_place_root: Option<String>` (`serde(default)`, omitted when `None`, so the wire format for existing senders is byte-identical).
- `temps-cloud` sweep: sets `in_place_root` to the engine's root for managed sources and skips the upload loop when Cloud answers `upload_required: false`. A Cloud that predates the field ignores it and the copy path runs exactly as before.

WAL-G repositories keep the copy path for now (shared objects rotated by WAL-G's own retention; tracked as a follow-up in the ADR).

## Evidence

**Protocol round-trip**
```
cargo test -p temps-cloud-protocol --lib -- native_snapshot_in_place_root_round_trips_and_defaults native_mongodb_snapshot_has_a_tagged_restore_identity
test result: ok. 2 passed
```

**Sweep end to end against a real S3 stub and a stub Cloud** that answers `upload_required: false` and returns 500 on any object-target call:
```
cargo test -p temps-cloud --lib -- managed_native_snapshots_are_declared_in_place_and_never_re_uploaded --nocapture
test backup_mirror::tests::managed_native_snapshots_are_declared_in_place_and_never_re_uploaded ... ok
```
Asserts: declared body carries `in_place_root == <engine root>`, two objects declared, **0** target calls, **1** snapshot completion.

**Full crates**
```
cargo test -p temps-cloud -p temps-cloud-protocol --lib
111 passed
cargo clippy -p temps-cloud -p temps-cloud-protocol --all-targets -- -D warnings   # clean
```