### PR TITLE
feat(cloud): declare managed backups by size, WAL-G repositories in place, report deletions

### DIFF
--- a/crates/temps-backup/src/services/backup.rs
+++ b/crates/temps-backup/src/services/backup.rs
@@ -10813,14 +10813,43 @@ mod tests {
     struct NoopJobQueue;
 
     /// Records every job sent, so a test can assert what the service
-    /// published without a live consumer.
+    /// published without a live consumer. Flip `refuse` to make every send
+    /// fail, the way a queue does when its backing channel is gone.
     struct RecordingJobQueue {
         sent: std::sync::Mutex<Vec<temps_core::Job>>,
+        refuse: std::sync::atomic::AtomicBool,
+    }
+
+    impl RecordingJobQueue {
+        fn new() -> Self {
+            Self {
+                sent: std::sync::Mutex::new(Vec::new()),
+                refuse: std::sync::atomic::AtomicBool::new(false),
+            }
+        }
+
+        /// The `BackupDeleted` jobs published so far, in order.
+        fn deleted_jobs(&self) -> Vec<temps_core::BackupDeletedJob> {
+            self.sent
+                .lock()
+                .unwrap()
+                .iter()
+                .filter_map(|job| match job {
+                    temps_core::Job::BackupDeleted(job) => Some(job.clone()),
+                    _ => None,
+                })
+                .collect()
+        }
     }
 
     #[async_trait::async_trait]
     impl temps_core::JobQueue for RecordingJobQueue {
         async fn send(&self, job: temps_core::Job) -> Result<(), temps_core::QueueError> {
+            if self.refuse.load(std::sync::atomic::Ordering::SeqCst) {
+                return Err(temps_core::QueueError::SendError(
+                    "queue refused the job for the test".to_string(),
+                ));
+            }
             self.sent.lock().unwrap().push(job);
             Ok(())
         }
@@ -11313,9 +11342,7 @@ mod tests {
             config_service,
             encryption_service,
         );
-        let published = Arc::new(RecordingJobQueue {
-            sent: std::sync::Mutex::new(Vec::new()),
-        });
+        let published = Arc::new(RecordingJobQueue::new());
         backup_service.set_queue(published.clone());
 
         // Create a test user for backup operations
@@ -11496,21 +11523,18 @@ mod tests {
             .expect("backup deletion should complete");
         assert_eq!(deleted_objects, 2, "dump and metadata must be deleted");
         // Anything cataloging this backup elsewhere (the Cloud mirror) hears
-        // about the deletion, keyed on the stable backup uuid.
-        let deleted_jobs: Vec<temps_core::BackupDeletedJob> = published
-            .sent
-            .lock()
-            .unwrap()
-            .iter()
-            .filter_map(|job| match job {
-                temps_core::Job::BackupDeleted(job) => Some(job.clone()),
-                _ => None,
-            })
-            .collect();
+        // about the deletion, keyed on the stable backup uuid, and only once
+        // the row is gone: the job is the last thing the deletion does.
+        let deleted_jobs = published.deleted_jobs();
         assert_eq!(deleted_jobs.len(), 1, "one BackupDeleted per deletion");
         assert_eq!(deleted_jobs[0].backup_uuid, backup_result.backup_id);
         assert_eq!(deleted_jobs[0].backup_id, backup_result.id);
         assert_eq!(deleted_jobs[0].s3_location, backup_result.s3_location);
+        assert!(backup_service
+            .get_backup(&backup_result.backup_id)
+            .await
+            .expect("database lookup should succeed")
+            .is_none());
         let remaining = s3_client
             .list_objects_v2()
             .bucket(bucket_name)
@@ -11548,6 +11572,85 @@ mod tests {
             .expect("backup index must contain an array")
             .iter()
             .all(|entry| entry["backup_id"] != backup_result.backup_id));
+
+        // Retention deletion goes through the same path and publishes the
+        // same job. Age a second backup past the schedule's retention period
+        // and let the scheduler's sweep delete it.
+        let retained = backup_service
+            .create_backup(Some(schedule.id), s3_source.id, "full", 1)
+            .await
+            .expect("Failed to create the backup that retention will expire");
+        temps_entities::backups::Entity::update_many()
+            .col_expr(
+                temps_entities::backups::Column::StartedAt,
+                sea_orm::sea_query::Expr::value(chrono::Utc::now() - chrono::Duration::days(8)),
+            )
+            .filter(temps_entities::backups::Column::Id.eq(retained.id))
+            .exec(test_db.db.as_ref())
+            .await
+            .expect("aging the backup should succeed");
+        let report = backup_service
+            .enforce_retention(Some(schedule.id), None)
+            .await
+            .expect("retention enforcement should complete");
+        assert_eq!(report.deleted, 1, "the aged backup is the only candidate");
+        assert_eq!(report.failed, 0, "{:?}", report.failures);
+        let deleted_jobs = published.deleted_jobs();
+        assert_eq!(
+            deleted_jobs.len(),
+            2,
+            "retention publishes BackupDeleted too"
+        );
+        assert_eq!(deleted_jobs[1].backup_uuid, retained.backup_id);
+        assert_eq!(deleted_jobs[1].backup_id, retained.id);
+        assert!(backup_service
+            .get_backup(&retained.backup_id)
+            .await
+            .expect("database lookup should succeed")
+            .is_none());
+
+        // Publishing is best effort: a queue that refuses the job must not
+        // turn a finished deletion into an error, and must not leave the row
+        // or the objects behind.
+        let unannounced = backup_service
+            .create_backup(Some(schedule.id), s3_source.id, "full", 1)
+            .await
+            .expect("Failed to create the backup deleted without a queue");
+        published
+            .refuse
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let (_, deleted_objects) = backup_service
+            .delete_backup(&unannounced.backup_id)
+            .await
+            .expect("a refused publication must not fail the deletion");
+        assert_eq!(
+            deleted_objects, 2,
+            "dump and metadata must still be deleted"
+        );
+        assert_eq!(
+            published.deleted_jobs().len(),
+            2,
+            "the refused job is not recorded"
+        );
+        assert!(backup_service
+            .get_backup(&unannounced.backup_id)
+            .await
+            .expect("database lookup should succeed")
+            .is_none());
+        let unannounced_prefix =
+            validated_snapshot_prefix(&unannounced.s3_location, &s3_source, &unannounced.backup_id)
+                .expect("backup must have an attributable snapshot prefix");
+        let remaining = s3_client
+            .list_objects_v2()
+            .bucket(bucket_name)
+            .prefix(format!("{unannounced_prefix}/"))
+            .send()
+            .await
+            .expect("snapshot prefix should remain listable");
+        assert!(
+            remaining.contents().is_empty(),
+            "snapshot prefix must be empty"
+        );
 
         println!("\n✓ Integration test passed:");
         println!("  - Database container started (timescale/timescaledb-ha)");

--- a/crates/temps-backup/src/services/backup.rs
+++ b/crates/temps-backup/src/services/backup.rs
@@ -4746,6 +4746,24 @@ SELECT cp.id
         }
 
         info!(backup_id = %backup.backup_id, "Backup deleted successfully");
+        // Tell anyone cataloging this instance's backups elsewhere. Best
+        // effort: the deletion is done either way, and the Cloud mirror has
+        // its own presence check for events that never arrive.
+        if let Some(queue) = self.queue.get() {
+            if let Err(error) = queue
+                .send(temps_core::Job::BackupDeleted(
+                    temps_core::BackupDeletedJob {
+                        backup_id: backup.id,
+                        backup_uuid: backup.backup_id.clone(),
+                        engine: engine.to_string(),
+                        s3_location: backup.s3_location.clone(),
+                    },
+                ))
+                .await
+            {
+                warn!(backup_id = %backup.backup_id, error = %error, "could not publish BackupDeleted");
+            }
+        }
         Ok((backup, deleted_objects))
     }
 

--- a/crates/temps-backup/src/services/backup.rs
+++ b/crates/temps-backup/src/services/backup.rs
@@ -10812,6 +10812,24 @@ mod tests {
 
     struct NoopJobQueue;
 
+    /// Records every job sent, so a test can assert what the service
+    /// published without a live consumer.
+    struct RecordingJobQueue {
+        sent: std::sync::Mutex<Vec<temps_core::Job>>,
+    }
+
+    #[async_trait::async_trait]
+    impl temps_core::JobQueue for RecordingJobQueue {
+        async fn send(&self, job: temps_core::Job) -> Result<(), temps_core::QueueError> {
+            self.sent.lock().unwrap().push(job);
+            Ok(())
+        }
+
+        fn subscribe(&self) -> Box<dyn temps_core::JobReceiver> {
+            unimplemented!("RecordingJobQueue does not support subscribing in tests")
+        }
+    }
+
     #[async_trait::async_trait]
     impl temps_core::JobQueue for NoopJobQueue {
         async fn send(&self, _job: temps_core::Job) -> Result<(), temps_core::QueueError> {
@@ -11295,6 +11313,10 @@ mod tests {
             config_service,
             encryption_service,
         );
+        let published = Arc::new(RecordingJobQueue {
+            sent: std::sync::Mutex::new(Vec::new()),
+        });
+        backup_service.set_queue(published.clone());
 
         // Create a test user for backup operations
         use sea_orm::{ActiveModelTrait, Set};
@@ -11473,6 +11495,22 @@ mod tests {
             .await
             .expect("backup deletion should complete");
         assert_eq!(deleted_objects, 2, "dump and metadata must be deleted");
+        // Anything cataloging this backup elsewhere (the Cloud mirror) hears
+        // about the deletion, keyed on the stable backup uuid.
+        let deleted_jobs: Vec<temps_core::BackupDeletedJob> = published
+            .sent
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|job| match job {
+                temps_core::Job::BackupDeleted(job) => Some(job.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(deleted_jobs.len(), 1, "one BackupDeleted per deletion");
+        assert_eq!(deleted_jobs[0].backup_uuid, backup_result.backup_id);
+        assert_eq!(deleted_jobs[0].backup_id, backup_result.id);
+        assert_eq!(deleted_jobs[0].s3_location, backup_result.s3_location);
         let remaining = s3_client
             .list_objects_v2()
             .bucket(bucket_name)

--- a/crates/temps-cloud-protocol/src/messages.rs
+++ b/crates/temps-cloud-protocol/src/messages.rs
@@ -314,7 +314,12 @@ pub struct NativeSnapshotObjectDeclaration {
     pub relative_key: String,
     pub kind: NativeSnapshotObjectKind,
     pub bytes: u64,
-    pub checksum_sha256: String,
+    /// Hex SHA-256 of the object. Optional: an object Cloud catalogs in
+    /// place (`in_place_root`) is declared by size alone, so the instance
+    /// never reads it back to hash it. The copy path always carries one,
+    /// because Cloud binds it into the presigned upload.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub checksum_sha256: Option<String>,
 }
 
 /// Engine-neutral registration envelope for physical/native backups.
@@ -394,8 +399,11 @@ pub struct WalGObjectDeclaration {
     pub bytes: u64,
     /// Hex SHA-256 computed by streaming the source object once. Cloud binds
     /// it into the presigned PUT; the subsequent upload is a second bounded-
-    /// memory stream and never requires a local staging file.
-    pub checksum_sha256: String,
+    /// memory stream and never requires a local staging file. Optional for
+    /// the same reason as on `NativeSnapshotObjectDeclaration`: a
+    /// repository cataloged in place is declared by size alone.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub checksum_sha256: Option<String>,
 }
 
 /// Register a physical PostgreSQL snapshot before mirroring its objects.
@@ -413,6 +421,16 @@ pub struct WalGSnapshotRequest {
     pub start_lsn: String,
     pub finish_lsn: String,
     pub objects: Vec<WalGObjectDeclaration>,
+    /// The WAL-G repository root in the Cloud-managed bucket under which
+    /// every object in `objects` already sits (`<in_place_root>/<relative_key>`).
+    /// Same contract as `NativeSnapshotRequest::in_place_root`: set only for
+    /// sources the cloud manages, so Cloud catalogs the repository where it
+    /// is instead of asking for a second copy. The repository is shared by
+    /// every snapshot of the service; Cloud confirms only the declared keys.
+    /// A Cloud that predates the field ignores it and answers
+    /// `upload_required: true`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub in_place_root: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -664,6 +682,9 @@ pub enum BackupLifecycleStage {
     Started,
     Completed,
     Failed,
+    /// The instance deleted the backup (schedule retention or by hand), so
+    /// Cloud's catalog entry for it must stop being offered as restorable.
+    Deleted,
 }
 
 /// A backup lifecycle transition reported by an instance. `instance_id`
@@ -684,6 +705,12 @@ pub struct BackupLifecycleEventRequest {
     pub size_bytes: Option<i64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error_message: Option<String>,
+    /// The instance's own `backups.backup_id` (its stable UUID string), the
+    /// value the mirror sweep hashes with `instance_id` into the catalog
+    /// `backup_id`. Sent with `Deleted` so Cloud can find the catalog entry
+    /// without a lookup table; older instances never send it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backup_uuid: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1078,13 +1105,57 @@ mod tests {
                     "basebackups_005/base_00000001000000000000000A_backup_stop_sentinel.json".into(),
                 kind: WalGObjectKind::Sentinel,
                 bytes: 512,
-                checksum_sha256: "00".repeat(32),
+                checksum_sha256: Some("00".repeat(32)),
             }],
+            in_place_root: None,
         };
         let value = serde_json::to_value(request).unwrap();
         assert_eq!(value["engine"], "postgres");
         assert_eq!(value["objects"][0]["kind"], "sentinel");
         assert_eq!(value["timeline"], 1);
+    }
+
+    /// An in-place declaration carries no checksum and the WAL-G root; the
+    /// keys are absent from the wire, not null, so a Cloud built before them
+    /// sees the request it always did.
+    #[test]
+    fn in_place_declarations_omit_absent_checksums_and_carry_the_root() {
+        let object = WalGObjectDeclaration {
+            relative_key: "wal_005/000000010000000000000005.lz4".into(),
+            kind: WalGObjectKind::Wal,
+            bytes: 16_777_216,
+            checksum_sha256: None,
+        };
+        let value = serde_json::to_value(&object).unwrap();
+        assert!(value.get("checksum_sha256").is_none());
+        let parsed: WalGObjectDeclaration = serde_json::from_value(value).unwrap();
+        assert_eq!(parsed, object);
+        let with_hash: WalGObjectDeclaration = serde_json::from_value(serde_json::json!({
+            "relative_key": "a",
+            "kind": "wal",
+            "bytes": 1,
+            "checksum_sha256": "ab".repeat(32),
+        }))
+        .unwrap();
+        assert_eq!(
+            with_hash.checksum_sha256.as_deref(),
+            Some("ab".repeat(32).as_str())
+        );
+
+        let event = BackupLifecycleEventRequest {
+            instance_id: Uuid::new_v4(),
+            backup_id: 3,
+            engine: "postgres_walg".into(),
+            stage: BackupLifecycleStage::Deleted,
+            occurred_at: chrono::Utc::now(),
+            s3_location: None,
+            size_bytes: None,
+            error_message: None,
+            backup_uuid: Some("backup-uuid".into()),
+        };
+        let value = serde_json::to_value(&event).unwrap();
+        assert_eq!(value["stage"], "deleted");
+        assert_eq!(value["backup_uuid"], "backup-uuid");
     }
 
     #[test]
@@ -1104,7 +1175,7 @@ mod tests {
                 relative_key: "streams/mongodb.archive.lz4".into(),
                 kind: NativeSnapshotObjectKind::Data,
                 bytes: 1_024,
-                checksum_sha256: "ab".repeat(32),
+                checksum_sha256: Some("ab".repeat(32)),
             }],
             source_image: None,
             in_place_root: None,

--- a/crates/temps-cloud/src/backup_mirror.rs
+++ b/crates/temps-cloud/src/backup_mirror.rs
@@ -1164,20 +1164,72 @@ async fn mirror_native_backup(
 /// layout in the same bucket. A Cloud that predates the field answers
 /// `upload_required: true` and the copy path runs unchanged.
 ///
-/// Only snapshot-exclusive layouts qualify: an object set or a logical dump
-/// lives under a root that belongs to this backup alone. A WAL-G stream
-/// snapshot (Redis/MongoDB `/walg`, MariaDB physical) selects its objects out
-/// of a repository shared by every backup of that service, and WAL-G's own
-/// retention later deletes from it, so cataloging those objects in place would
-/// leave Cloud pointing at files that disappear. They keep the copy path.
-fn in_place_root_for(
-    managed_by_cloud: bool,
-    compression: BackupCompression,
-    root: &str,
-) -> Option<String> {
-    (managed_by_cloud && compression != BackupCompression::WalGNative)
+/// Every managed source qualifies, including WAL-G repositories shared by
+/// every backup of a service: Cloud confirms only the declared keys of a
+/// shared repository and hears about deletions through the `deleted`
+/// lifecycle event (and its own presence check), so WAL-G's retention no
+/// longer leaves it pointing at files that disappeared.
+fn in_place_root_for(managed_by_cloud: bool, root: &str) -> Option<String> {
+    managed_by_cloud
         .then(|| root.trim_matches('/').to_string())
         .filter(|root| !root.is_empty())
+}
+
+/// Build a native snapshot's object declarations from the listing. With
+/// `hash`, every object is streamed once for its SHA-256 (the copy path
+/// needs it: Cloud binds it into the presigned upload). Without, the listed
+/// size is the declaration and nothing is read: an in-place declaration is
+/// confirmed by Cloud against the bucket, and reading every object back
+/// only to hash it was the whole cost of a sweep.
+async fn native_declarations(
+    resources: &mut SweepResources<'_>,
+    backup: &backups::Model,
+    source_config: &s3_sources::Model,
+    root: &str,
+    selected: &[SourceObject],
+    engine: BackupEngine,
+    hash: bool,
+) -> Result<Vec<NativeSnapshotObjectDeclaration>, StageError> {
+    let mut declarations = Vec::with_capacity(selected.len());
+    for object in selected {
+        let (bytes, checksum_sha256) = if hash {
+            let (bytes, checksum) = resources
+                .inspect_object(backup.s3_source_id, &source_config.bucket_name, &object.key)
+                .await?;
+            if bytes != object.bytes {
+                return Err(StageError::Retry(format!(
+                    "native snapshot object {} changed while its manifest was built",
+                    object.key
+                )));
+            }
+            (bytes, Some(checksum))
+        } else {
+            (object.bytes, None)
+        };
+        let relative_key = object
+            .key
+            .strip_prefix(&format!("{root}/"))
+            .unwrap_or_else(|| object.key.rsplit('/').next().unwrap_or(&object.key))
+            .to_string();
+        let kind = if object.key.ends_with("_backup_stop_sentinel.json")
+            || object.key.ends_with("metadata.json")
+        {
+            NativeSnapshotObjectKind::Metadata
+        } else if engine == BackupEngine::MariaDb {
+            NativeSnapshotObjectKind::BaseBackup
+        } else if engine == BackupEngine::RustFs {
+            NativeSnapshotObjectKind::Object
+        } else {
+            NativeSnapshotObjectKind::Data
+        };
+        declarations.push(NativeSnapshotObjectDeclaration {
+            relative_key,
+            kind,
+            bytes,
+            checksum_sha256,
+        });
+    }
+    Ok(declarations)
 }
 
 /// Declare, upload (if required), and complete a native snapshot against
@@ -1203,47 +1255,23 @@ async fn declare_and_complete_native_snapshot(
     selected: &[SourceObject],
     source_image: Option<String>,
 ) -> Result<(), StageError> {
-    let mut declarations = Vec::with_capacity(selected.len());
-    for object in selected {
-        let (bytes, checksum_sha256) = resources
-            .inspect_object(backup.s3_source_id, &source_config.bucket_name, &object.key)
-            .await?;
-        if bytes != object.bytes {
-            return Err(StageError::Retry(format!(
-                "native snapshot object {} changed while its manifest was built",
-                object.key
-            )));
-        }
-        let relative_key = object
-            .key
-            .strip_prefix(&format!("{root}/"))
-            .unwrap_or_else(|| object.key.rsplit('/').next().unwrap_or(&object.key))
-            .to_string();
-        let kind = if object.key.ends_with("_backup_stop_sentinel.json")
-            || object.key.ends_with("metadata.json")
-        {
-            NativeSnapshotObjectKind::Metadata
-        } else if engine == BackupEngine::MariaDb {
-            NativeSnapshotObjectKind::BaseBackup
-        } else if engine == BackupEngine::RustFs {
-            NativeSnapshotObjectKind::Object
-        } else {
-            NativeSnapshotObjectKind::Data
-        };
-        declarations.push(NativeSnapshotObjectDeclaration {
-            relative_key,
-            kind,
-            bytes,
-            checksum_sha256,
-        });
-    }
+    let in_place_root = in_place_root_for(source_config.managed_by_cloud, root);
+    let mut declarations = native_declarations(
+        resources,
+        backup,
+        source_config,
+        root,
+        selected,
+        engine,
+        in_place_root.is_none(),
+    )
+    .await?;
     let cloud_backup_id = Uuid::new_v5(
         &link
             .tenant_id()
             .ok_or_else(|| StageError::Retry("Cloud link lost its tenant identity".into()))?,
         format!("{instance_id}:{}", backup.backup_id).as_bytes(),
     );
-    let in_place_root = in_place_root_for(source_config.managed_by_cloud, compression, root);
     let mut request = NativeSnapshotRequest {
         backup_id: cloud_backup_id,
         instance_id,
@@ -1270,7 +1298,21 @@ async fn declare_and_complete_native_snapshot(
                 %detail,
                 "Cloud declined to catalog the snapshot in place; mirroring a copy instead"
             );
+            // The copy path binds a checksum into every upload, so the
+            // objects are read now, once, for exactly the snapshots Cloud
+            // would not take in place.
+            declarations = native_declarations(
+                resources,
+                backup,
+                source_config,
+                root,
+                selected,
+                engine,
+                true,
+            )
+            .await?;
             request.in_place_root = None;
+            request.objects = declarations.clone();
             link.declare_native_snapshot(&request)
                 .await
                 .map_err(|error| StageError::Retry(error.to_string()))?
@@ -1528,43 +1570,25 @@ async fn mirror_walg_backup(
         }
     }
 
-    let mut declarations = Vec::with_capacity(selected.len());
-    for object in &selected {
-        let (bytes, checksum_sha256) = resources
-            .inspect_object(backup.s3_source_id, &source_config.bucket_name, &object.key)
-            .await?;
-        if bytes != object.bytes {
-            return Err(StageError::Retry(format!(
-                "WAL-G object {} changed while its manifest was being built",
-                object.key
-            )));
-        }
-        declarations.push(WalGObjectDeclaration {
-            relative_key: object
-                .key
-                .strip_prefix(&format!("{root}/"))
-                .ok_or_else(|| {
-                    StageError::Retry(format!("object {} escaped repository", object.key))
-                })?
-                .to_string(),
-            kind: if object.key == sentinel_key {
-                WalGObjectKind::Sentinel
-            } else if object.key.starts_with(&base_prefix) {
-                WalGObjectKind::BaseBackup
-            } else {
-                WalGObjectKind::Wal
-            },
-            bytes,
-            checksum_sha256,
-        });
-    }
+    let in_place_root = in_place_root_for(source_config.managed_by_cloud, &root);
+    let mut declarations = walg_declarations(
+        resources,
+        backup,
+        &source_config,
+        &root,
+        &selected,
+        &sentinel_key,
+        &base_prefix,
+        in_place_root.is_none(),
+    )
+    .await?;
     let cloud_backup_id = Uuid::new_v5(
         &link
             .tenant_id()
             .ok_or_else(|| StageError::Retry("Cloud link lost its tenant identity".into()))?,
         format!("{instance_id}:{}", backup.backup_id).as_bytes(),
     );
-    let request = WalGSnapshotRequest {
+    let mut request = WalGSnapshotRequest {
         backup_id: cloud_backup_id,
         instance_id,
         source,
@@ -1584,6 +1608,7 @@ async fn mirror_walg_backup(
         start_lsn,
         finish_lsn,
         objects: declarations.clone(),
+        in_place_root,
     };
     // The declared manifest is what Cloud binds the snapshot to, and a retry
     // that computes a different one is rejected. Log the identity and the shape
@@ -1600,10 +1625,45 @@ async fn mirror_walg_backup(
         manifest_digest = %manifest_digest(&declarations),
         "Cloud backup mirror declaring WAL-G snapshot"
     );
-    let snapshot = link
-        .declare_walg_snapshot(&request)
-        .await
-        .map_err(|error| StageError::Retry(error.to_string()))?;
+    let snapshot = match link.declare_walg_snapshot(&request).await {
+        Ok(snapshot) => snapshot,
+        // Same reasoning as the native path: a 400 to an in-place
+        // declaration is a verdict on the layout, not a transient fault.
+        // Hash the objects now (the copy path needs it) and re-declare.
+        Err(CloudError::Rejected { detail }) if request.in_place_root.is_some() => {
+            warn!(
+                local_backup_id = %backup.backup_id,
+                %cloud_backup_id,
+                %detail,
+                "Cloud declined to catalog the WAL-G repository in place; mirroring a copy instead"
+            );
+            declarations = walg_declarations(
+                resources,
+                backup,
+                &source_config,
+                &root,
+                &selected,
+                &sentinel_key,
+                &base_prefix,
+                true,
+            )
+            .await?;
+            request.in_place_root = None;
+            request.objects = declarations.clone();
+            link.declare_walg_snapshot(&request)
+                .await
+                .map_err(|error| StageError::Retry(error.to_string()))?
+        }
+        Err(error) => return Err(StageError::Retry(error.to_string())),
+    };
+    if !snapshot.upload_required && request.in_place_root.is_some() {
+        info!(
+            local_backup_id = %backup.backup_id,
+            %cloud_backup_id,
+            objects = declarations.len(),
+            "Cloud cataloged the WAL-G repository in place; no second copy uploaded"
+        );
+    }
     if snapshot.upload_required {
         let mut pass = UploadPass {
             declared: declarations.len(),
@@ -1664,6 +1724,58 @@ async fn mirror_walg_backup(
     })
     .await
     .map_err(|error| StageError::Retry(error.to_string()))
+}
+
+/// WAL-G counterpart of [`native_declarations`]: listed sizes without a
+/// read for an in-place declaration, one hashing read per object for the
+/// copy path.
+#[allow(clippy::too_many_arguments)]
+async fn walg_declarations(
+    resources: &mut SweepResources<'_>,
+    backup: &backups::Model,
+    source_config: &s3_sources::Model,
+    root: &str,
+    selected: &[SourceObject],
+    sentinel_key: &str,
+    base_prefix: &str,
+    hash: bool,
+) -> Result<Vec<WalGObjectDeclaration>, StageError> {
+    let mut declarations = Vec::with_capacity(selected.len());
+    for object in selected {
+        let (bytes, checksum_sha256) = if hash {
+            let (bytes, checksum) = resources
+                .inspect_object(backup.s3_source_id, &source_config.bucket_name, &object.key)
+                .await?;
+            if bytes != object.bytes {
+                return Err(StageError::Retry(format!(
+                    "WAL-G object {} changed while its manifest was being built",
+                    object.key
+                )));
+            }
+            (bytes, Some(checksum))
+        } else {
+            (object.bytes, None)
+        };
+        declarations.push(WalGObjectDeclaration {
+            relative_key: object
+                .key
+                .strip_prefix(&format!("{root}/"))
+                .ok_or_else(|| {
+                    StageError::Retry(format!("object {} escaped repository", object.key))
+                })?
+                .to_string(),
+            kind: if object.key == sentinel_key {
+                WalGObjectKind::Sentinel
+            } else if object.key.starts_with(base_prefix) {
+                WalGObjectKind::BaseBackup
+            } else {
+                WalGObjectKind::Wal
+            },
+            bytes,
+            checksum_sha256,
+        });
+    }
+    Ok(declarations)
 }
 
 #[derive(Clone, Debug)]
@@ -1858,7 +1970,7 @@ fn manifest_digest(declarations: &[WalGObjectDeclaration]) -> String {
         hasher.update(object.relative_key.as_bytes());
         hasher.update([0]);
         hasher.update(object.bytes.to_le_bytes());
-        hasher.update(object.checksum_sha256.as_bytes());
+        hasher.update(object.checksum_sha256.as_deref().unwrap_or("").as_bytes());
         hasher.update([0]);
     }
     hasher
@@ -1942,6 +2054,18 @@ async fn inspect_source_object(
     Ok((bytes, checksum))
 }
 
+/// The copy path uploads against a checksum Cloud bound into the target, so
+/// an object declared without one (an in-place declaration) can never be
+/// uploaded. The sweep re-declares with hashes before it ever gets here;
+/// reaching this is a programming error, not a transient condition.
+fn declared_checksum(relative_key: &str, checksum: &Option<String>) -> Result<String, StageError> {
+    checksum.clone().ok_or_else(|| {
+        StageError::Unsupported(format!(
+            "{relative_key} was declared without a checksum and cannot be uploaded"
+        ))
+    })
+}
+
 async fn upload_repository_object(
     link: &CloudLink,
     source_client: &S3Client,
@@ -1951,6 +2075,8 @@ async fn upload_repository_object(
     backup_id: Uuid,
     declaration: WalGObjectDeclaration,
 ) -> Result<(), StageError> {
+    let checksum_sha256 =
+        declared_checksum(&declaration.relative_key, &declaration.checksum_sha256)?;
     let target = link
         .walg_object_target(&WalGObjectTargetRequest {
             backup_id,
@@ -2049,7 +2175,7 @@ async fn upload_repository_object(
         backup_id,
         relative_key: declaration.relative_key,
         bytes: declaration.bytes,
-        checksum_sha256: declaration.checksum_sha256,
+        checksum_sha256,
     })
     .await
     .map_err(|error| StageError::Retry(error.to_string()))
@@ -2064,6 +2190,8 @@ async fn upload_native_object(
     backup_id: Uuid,
     declaration: NativeSnapshotObjectDeclaration,
 ) -> Result<(), StageError> {
+    let checksum_sha256 =
+        declared_checksum(&declaration.relative_key, &declaration.checksum_sha256)?;
     let target = link
         .native_object_target(&WalGObjectTargetRequest {
             backup_id,
@@ -2159,7 +2287,7 @@ async fn upload_native_object(
         backup_id,
         relative_key: declaration.relative_key,
         bytes: declaration.bytes,
-        checksum_sha256: declaration.checksum_sha256,
+        checksum_sha256,
     })
     .await
     .map_err(|error| StageError::Retry(error.to_string()))
@@ -2616,9 +2744,8 @@ mod tests {
     use sha2::{Digest, Sha256};
     use temps_cloud_client::{BackendUrl, CloudFeatureSwitches, CloudLink};
     use temps_cloud_protocol::{
-        BackupCompression, NativeSnapshot, NativeSnapshotObjectDeclaration,
-        NativeSnapshotObjectKind, NativeSnapshotRequest, WalGObjectCompleted,
-        WalGObjectTargetRequest,
+        NativeSnapshot, NativeSnapshotObjectDeclaration, NativeSnapshotObjectKind,
+        NativeSnapshotRequest, WalGObjectCompleted, WalGObjectTargetRequest,
     };
     use uuid::Uuid;
 
@@ -2627,7 +2754,7 @@ mod tests {
             relative_key: relative_key.to_owned(),
             kind: NativeSnapshotObjectKind::Object,
             bytes: 1,
-            checksum_sha256: "ab".repeat(32),
+            checksum_sha256: Some("ab".repeat(32)),
         }
     }
 
@@ -4443,27 +4570,34 @@ mod tests {
                 "a real repository with a complete dump + metadata.json must not be Unsupported: {reason}"
             ),
         }
-        assert_eq!(
-            resources.object_inspections.len(),
-            2,
-            "expected exactly the dump object and metadata.json to be read and checksummed, \
-             proving the decoy object was excluded and both real objects were reached"
+        assert!(
+            resources.object_inspections.is_empty(),
+            "a managed source is declared in place from the listing: nothing is read back \
+             to be hashed (`managed_native_snapshots_are_declared_in_place_and_never_re_uploaded` \
+             proves the selection against the same decoy)"
         );
     }
 
     #[test]
-    fn only_snapshot_exclusive_layouts_on_managed_sources_catalog_in_place() {
+    fn every_managed_source_catalogs_in_place() {
         let root = "/t/managed-backups/external_services/s3/store/2026-09-11/backup-7/";
         assert_eq!(
-            super::in_place_root_for(true, BackupCompression::None, root).as_deref(),
+            super::in_place_root_for(true, root).as_deref(),
             Some("t/managed-backups/external_services/s3/store/2026-09-11/backup-7")
         );
-        assert!(super::in_place_root_for(true, BackupCompression::Gzip, root).is_some());
-        // Shared WAL-G repositories are rotated by WAL-G retention: copy.
-        assert!(super::in_place_root_for(true, BackupCompression::WalGNative, root).is_none());
+        // Shared WAL-G repositories too: Cloud confirms only the declared
+        // keys and learns of deletions through the lifecycle event.
+        assert_eq!(
+            super::in_place_root_for(
+                true,
+                "/t/managed-backups/external_services/postgres/main/walg"
+            )
+            .as_deref(),
+            Some("t/managed-backups/external_services/postgres/main/walg")
+        );
         // Operator-owned sources are not the cloud bucket: copy.
-        assert!(super::in_place_root_for(false, BackupCompression::None, root).is_none());
-        assert!(super::in_place_root_for(true, BackupCompression::None, "/").is_none());
+        assert!(super::in_place_root_for(false, root).is_none());
+        assert!(super::in_place_root_for(true, "/").is_none());
     }
 
     struct InPlaceCloudStub {
@@ -4588,6 +4722,10 @@ mod tests {
             let mut objects = state.objects.lock().expect("repository stub objects lock");
             objects.insert(dump_key, b"redis-rdb-dump-bytes".to_vec());
             objects.insert(metadata_key, b"{\"redis_version\":\"7.4\"}".to_vec());
+            objects.insert(
+                format!("{expected_root}/unrelated-object.tmp"),
+                b"not part of this backup".to_vec(),
+            );
         }
 
         let temp = tempfile::tempdir().expect("cloud-link state dir");
@@ -4633,7 +4771,22 @@ mod tests {
             declared[0].in_place_root.as_deref(),
             Some(expected_root.as_str())
         );
-        assert_eq!(declared[0].objects.len(), 2);
+        assert_eq!(
+            declared[0].objects.len(),
+            2,
+            "the dump and its metadata.json, not the decoy"
+        );
+        assert!(
+            declared[0]
+                .objects
+                .iter()
+                .all(|object| object.checksum_sha256.is_none()),
+            "an in-place declaration carries sizes, not hashes"
+        );
+        assert!(
+            resources.object_inspections.is_empty(),
+            "nothing is read back from the bucket to declare in place"
+        );
         assert_eq!(
             cloud.target_calls.load(Ordering::SeqCst),
             0,
@@ -4748,9 +4901,20 @@ mod tests {
             "in-place attempt, then the copy-path re-declaration"
         );
         assert!(declared[0].in_place_root.is_some());
+        assert!(declared[0]
+            .objects
+            .iter()
+            .all(|object| object.checksum_sha256.is_none()));
         assert!(
             declared[1].in_place_root.is_none(),
             "the fallback must not carry the rejected root"
+        );
+        assert!(
+            declared[1]
+                .objects
+                .iter()
+                .all(|object| object.checksum_sha256.is_some()),
+            "the copy path re-declares with the hashes its uploads bind"
         );
         assert!(
             cloud.target_calls.load(Ordering::SeqCst) > 0,
@@ -4992,7 +5156,7 @@ mod tests {
             relative_key: key.to_owned(),
             kind: WalGObjectKind::Wal,
             bytes,
-            checksum_sha256: checksum.to_owned(),
+            checksum_sha256: Some(checksum.to_owned()),
         };
         let checksum = "a".repeat(64);
         let manifest = vec![
@@ -5018,7 +5182,7 @@ mod tests {
         assert_ne!(manifest_digest(&rekeyed), digest);
 
         let mut rechecksummed = manifest;
-        rechecksummed[1].checksum_sha256 = "b".repeat(64);
+        rechecksummed[1].checksum_sha256 = Some("b".repeat(64));
         assert_ne!(manifest_digest(&rechecksummed), digest);
     }
 
@@ -5402,7 +5566,7 @@ mod tests {
             relative_key: "object-0001.bin".into(),
             kind: NativeSnapshotObjectKind::Object,
             bytes,
-            checksum_sha256,
+            checksum_sha256: Some(checksum_sha256),
         };
 
         expect_stage_ok(
@@ -5531,7 +5695,7 @@ mod tests {
                     relative_key: "object-0001.bin".into(),
                     kind: NativeSnapshotObjectKind::Object,
                     bytes: source_body.len() as u64,
-                    checksum_sha256: expected_checksum,
+                    checksum_sha256: Some(expected_checksum),
                 },
             )
             .await,

--- a/crates/temps-cloud/src/backup_mirror.rs
+++ b/crates/temps-cloud/src/backup_mirror.rs
@@ -1284,7 +1284,7 @@ async fn declare_and_complete_native_snapshot(
         source_image,
         in_place_root,
     };
-    let snapshot = match link.declare_native_snapshot(&request).await {
+    let mut snapshot = match link.declare_native_snapshot(&request).await {
         Ok(snapshot) => snapshot,
         // Cloud understood the in-place request and refused it (a root it
         // will not accept, a bucket that disagrees with the manifest). That
@@ -1319,6 +1319,34 @@ async fn declare_and_complete_native_snapshot(
         }
         Err(error) => return Err(StageError::Retry(error.to_string())),
     };
+    if snapshot.upload_required && request.in_place_root.is_some() {
+        // Cloud took the declaration but wants a copy anyway: a Cloud that
+        // does not know `in_place_root` ignores it and answers as it always
+        // did. Its uploads bind checksums the in-place declaration did not
+        // carry, so hash now and re-declare the copy manifest; Cloud
+        // replaces the never-completed draft.
+        info!(
+            local_backup_id = %backup.backup_id,
+            %cloud_backup_id,
+            "Cloud did not catalog the snapshot in place; mirroring a copy instead"
+        );
+        declarations = native_declarations(
+            resources,
+            backup,
+            source_config,
+            root,
+            selected,
+            engine,
+            true,
+        )
+        .await?;
+        request.in_place_root = None;
+        request.objects = declarations.clone();
+        snapshot = link
+            .declare_native_snapshot(&request)
+            .await
+            .map_err(|error| StageError::Retry(error.to_string()))?;
+    }
     if !snapshot.upload_required && request.in_place_root.is_some() {
         info!(
             local_backup_id = %backup.backup_id,
@@ -1625,7 +1653,7 @@ async fn mirror_walg_backup(
         manifest_digest = %manifest_digest(&declarations),
         "Cloud backup mirror declaring WAL-G snapshot"
     );
-    let snapshot = match link.declare_walg_snapshot(&request).await {
+    let mut snapshot = match link.declare_walg_snapshot(&request).await {
         Ok(snapshot) => snapshot,
         // Same reasoning as the native path: a 400 to an in-place
         // declaration is a verdict on the layout, not a transient fault.
@@ -1656,6 +1684,32 @@ async fn mirror_walg_backup(
         }
         Err(error) => return Err(StageError::Retry(error.to_string())),
     };
+    if snapshot.upload_required && request.in_place_root.is_some() {
+        // See the native path: a Cloud that ignores `in_place_root` still
+        // wants a copy, and the copy needs hashes.
+        info!(
+            local_backup_id = %backup.backup_id,
+            %cloud_backup_id,
+            "Cloud did not catalog the WAL-G repository in place; mirroring a copy instead"
+        );
+        declarations = walg_declarations(
+            resources,
+            backup,
+            &source_config,
+            &root,
+            &selected,
+            &sentinel_key,
+            &base_prefix,
+            true,
+        )
+        .await?;
+        request.in_place_root = None;
+        request.objects = declarations.clone();
+        snapshot = link
+            .declare_walg_snapshot(&request)
+            .await
+            .map_err(|error| StageError::Retry(error.to_string()))?;
+    }
     if !snapshot.upload_required && request.in_place_root.is_some() {
         info!(
             local_backup_id = %backup.backup_id,
@@ -4606,6 +4660,9 @@ mod tests {
         /// Refuse declarations that carry `in_place_root` with a 400, the
         /// way Cloud does for a root it will not catalog.
         reject_in_place: bool,
+        /// Accept declarations but answer `upload_required: true` whatever
+        /// they carry, the way a Cloud that predates `in_place_root` does.
+        ignore_in_place: bool,
         target_calls: AtomicUsize,
         completions: AtomicUsize,
     }
@@ -4629,7 +4686,7 @@ mod tests {
         let in_place = request.in_place_root.is_some();
         let response = NativeSnapshot {
             backup_id: request.backup_id,
-            upload_required: !in_place,
+            upload_required: !in_place || state.ignore_in_place,
             completed_relative_keys: Vec::new(),
         };
         state.declared.lock().expect("declared lock").push(request);
@@ -4688,6 +4745,7 @@ mod tests {
         let cloud = Arc::new(InPlaceCloudStub {
             declared: Mutex::new(Vec::new()),
             reject_in_place: false,
+            ignore_in_place: false,
             target_calls: AtomicUsize::new(0),
             completions: AtomicUsize::new(0),
         });
@@ -4801,8 +4859,7 @@ mod tests {
     /// what Cloud always accepted. The stub's target endpoint returns 500,
     /// so reaching it is the proof that the fallback happened, and the
     /// resulting error is `Retry`, exactly as for any copy-path hiccup.
-    #[tokio::test]
-    async fn a_rejected_in_place_declaration_falls_back_to_the_copy_path() {
+    async fn copy_path_fallback_case(reject_in_place: bool, ignore_in_place: bool) {
         let Some((origin, state)) = spawn_repository_stub(HashMap::new()).await else {
             return;
         };
@@ -4820,7 +4877,8 @@ mod tests {
         );
         let cloud = Arc::new(InPlaceCloudStub {
             declared: Mutex::new(Vec::new()),
-            reject_in_place: true,
+            reject_in_place,
+            ignore_in_place,
             target_calls: AtomicUsize::new(0),
             completions: AtomicUsize::new(0),
         });
@@ -4921,6 +4979,21 @@ mod tests {
             "the copy path asked for an upload target"
         );
         assert_eq!(cloud.completions.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn a_rejected_in_place_declaration_falls_back_to_the_copy_path() {
+        copy_path_fallback_case(true, false).await;
+    }
+
+    /// A Cloud that predates `in_place_root` accepts the declaration and
+    /// answers `upload_required: true` as it always did. The in-place
+    /// declaration carried no checksums and uploads need them, so the sweep
+    /// must re-declare a hashed copy manifest before its first upload
+    /// rather than fail every object.
+    #[tokio::test]
+    async fn an_ignored_in_place_root_re_declares_with_checksums_before_uploading() {
+        copy_path_fallback_case(false, true).await;
     }
 
     /// The `mirror_native_backup` fallback branch treats a dump with no

--- a/crates/temps-cloud/src/lifecycle_notify.rs
+++ b/crates/temps-cloud/src/lifecycle_notify.rs
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: 2024-2026 Temps Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Push backup lifecycle events (started/completed/failed) to Cloud as they
-//! happen, instead of waiting for [`crate::backup_mirror`]'s next poll to
-//! notice. That sweep remains the source of truth for what actually
+//! Push backup lifecycle events (started/completed/failed/deleted) to Cloud
+//! as they happen, instead of waiting for [`crate::backup_mirror`]'s next
+//! poll to notice. That sweep remains the source of truth for what actually
 //! happened -- a dropped or failed push here costs Cloud a stale
 //! "processing" indicator until the next sweep tick, never an incorrect or
-//! lost backup record.
+//! lost backup record. `deleted` is the one stage the sweep cannot replay
+//! (the row is gone); Cloud's own presence check covers a lost push.
 
 use std::sync::{Arc, LazyLock};
 
@@ -54,6 +55,7 @@ pub async fn run(service: Arc<CloudService>, queue: Arc<dyn JobQueue>) {
                     s3_location: stage_job.s3_location,
                     size_bytes: stage_job.size_bytes,
                     error_message: stage_job.error_message,
+                    backup_uuid: stage_job.backup_uuid,
                 };
 
                 match service.link().notify_backup_lifecycle(&event).await {
@@ -91,6 +93,7 @@ struct LifecycleJob {
     s3_location: Option<String>,
     size_bytes: Option<i64>,
     error_message: Option<String>,
+    backup_uuid: Option<String>,
 }
 
 fn to_lifecycle_job(job: &Job) -> Option<LifecycleJob> {
@@ -102,6 +105,7 @@ fn to_lifecycle_job(job: &Job) -> Option<LifecycleJob> {
             s3_location: None,
             size_bytes: None,
             error_message: None,
+            backup_uuid: None,
         }),
         Job::BackupCompleted(j) => Some(LifecycleJob {
             backup_id: j.backup_id,
@@ -110,6 +114,7 @@ fn to_lifecycle_job(job: &Job) -> Option<LifecycleJob> {
             s3_location: Some(j.s3_location.clone()),
             size_bytes: j.size_bytes,
             error_message: None,
+            backup_uuid: None,
         }),
         Job::BackupFailed(j) => Some(LifecycleJob {
             backup_id: j.backup_id,
@@ -118,6 +123,16 @@ fn to_lifecycle_job(job: &Job) -> Option<LifecycleJob> {
             s3_location: None,
             size_bytes: None,
             error_message: Some(bound_error_message(&redact_credentials(&j.error_message))),
+            backup_uuid: None,
+        }),
+        Job::BackupDeleted(j) => Some(LifecycleJob {
+            backup_id: j.backup_id,
+            engine: j.engine.clone(),
+            stage: BackupLifecycleStage::Deleted,
+            s3_location: Some(j.s3_location.clone()),
+            size_bytes: None,
+            error_message: None,
+            backup_uuid: Some(j.backup_uuid.clone()),
         }),
         _ => None,
     }
@@ -185,6 +200,32 @@ fn redact_credentials(message: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_deleted_backup_becomes_a_deleted_stage_with_its_uuid() {
+        let job = Job::BackupDeleted(temps_core::BackupDeletedJob {
+            backup_id: 7,
+            backup_uuid: "2e0a9d61-6a7c-4a1a-9a2b-0f6f2d0e1c11".into(),
+            engine: "postgres_walg".into(),
+            s3_location: "s3://bucket/t/managed-backups/external_services/postgres/main/walg"
+                .into(),
+        });
+        let lifecycle = to_lifecycle_job(&job).expect("deleted maps to a lifecycle stage");
+        assert_eq!(lifecycle.stage, BackupLifecycleStage::Deleted);
+        assert_eq!(
+            lifecycle.backup_uuid.as_deref(),
+            Some("2e0a9d61-6a7c-4a1a-9a2b-0f6f2d0e1c11")
+        );
+        assert_eq!(lifecycle.backup_id, 7);
+        // Only the deletion carries the uuid; Cloud keys the other stages
+        // on (instance_id, backup_id).
+        let started = to_lifecycle_job(&Job::BackupStarted(temps_core::BackupStartedJob {
+            backup_id: 7,
+            engine: "postgres_walg".into(),
+        }))
+        .expect("started maps");
+        assert!(started.backup_uuid.is_none());
+    }
 
     #[test]
     fn redact_postgres_connection_string_password() {

--- a/crates/temps-core/src/jobs.rs
+++ b/crates/temps-core/src/jobs.rs
@@ -382,6 +382,21 @@ pub struct BackupFailedJob {
     pub error_message: String,
 }
 
+/// Published by the backup service once a backup's remote objects and its
+/// row are gone (a manual delete or schedule retention). Lets anything that
+/// catalogs the instance's backups elsewhere (the Cloud mirror) stop
+/// offering it, instead of discovering the loss at the next failed restore.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BackupDeletedJob {
+    /// The local `backups.id`; already gone from the table when this fires.
+    pub backup_id: i32,
+    /// The backup's stable `backups.backup_id` UUID string, the identity
+    /// remote catalogs key on.
+    pub backup_uuid: String,
+    pub engine: String,
+    pub s3_location: String,
+}
+
 /// Ask the deployment job processor to re-run its [`DeploymentGate`] check for
 /// a deployment that a previous check left sitting in `Pending`.
 ///
@@ -459,6 +474,7 @@ pub enum Job {
     BackupStarted(BackupStartedJob),
     BackupCompleted(BackupCompletedJob),
     BackupFailed(BackupFailedJob),
+    BackupDeleted(BackupDeletedJob),
     BackupCancelRequested(BackupCancelRequestedJob),
     /// Scheduled hourly to prune raw service_metrics rows older than the
     /// configured `retention_raw_days` window. Continuous aggregates
@@ -518,6 +534,7 @@ impl fmt::Display for Job {
             Job::BackupStarted(job) => write!(f, "BackupStarted(backup: {}, engine: {})", job.backup_id, job.engine),
             Job::BackupCompleted(job) => write!(f, "BackupCompleted(backup: {}, engine: {}, size: {:?})", job.backup_id, job.engine, job.size_bytes),
             Job::BackupFailed(job) => write!(f, "BackupFailed(backup: {}, engine: {})", job.backup_id, job.engine),
+            Job::BackupDeleted(job) => write!(f, "BackupDeleted(backup: {}, engine: {})", job.backup_id, job.engine),
             Job::BackupCancelRequested(job) => write!(f, "BackupCancelRequested(backup: {})", job.backup_id),
             Job::PruneMetrics => write!(f, "PruneMetrics"),
             Job::DeploymentGateRecheck(job) => {


### PR DESCRIPTION
## Summary

Three changes to the Cloud backup mirror, all instance-side halves of a Cloud change that is already deployed (Cloud accepts the new wire shapes and still serves older instances):

1. **No per-object hashing.** A managed source is declared in place straight from the listing: object declarations carry sizes and no checksum (`checksum_sha256` becomes `Option<String>` on `NativeSnapshotObjectDeclaration` / `WalGObjectDeclaration`, omitted from the wire when absent). Reading every object back only to hash it was the entire cost of a sweep. The sweep hashes only when Cloud refuses the in-place declaration and it must take the copy path, whose uploads still bind a checksum (`declared_checksum` enforces that).
2. **WAL-G repositories in place.** `WalGSnapshotRequest` gains `in_place_root`; `mirror_walg_backup` sends the repository root for managed sources and falls back to the copy path on a 400, like the native path already did. `in_place_root_for` no longer excludes `WalGNative`: Cloud confirms only the declared keys of a shared repository.
3. **Deletions reach Cloud.** `delete_backup_model` publishes `Job::BackupDeleted { backup_id, backup_uuid, engine, s3_location }` after the row is gone (manual delete and schedule retention share the path). The lifecycle notifier forwards it as a `deleted` lifecycle event with `backup_uuid`, the value the sweep hashes into the Cloud catalog id, so Cloud expires the entry instead of discovering the loss at the next failed restore. Publishing is best effort and only when the queue is wired.

A self-hosted instance that never links to Cloud is unaffected: the job is one more variant on the queue, the sweep and notifier only run when linked.

## Compatibility

- A Cloud built before this change 400s a checksum-less declaration; the sweep treats that as `Rejected` and re-declares with hashes on the copy path, so nothing regresses against an older Cloud.
- Older instances keep sending checksums and never send `deleted`; Cloud accepts both.

## Evidence

```
$ cargo test -p temps-cloud -p temps-cloud-protocol -p temps-cloud-client -p temps-core
test result: ok. 85 passed  (temps-cloud: sweep, incl. managed_native_snapshots_are_declared_in_place_and_never_re_uploaded
                            now asserting no checksums and zero reads, a_rejected_in_place_declaration_falls_back_to_the_copy_path
                            asserting the re-declaration carries hashes, every_managed_source_catalogs_in_place,
                            a_deleted_backup_becomes_a_deleted_stage_with_its_uuid)
test result: ok. 30 passed  (temps-cloud-protocol, incl. in_place_declarations_omit_absent_checksums_and_carry_the_root)
test result: ok. 124 / 8 / 19 passed (temps-cloud-client)
$ cargo test -p temps-backup --lib
228 passed, 5 ignored
$ cargo clippy -p temps-cloud -p temps-cloud-protocol -p temps-cloud-client -p temps-core -p temps-backup -p temps-webhooks -p temps-backup-core --all-targets -- -D warnings
clean
$ python3 scripts/source_attribution.py check
Attribution check passed for 3861 source files.
```

The Cloud side (declaration without checksums, WAL-G shared-repository confirmation, `deleted` → expiry, purge and presence worker passes) is covered by Cloud's own integration tests against Postgres and is deployed.
