### PR TITLE
fix(ci): stop blocking builds on captcha WASM byte differences

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -171,19 +171,15 @@ jobs:
             temps-musl-fast-
             compose-security-musl-
 
-      # The committed package has a canonical Linux/AMD64 compiler host.
-      # Rust's WASM output can differ between host architectures. Verify before
-      # the web UI and application build, which can take over an hour cold.
-      - name: Rebuild CAPTCHA WASM in canonical toolchain
+      # Build the CAPTCHA from source before embedding it in the application.
+      # Byte differences from the committed package do not block the build.
+      - name: Rebuild CAPTCHA WASM in toolchain container
         run: |
           docker run --rm --platform linux/amd64 \
             --volume "$PWD":/build --workdir /build/crates/temps-captcha-wasm \
             --env CARGO_TARGET_DIR=/tmp/captcha-target \
             temps-toolchain:ci \
             sh -ec 'git config --global --add safe.directory /build; rustc -Vv; wasm-pack --version; wasm-bindgen --version; npm run build'
-
-      - name: Verify committed WASM package matches a reproducible rebuild
-        run: bash scripts/verify-captcha-wasm.sh
 
       # Continues the Dockerfile builder stage (web UI -> cargo build)
       # inside the toolchain container, with target/ and the cargo registry

--- a/crates/temps-captcha-wasm/README.md
+++ b/crates/temps-captcha-wasm/README.md
@@ -19,7 +19,10 @@ bash scripts/rebuild-captcha-wasm.sh
 This uses the Dockerfile's pinned toolchain on **Linux/AMD64**, including on
 Apple Silicon. The compiler host architecture affects the generated WASM bytes;
 a native ARM64 or macOS rebuild is not the canonical artifact. Commit the updated
-`pkg/` files after regenerating. CI verifies this before building the application.
+`pkg/` files after regenerating. CI rebuilds the package from source before
+building the application; it does not require byte equality with the committed
+package. `bash scripts/verify-captcha-wasm.sh` remains available as an optional
+local comparison.
 
 For local development (output may differ from the committed package):
 

--- a/scripts/test_captcha_wasm_build.py
+++ b/scripts/test_captcha_wasm_build.py
@@ -66,9 +66,10 @@ class CaptchaWasmBuildTests(unittest.TestCase):
         self.assertNotIn("matches the canonical rebuild", result.stdout)
         self.assertIn("Cannot inspect", result.stderr)
 
-    def test_gate_precedes_application_build(self):
+    def test_ci_rebuilds_before_application_without_byte_comparison(self):
         workflow = (ROOT / ".github/workflows/rust-tests.yml").read_text()
-        self.assertLess(workflow.index("run: bash scripts/verify-captcha-wasm.sh"),
+        self.assertNotIn("scripts/verify-captcha-wasm.sh", workflow)
+        self.assertLess(workflow.index("name: Rebuild CAPTCHA WASM in toolchain container"),
                         workflow.index("cargo build --profile fast --bin temps"))
 
     def test_rebuild_uses_amd64_for_image_and_container(self):


### PR DESCRIPTION
CI rebuilds CAPTCHA WASM from source successfully, then fails because its bytes differ from the committed package. Remove that byte-comparison gate as requested. The WASM build remains mandatory and runs before the web/application builds, so the application embeds the fresh output and compilation errors still fail CI.

Keep the comparison script available for optional local diagnostics and update the README. The workflow regression test now asserts that CI retains the source rebuild before application compilation without invoking the byte gate.

## Evidence

```text
$ python3 scripts/test_captcha_wasm_build.py
Ran 7 tests
OK
$ python3 .github/scripts/check-cache-save-guards.py
OK: PR caches are guarded and the release workflow cache is read-only.
$ git diff --check
(no output)
```
The main run at https://github.com/gotempsh/temps/actions/runs/34538990450/job/103086488883 already passed the retained WASM rebuild step and failed only at the comparison step removed here. No Rust source or generated WASM changes. Full application CI remains pending on this PR.
