### PR TITLE
fix(logs): retain partial results when search reaches its limit

### DIFF
--- a/apps/temps-cli/openapi.json
+++ b/apps/temps-cli/openapi.json
@@ -22049,7 +22049,7 @@
             ]
           },
           "scan_limit_reached": {
-            "description": "True means no complete ordered page could be established within the\nscan budget. Lines are empty; narrow the search rather than skipping logs.",
+            "description": "True means the scan budget was exhausted. Lines contain the newest\nmatches found so far, but unread chunks may contain newer lines.\nNo cursor is returned because the partial results cannot be paginated safely.",
             "type": "boolean"
           },
           "scanned_bytes": {

--- a/apps/temps-cli/src/api/types.gen.ts
+++ b/apps/temps-cli/src/api/types.gen.ts
@@ -10265,8 +10265,9 @@ export type GlobalLogSearchResponse = {
     lines: Array<GlobalLogLine>;
     next_cursor?: string | null;
     /**
-     * True means no complete ordered page could be established within the
-     * scan budget. Lines are empty; narrow the search rather than skipping logs.
+     * True means the scan budget was exhausted. Lines contain the newest
+     * matches found so far, but unread chunks may contain newer lines.
+     * No cursor is returned because the partial results cannot be paginated safely.
      */
     scan_limit_reached: boolean;
     scanned_bytes: number;

--- a/crates/temps-log-aggregator/src/services/global_search.rs
+++ b/crates/temps-log-aggregator/src/services/global_search.rs
@@ -75,8 +75,9 @@ pub struct GlobalLogSearchResponse {
     /// Newest first, ordered by timestamp, chunk ID and line offset.
     pub lines: Vec<GlobalLogLine>,
     pub next_cursor: Option<String>,
-    /// True means no complete ordered page could be established within the
-    /// scan budget. Lines are empty; narrow the search rather than skipping logs.
+    /// True means the scan budget was exhausted. Lines contain the newest
+    /// matches found so far, but unread chunks may contain newer lines.
+    /// No cursor is returned because the partial results cannot be paginated safely.
     pub scan_limit_reached: bool,
     pub scanned_chunks: usize,
     pub scanned_bytes: usize,
@@ -303,7 +304,12 @@ impl LogSearchService {
         }
         if !complete {
             return Ok(GlobalLogSearchResponse {
-                lines: vec![],
+                lines: matches
+                    .into_iter()
+                    .rev()
+                    .take(cap)
+                    .map(|(_, line)| line)
+                    .collect(),
                 next_cursor: None,
                 scan_limit_reached: true,
                 scanned_chunks,
@@ -426,11 +432,109 @@ mod tests {
         services::LogMetadataService,
         storage::{FilesystemStorage, LogStorage},
     };
-    use sea_orm::{ConnectOptions, Database};
-    use std::{collections::HashSet, sync::Arc};
+    use sea_orm::{ConnectOptions, Database, DatabaseBackend, MockDatabase};
+    use std::{
+        collections::{BTreeMap, HashSet},
+        sync::Arc,
+    };
 
     fn request() -> GlobalLogSearchRequest {
         serde_json::from_value(serde_json::json!({"start_time":"2026-01-01T00:00:00Z", "end_time":"2026-01-02T00:00:00Z", "page_size":17})).unwrap()
+    }
+
+    fn mock_candidate(id: u128, key: &str, size: i32) -> BTreeMap<String, Value> {
+        let mut row = BTreeMap::new();
+        row.insert("id".into(), Uuid::from_u128(id).into());
+        row.insert("project_id".into(), 1.into());
+        row.insert("external_service_id".into(), Option::<i32>::None.into());
+        row.insert("owner".into(), "Project".into());
+        row.insert("env".into(), "production".into());
+        row.insert(
+            "ended_at".into(),
+            "2026-01-01T12:00:01Z"
+                .parse::<DateTime<Utc>>()
+                .unwrap()
+                .into(),
+        );
+        row.insert("storage_key".into(), key.into());
+        row.insert("compressed_size_bytes".into(), size.into());
+        row
+    }
+
+    async fn mock_search(lines: &[(&str, &str)], text: Option<&str>) -> GlobalLogSearchResponse {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Arc::new(FilesystemStorage::new(dir.path().into()).unwrap());
+        let mut content = Vec::new();
+        for (timestamp, message) in lines {
+            content.extend(
+                serde_json::to_vec(&serde_json::json!({
+                    "ts": timestamp, "level": "ERROR", "msg": message,
+                    "stream": "stderr", "container_id": "container-1", "service": "app",
+                    "env": "production", "project_id": 1
+                }))
+                .unwrap(),
+            );
+            content.push(b'\n');
+        }
+        let compressed = zstd::encode_all(content.as_slice(), 1).unwrap();
+        storage.write_chunk("valid.zst", &compressed).await.unwrap();
+        let db = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([vec![
+                    mock_candidate(2, "valid.zst", compressed.len() as i32),
+                    mock_candidate(1, "oversized.zst", MAX_CHUNK_BYTES as i32 + 1),
+                ]])
+                .into_connection(),
+        );
+        let service = LogSearchService::new(storage, Arc::new(LogMetadataService::new(db)));
+        let mut q = request();
+        q.page_size = Some(2);
+        q.text = text.map(str::to_owned);
+        service
+            .search_global(
+                &q,
+                &GlobalLogAccess {
+                    hidden_projects: vec![],
+                    bound_project: None,
+                    unrestricted_services: true,
+                    user_id: None,
+                },
+            )
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn budget_exhaustion_keeps_newest_collected_lines_without_cursor() {
+        let result = mock_search(
+            &[
+                ("2026-01-01T12:00:00Z", "oldest"),
+                ("2026-01-01T12:00:03Z", "newest"),
+                ("2026-01-01T12:00:02Z", "middle"),
+            ],
+            None,
+        )
+        .await;
+        assert!(result.scan_limit_reached);
+        assert_eq!(result.scanned_chunks, 1);
+        assert!(result.scanned_bytes > 0);
+        assert!(result.next_cursor.is_none());
+        assert_eq!(
+            result
+                .lines
+                .iter()
+                .map(|line| line.line.message.as_str())
+                .collect::<Vec<_>>(),
+            vec!["newest", "middle"]
+        );
+    }
+
+    #[tokio::test]
+    async fn budget_exhaustion_without_matches_returns_empty_lines() {
+        let result = mock_search(&[("2026-01-01T12:00:00Z", "unrelated")], Some("absent")).await;
+        assert!(result.scan_limit_reached);
+        assert!(result.lines.is_empty());
+        assert!(result.next_cursor.is_none());
     }
 
     #[test]
@@ -576,6 +680,7 @@ mod tests {
             .lines
             .is_empty());
         q.text = None;
+        q.projects.clear();
         db.execute_unprepared(
             "UPDATE log_chunks SET compressed_size_bytes=99999999 WHERE project_id=105",
         )
@@ -583,7 +688,7 @@ mod tests {
         .unwrap();
         let limited = service.search_global(&q, &unrestricted).await.unwrap();
         assert!(limited.scan_limit_reached);
-        assert!(limited.lines.is_empty());
+        assert_eq!(limited.lines.len(), 16); // 8 newer chunks before project 105
         assert!(limited.next_cursor.is_none());
     }
 }

--- a/web/e2e/authenticated/global-observability.spec.ts
+++ b/web/e2e/authenticated/global-observability.spec.ts
@@ -257,6 +257,53 @@ test('scan-budget exhaustion asks for a narrower search instead of claiming no l
 })
 
 for (const width of [1440, 390]) {
+  test(`scan-budget exhaustion keeps partial logs visible at ${width}px`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width, height: 1000 })
+    await mock(page, 'logs')
+    await page.route(
+      (url) => url.pathname === endpoints.logs,
+      (route) =>
+        route.fulfill({
+          json: {
+            ...fixtures.logs,
+            scan_limit_reached: true,
+            scanned_chunks: 512,
+            next_cursor: null,
+          },
+        })
+    )
+    await page.goto('/logs')
+    await expect(
+      page.getByText('Partial results', { exact: true })
+    ).toBeVisible()
+    await expect(
+      page.getByRole('cell', { name: 'Checkout request failed', exact: false })
+    ).toBeVisible()
+    await expect(
+      page.getByText('1 loaded line · partial results', { exact: true })
+    ).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: 'Next page', exact: true })
+    ).toBeDisabled()
+    await expect(page.getByText('No logs in this view')).toHaveCount(0)
+    await page.screenshot({
+      path: `/tmp/temps-log-partial-results-${width}.png`,
+      fullPage: true,
+    })
+    await page.getByRole('button', { name: 'Patterns', exact: true }).click()
+    await expect(
+      page.getByText('Checkout request failed', { exact: true })
+    ).toBeVisible()
+    await page.getByRole('button', { name: 'By service', exact: true }).click()
+    await expect(
+      page.getByRole('button', { name: 'Storefront / web', exact: true })
+    ).toBeVisible()
+  })
+}
+
+for (const width of [1440, 390]) {
   test(`custom range validates, applies, and survives reload at ${width}px`, async ({
     page,
   }) => {

--- a/web/src/api/client/types.gen.ts
+++ b/web/src/api/client/types.gen.ts
@@ -10265,8 +10265,9 @@ export type GlobalLogSearchResponse = {
     lines: Array<GlobalLogLine>;
     next_cursor?: string | null;
     /**
-     * True means no complete ordered page could be established within the
-     * scan budget. Lines are empty; narrow the search rather than skipping logs.
+     * True means the scan budget was exhausted. Lines contain the newest
+     * matches found so far, but unread chunks may contain newer lines.
+     * No cursor is returned because the partial results cannot be paginated safely.
      */
     scan_limit_reached: boolean;
     scanned_bytes: number;

--- a/web/src/components/observability/LogExplorer.tsx
+++ b/web/src/components/observability/LogExplorer.tsx
@@ -240,7 +240,8 @@ export function LogExplorer({
             </Button>
           </div>
         </div>
-        {status ||
+        {status}
+        {(!status || lines.length > 0) &&
           (mode !== 'list' ? (
             <div className="border-x border-b">
               <p className="border-b px-3 py-2 text-xs text-muted-foreground">

--- a/web/src/pages/observability/GlobalLogs.tsx
+++ b/web/src/pages/observability/GlobalLogs.tsx
@@ -73,30 +73,33 @@ export default function GlobalLogs() {
     setAuto(false)
     view.patch(patch)
   }
-  const ready =
-    !query.error && !query.isPending && !query.data?.scan_limit_reached
+  const ready = !query.error && !query.isPending
+  const incomplete = ready && !!query.data?.scan_limit_reached
   const lines = ready ? (query.data?.lines ?? []) : []
-  const status =
-    query.data?.scan_limit_reached && !query.error ? (
-      <Alert variant="warning">
-        <AlertTitle>Search limit reached</AlertTitle>
-        <AlertDescription>
-          No complete result page could be established. Choose a shorter time
-          range or narrow the project, source, or message filters, then search
-          again.
-        </AlertDescription>
-      </Alert>
-    ) : !ready || !lines.length ? (
-      <QueryContent
-        title="Logs"
-        loading={query.isPending}
-        error={query.error}
-        empty={!lines.length}
-        retry={() => void query.refetch()}
-      >
-        {null}
-      </QueryContent>
-    ) : undefined
+  const status = incomplete ? (
+    <Alert variant="warning">
+      <AlertTitle>
+        {lines.length ? 'Partial results' : 'Search limit reached'}
+      </AlertTitle>
+      <AlertDescription>
+        {lines.length
+          ? 'Showing logs found before the search limit was reached. Some matching logs may be missing.'
+          : 'The search limit was reached before any matching logs were found.'}{' '}
+        Choose a shorter time range or narrow the project or source to search
+        fewer archives.
+      </AlertDescription>
+    </Alert>
+  ) : !ready || !lines.length ? (
+    <QueryContent
+      title="Logs"
+      loading={query.isPending}
+      error={query.error}
+      empty={!lines.length}
+      retry={() => void query.refetch()}
+    >
+      {null}
+    </QueryContent>
+  ) : undefined
   return (
     <PageContainer innerClassName="space-y-6">
       <PageHeader
@@ -203,7 +206,7 @@ export default function GlobalLogs() {
           <div className="flex flex-wrap items-center justify-between gap-2 border-t py-2 text-xs text-muted-foreground">
             <span>
               {ready
-                ? `${lines.length} loaded lines · newest first`
+                ? `${lines.length} loaded ${lines.length === 1 ? 'line' : 'lines'} · ${incomplete ? 'partial results' : 'newest first'}`
                 : query.isPending
                   ? 'Loading logs…'
                   : 'Search incomplete'}
@@ -226,7 +229,10 @@ export default function GlobalLogs() {
                 size="sm"
                 className="h-7 text-xs"
                 disabled={
-                  !query.data?.next_cursor || query.isFetching || !ready
+                  !query.data?.next_cursor ||
+                  query.isFetching ||
+                  !ready ||
+                  incomplete
                 }
                 onClick={() => {
                   setAuto(false)


### PR DESCRIPTION
## Summary

Global log searches that hit the scan budget currently discard every match and display an empty table. Keep the newest collected matches, capped at the requested page size, and show them alongside a **Partial results** warning. If no matches were collected, retain the search-limit warning rather than claiming there are no logs.

Incomplete searches return no cursor and disable Next page because unread chunks may contain newer events. Existing scan and memory limits remain in place. List, Patterns, and By service views all display retained results. The warning now recommends time, project, and source filters rather than message filters, which do not reduce archive reads.

Regenerated web and CLI SDK descriptions from the updated Rust OpenAPI schema; the response shape is unchanged.

## Evidence

**Backend:**
```text
cargo test --lib -p temps-log-aggregator
129 passed; 0 failed

cargo test --lib -p temps-log-aggregator global_search -- --nocapture
4 passed; 0 failed

GLOBAL_LOGS_TEST_DATABASE_URL=<local test database> cargo test --lib -p temps-log-aggregator global_logs_postgres_pagination_access_and_budget -- --nocapture
1 passed; 0 failed
```
The PostgreSQL integration uses session-local temporary tables and verifies that 16 collected lines survive an oversized later chunk, with no continuation cursor. Unit regressions verify newest-first ordering, the page-size cap, and exhausted searches with no matches.

**Browser:** Chromium against the worktree frontend with mocked API responses and a temporary local auth fixture: **7 passed**. The walkthrough covered desktop (1440px) and mobile (390px) normal loading, access-error recovery, cursor reset, empty exhausted searches, and partial results. In both viewport sizes, the warning and log row were visible together; Next page was disabled; Patterns and By service retained the log. The three scan-budget checks were rerun after the final wording change: **3 passed**.

**Other checks:** six log-explorer/query unit tests passed; Rust `cargo check --lib -p temps-log-aggregator` and Clippy with `-D warnings` passed; web and CLI TypeScript checks, changed-file ESLint, OpenAPI canonical-format check, attribution check, and `git diff --check` passed. The commit hooks also passed workspace Clippy (`cargo clippy --all-targets --all-features -- -D warnings`), formatting, spelling, and commit-message validation. Cargo emitted existing workspace-profile and dependency future-compatibility notices.
