### PR TITLE
fix(e2e): restore observability browser coverage

### DIFF
--- a/web/e2e/authenticated/environment-sidebar.spec.ts
+++ b/web/e2e/authenticated/environment-sidebar.spec.ts
@@ -3,6 +3,44 @@
 
 import { expect, test } from '@playwright/test'
 
+async function mockEnvironmentMetrics(
+  page: import('@playwright/test').Page,
+  projectId: number,
+  environmentId: number
+) {
+  await page.route(
+    `**/api/projects/${projectId}/environments/${environmentId}/container-history**`,
+    (route) =>
+      route.fulfill({
+        json: {
+          containers: [
+            {
+              id: 1,
+              container_id: 'e2e-container',
+              container_name: 'web',
+              deployment_id: 1,
+              deployed_at: new Date().toISOString(),
+              is_current: true,
+            },
+          ],
+          total_count: 1,
+        },
+      })
+  )
+  await page.route(
+    `**/api/projects/${projectId}/environments/${environmentId}/containers/*/metrics/history**`,
+    (route) => {
+      const now = Date.now()
+      return route.fulfill({
+        json: [0, 1, 2, 3].map((index) => ({
+          time: new Date(now - (3 - index) * 60_000).toISOString(),
+          value: index + 1,
+        })),
+      })
+    }
+  )
+}
+
 test('environment sidebar preserves the selected page when switching environments', async ({
   page,
 }) => {
@@ -26,6 +64,7 @@ test('environment sidebar preserves the selected page when switching environment
   await page.route(`**/api/projects/${project.id}/environments`, (route) =>
     route.fulfill({ json: [production, staging] })
   )
+  await mockEnvironmentMetrics(page, project.id, production.id)
   await page.route(
     `**/api/projects/${project.id}/environments/${staging.id}`,
     (route) => route.fulfill({ json: staging })
@@ -143,6 +182,10 @@ test('environment charts render with themed axis labels in dark mode', async ({
       item.slug.startsWith('observability-starter')
     ) ?? projects[0]
   await page.setViewportSize({ width: 1440, height: 1000 })
+  const environments = await (
+    await page.request.get(`/api/projects/${project.id}/environments`)
+  ).json()
+  await mockEnvironmentMetrics(page, project.id, environments[0].id)
   await page.goto(`/projects/${project.slug}/environments?view=metrics`)
   await expect(page.locator('html')).toHaveClass(/dark/)
   await expect(page.locator('[data-chart] .recharts-surface')).toHaveCount(3)

--- a/web/e2e/authenticated/global-observability.spec.ts
+++ b/web/e2e/authenticated/global-observability.spec.ts
@@ -171,7 +171,7 @@ for (const kind of Object.keys(fixtures) as Kind[]) {
             .getByRole('region', {
               name: `${kind[0].toUpperCase() + kind.slice(1)} filters`,
             })
-            .getByRole('combobox')
+            .getByRole('combobox', { name: 'Project scope' })
         ).toContainText('Storefront')
       expect(new URL(page.url()).searchParams.get('from')).toBe(frozen)
       expect(

--- a/web/e2e/authenticated/global-observability.spec.ts
+++ b/web/e2e/authenticated/global-observability.spec.ts
@@ -172,7 +172,7 @@ for (const kind of Object.keys(fixtures) as Kind[]) {
               name: `${kind[0].toUpperCase() + kind.slice(1)} filters`,
             })
             .getByRole('combobox')
-        ).toHaveText('Storefront')
+        ).toContainText('Storefront')
       expect(new URL(page.url()).searchParams.get('from')).toBe(frozen)
       expect(
         await page.evaluate(

--- a/web/e2e/authenticated/global-observability.spec.ts
+++ b/web/e2e/authenticated/global-observability.spec.ts
@@ -145,7 +145,7 @@ for (const kind of Object.keys(fixtures) as Kind[]) {
         const filters = page.getByRole('region', {
           name: `${kind[0].toUpperCase() + kind.slice(1)} filters`,
         })
-        await filters.getByRole('combobox', { name: 'All projects' }).click()
+        await filters.getByRole('combobox', { name: 'Project scope' }).click()
         await page.getByRole('option', { name: /Storefront/ }).click()
       }
       await expect(page).toHaveURL(/project_id=1/)

--- a/web/e2e/authenticated/global-observability.spec.ts
+++ b/web/e2e/authenticated/global-observability.spec.ts
@@ -142,8 +142,11 @@ for (const kind of Object.keys(fixtures) as Kind[]) {
           .fill('project:')
         await page.getByRole('option', { name: /project:Storefront/ }).click()
       } else {
-        await page.getByRole('combobox', { name: 'Project scope' }).click()
-        await page.getByRole('option', { name: 'Storefront' }).click()
+        const filters = page.getByRole('region', {
+          name: `${kind[0].toUpperCase() + kind.slice(1)} filters`,
+        })
+        await filters.getByRole('combobox', { name: 'All projects' }).click()
+        await page.getByRole('option', { name: /Storefront/ }).click()
       }
       await expect(page).toHaveURL(/project_id=1/)
       for (const preset of ['1h', '6h', '1d', '7d'])
@@ -164,7 +167,11 @@ for (const kind of Object.keys(fixtures) as Kind[]) {
         ).toContainText('Storefront')
       else
         await expect(
-          page.getByRole('combobox', { name: 'Project scope' })
+          page
+            .getByRole('region', {
+              name: `${kind[0].toUpperCase() + kind.slice(1)} filters`,
+            })
+            .getByRole('combobox')
         ).toHaveText('Storefront')
       expect(new URL(page.url()).searchParams.get('from')).toBe(frozen)
       expect(
@@ -198,11 +205,14 @@ for (const kind of Object.keys(fixtures) as Kind[]) {
           : route.fulfill({ json: fixtures[kind] })
     )
     await page.goto(`/${kind}`)
+    const retry = page.getByRole('button', {
+      name: `Retry ${kind === 'analytics' ? 'analytics metrics' : kind}`,
+      exact: true,
+    })
+    await expect(retry).toBeVisible()
     await expect(page.getByText('Access denied').first()).toBeVisible()
     failed = false
-    await page
-      .getByRole('button', { name: `Retry ${kind}`, exact: true })
-      .click()
+    await retry.click()
     await expect(
       kind === 'analytics'
         ? page
@@ -402,15 +412,17 @@ for (const width of [320, 390, 1440]) {
       const bounds = await pages.boundingBox()
       expect(bounds!.x + bounds!.width).toBeLessThanOrEqual(width)
     }
-    const tabs = page.getByRole('tablist', { name: 'Traffic presentation' })
-    await tabs.getByRole('tab', { name: 'Data table' }).click()
-    await expect(
-      page.getByRole('columnheader', { name: 'Hour (UTC)' })
-    ).toBeVisible()
-    await tabs.getByRole('tab', { name: 'Data table' }).press('ArrowLeft')
-    await expect(
-      tabs.getByRole('tab', { name: 'Chart', exact: true })
-    ).toHaveAttribute('aria-selected', 'true')
+    const tabs = page.getByRole('tablist', { name: 'Analytics breakdowns' })
+    await tabs.getByRole('tab', { name: 'Audience' }).click()
+    await expect(tabs.getByRole('tab', { name: 'Audience' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    )
+    await tabs.getByRole('tab', { name: 'Audience' }).press('ArrowLeft')
+    await expect(tabs.getByRole('tab', { name: 'Traffic' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    )
     await expect(page.getByRole('tabpanel')).toBeVisible()
     await page.screenshot({
       path: `/tmp/temps-mobile-analytics-${width}.png`,

--- a/web/e2e/authenticated/project-date-time-ranges.spec.ts
+++ b/web/e2e/authenticated/project-date-time-ranges.spec.ts
@@ -26,6 +26,11 @@ for (const [path, endpoint, fromKey, toKey] of cases) {
       await page.route(/\/has-events(?:\?|$)/, (route) =>
         route.fulfill({ json: { has_events: true } })
       )
+      // A fresh e2e project has never received traces. Keep the filter view
+      // mounted so this test measures time ranges rather than onboarding.
+      await page.route('**/api/otel/has-traces/*', (route) =>
+        route.fulfill({ json: { has_traces: true } })
+      )
       await page.route(/\/has-error-groups(?:\?|$)/, (route) =>
         route.fulfill({ json: { has_error_groups: true } })
       )

--- a/web/src/components/observability/GlobalPage.tsx
+++ b/web/src/components/observability/GlobalPage.tsx
@@ -68,6 +68,7 @@ export function ProjectScope({
 }) {
   return (
     <ProjectSelect
+      ariaLabel="Project scope"
       value={disabled ? null : (view.projectId ?? null)}
       onValueChange={(id) =>
         view.patch({ project_id: id == null ? undefined : String(id) })

--- a/web/src/components/project/ProjectSelect.tsx
+++ b/web/src/components/project/ProjectSelect.tsx
@@ -25,6 +25,8 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { Check, ChevronsUpDown, RefreshCw } from 'lucide-react'
 
 interface ProjectSelectProps {
+  /** Accessible name for the picker in its specific context. */
+  ariaLabel?: string
   /** Selected project id, or null for the "All projects" row. */
   value: number | null
   onValueChange: (projectId: number | null) => void
@@ -45,6 +47,7 @@ interface ProjectSelectProps {
  * findable here without a timed wait.
  */
 export function ProjectSelect({
+  ariaLabel,
   value,
   onValueChange,
   allowAll = true,
@@ -128,6 +131,7 @@ export function ProjectSelect({
           type="button"
           variant="outline"
           role="combobox"
+          aria-label={ariaLabel}
           aria-expanded={open}
           disabled={disabled}
           className={cn(

--- a/web/src/pages/observability/GlobalTraces.tsx
+++ b/web/src/pages/observability/GlobalTraces.tsx
@@ -176,6 +176,12 @@ export default function GlobalTraces() {
                         {trace.trace_id.slice(0, 8)}
                       </span>
                     </p>
+                    <Link
+                      className="text-xs text-muted-foreground underline whitespace-nowrap"
+                      to={`/traces/global/${trace.trace_id}`}
+                    >
+                      Cross-project waterfall
+                    </Link>
                   </TableCell>
                   <TableCell className="hidden md:table-cell">
                     <Link


### PR DESCRIPTION
Fresh CI projects have no container history or traces, so observability E2E tests hit onboarding states instead of the charts and filters they intend to test. The global observability specs also used selectors and analytics controls that no longer matched the console. Selecting a global project exposed a real accessibility gap: the project scope combobox had no accessible name.

This change supplies the missing test data, updates the specs to the current observability UI, names the global project scope picker, and checks its selected project name while allowing for the project icon. It restores the cross-project waterfall link to trace rows, which remains a supported detail route.

Validation: TypeScript, ESLint, Prettier, Playwright test discovery, source attribution, and `git diff --check` pass locally. Browser smoke checks at 390px confirmed project selection, range persistence after reload, trace/error detail links, no horizontal overflow, and no page errors. The full E2E deployment job passed on the latest commit: 106 console Playwright tests passed and 5 were skipped.
